### PR TITLE
fix(waveform): use record dot for resume recording button

### DIFF
--- a/src/views/WaveformView.vue
+++ b/src/views/WaveformView.vue
@@ -44,7 +44,7 @@
             <rect x="8.5" y="1" width="3.5" height="12" rx="1" fill="currentColor" />
           </svg>
           <svg v-else width="14" height="14" viewBox="0 0 14 14">
-            <polygon points="3,1 13,7 3,13" fill="currentColor" />
+            <circle cx="7" cy="7" r="5.5" fill="currentColor" />
           </svg>
         </button>
         <button


### PR DESCRIPTION

<img width="319" height="52" alt="Screenshot 2026-05-28 at 14 32 39" src="https://github.com/user-attachments/assets/3b7bd589-f50b-4231-9403-2d242def5556" />

## What

Replaces the **play triangle** icon on the pause/resume control with a **filled record dot** for the resume (paused) state.

## Why

A right-pointing triangle is the universal *playback* symbol — it reads as "play audio," which is the wrong action. Resuming a paused recording means "start capturing again," and the conventional symbol for that is the record dot. The app already uses this exact shape for the live `rec-dot` REC indicator, so the button now stays visually consistent and communicates "tap to record again."

## Change

`src/views/WaveformView.vue` — swap `<polygon>` (triangle) for `<circle>` in the resume-state SVG. The pause-state (two bars) is unchanged, and the icon still inherits `currentColor` to match neutral control-button styling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated the pause/resume button’s paused-state icon: replaced the previous polygon/triangle shape with a circular icon for a cleaner visual.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ariso-ai/sage/pull/5?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->