### PR TITLE
ci(desktop): build Rust on PR instead of cargo check

### DIFF
--- a/.github/workflows/desktop.yaml
+++ b/.github/workflows/desktop.yaml
@@ -21,7 +21,7 @@ concurrency:
 
 jobs:
   validate:
-    name: Validate (frontend + cargo check)
+    name: Validate (frontend + cargo build)
     runs-on: [self-hosted, macOS, ARM64]
     permissions:
       contents: read
@@ -57,9 +57,9 @@ jobs:
       - name: Build frontend
         run: npm run vite:build
 
-      - name: Check Rust
+      - name: Build Rust
         working-directory: src-tauri
-        run: cargo check --locked
+        run: cargo build --locked
 
   release:
     name: Sign, notarize, and bundle


### PR DESCRIPTION
Swap PR validation from `cargo check --locked` to `cargo build --locked` so link errors, codegen failures, and proc-macro issues are caught before release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced build validation for desktop applications to verify that Rust code compiles successfully during automated checks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ariso-ai/sage/pull/3?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->