### PR TITLE
ci(apply-fixes): log triage result, enforce reply record, tighten severity gate

### DIFF
--- a/.github/apply-fixes-prompt.md
+++ b/.github/apply-fixes-prompt.md
@@ -60,6 +60,9 @@ edits together. Use the `Edit` tool — no shell-based file rewriting.
 
 ### Do NOT apply suggestions that
 
+- Touch documentation-only files — anything under `docs/` or any `*.md`
+  file. Code is the source of truth; doc drift is out of scope for this
+  job and is never worth a commit here.
 - Remove error handling (Rust `?` / `match` over `Result`, JS `try`/
   `catch`, Tauri command error returns).
 - Change public API signatures without confirming callers via `grep`:

--- a/.github/workflows/apply-fixes.yml
+++ b/.github/workflows/apply-fixes.yml
@@ -22,7 +22,12 @@ concurrency:
 env:
   CODERABBIT_BOT_LOGIN: "coderabbitai[bot]"
   HUMAN_REVIEWERS: "shawnzhu"
-  MAJOR_PATTERN: '⚠️ Potential issue|🛑|security|data loss|race condition'
+  # Match CodeRabbit's severity badge (🔴 Critical / 🟠 Major) and hard
+  # blockers — NOT '⚠️ Potential issue', which prefixes every finding
+  # header (including 🟡 Minor nits) and so let doc-only minors through
+  # as "majors". The keyword alternatives still catch severe issues by
+  # content even if the badge wording shifts.
+  MAJOR_PATTERN: '🛑|🔴 Critical|🟠 Major|security|data loss|race condition'
 
 jobs:
   apply-fixes:
@@ -159,7 +164,13 @@ jobs:
             --allowed-tools "Read Edit Write Grep Glob Bash(git diff:*) Bash(git log:*) Bash(git status:*) Bash(grep:*) Bash(npm:*) Bash(cargo:*) Bash(cd:*)" \
             --permission-mode acceptEdits \
             > /tmp/claude-output.json
-          echo "Claude finished. Output length: $(jq -r '.result | length' /tmp/claude-output.json) chars"
+          # Surface Claude's full triage summary in the log. Without this
+          # a no-change run is a black box — you can't tell "correctly
+          # decided to skip" from "silently misfired".
+          echo "Claude finished. Result:"
+          echo "----------------------------------------"
+          jq -r '.result // "(no result field)"' /tmp/claude-output.json
+          echo "----------------------------------------"
 
       - name: Detect changes
         if: steps.findings.outputs.total != '0'
@@ -200,6 +211,20 @@ jobs:
               && echo "  replied to comment $id" \
               || echo "::warning::failed to reply to comment $id"
           done
+
+      # Step 5 of the prompt requires Claude to write thread-replies.json
+      # even when it applies nothing, so every finding gets a recorded
+      # triage decision. If it applied no fix AND left no replies, the run
+      # produced no commit and no audit trail — fail loudly rather than
+      # passing as a silent no-op.
+      - name: Require triage record when no fixes applied
+        if: steps.findings.outputs.total != '0' && steps.changes.outputs.no_changes == 'true'
+        run: |
+          if [ ! -s /tmp/thread-replies.json ]; then
+            echo "::error::Claude applied no fixes and wrote no /tmp/thread-replies.json. Per Step 5 it must record a triage reply for every finding — treating this as a failed run, not a clean no-op."
+            exit 1
+          fi
+          echo "No fixes applied; triage replies were recorded and posted."
 
       - name: Cleanup
         if: always()


### PR DESCRIPTION
## Motivation

Run [#26659345971](https://github.com/ariso-ai/sage/actions/runs/26659345971/job/78577626091) on PR #7 fetched 2 "major" CodeRabbit findings, ran Claude, then reported `Claude made no file changes` and exited green — with no way to tell whether that was a correct skip or a silent misfire.

Investigation found three problems:

1. **No observability on the no-change path.** The job logged only `jq -r '.result | length'` (the char count), then `Cleanup` deleted the output. Claude's actual reasoning was unrecoverable.
2. **No enforcement of Step 5.** The prompt requires Claude to write `/tmp/thread-replies.json` even when it applies nothing, so every finding gets a recorded triage decision. Claude skipped it, the "Post thread replies" step was skipped (file absent), and the threads got no reply — zero audit trail.
3. **Severity gate too loose.** `MAJOR_PATTERN` matched `⚠️ Potential issue`, which CodeRabbit puts in the header of *every* finding — including ones explicitly labeled `🟡 Minor`. Both findings in that run were Minor doc-only nits (`start_time` → `start_at` in a design doc) pulled in as "majors".

## Changes

- **Log Claude's full result text**, not just its length, so no-change runs are debuggable.
- **Add a guard** that fails the job when no fix was applied *and* no `/tmp/thread-replies.json` was written. Placed after "Post thread replies" so valid runs still post before any failure.
- **Tighten `MAJOR_PATTERN`** to match the severity badge (`🛑｜🔴 Critical｜🟠 Major`) plus the security/data-loss/race-condition keywords, instead of the `⚠️ Potential issue` issue-type prefix.

## Verification

- `python3 -c "import yaml; yaml.safe_load(open(...))"` → YAML OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Refined issue severity classification for more accurate triage.
  * Improved workflow logging to make triage results clearer.
  * Enforced audit-trail checks so runs fail if actionable findings exist but no fixes or thread replies are recorded.
  * Added a rule preventing automated fixes from modifying documentation-only files.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ariso-ai/sage/pull/8?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->