### PR TITLE
chore(mcp): use dev dependency path for ariso-desktop MCP server

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -5,7 +5,7 @@
       "command": "node",
       "args": ["node_modules/tauri-plugin-mcp-server/build/index.js"],
       "env": {
-        "TAURI_MCP_IPC_PATH": "/tmp/ariso-mcp.sock"
+        "TAURI_MCP_IPC_PATH": "${HOME}/.ariso/run/sage-mcp.sock"
       }
     }
   }

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "ariso-desktop": {
+      "type": "stdio",
+      "command": "node",
+      "args": ["node_modules/tauri-plugin-mcp-server/build/index.js"],
+      "env": {
+        "TAURI_MCP_IPC_PATH": "/tmp/ariso-mcp.sock"
+      }
+    }
+  }
+}

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -83,8 +83,10 @@ fn main() {
 
     #[cfg(all(debug_assertions, feature = "mcp"))]
     {
-        let socket_path = std::path::PathBuf::from(std::env::var("HOME").expect("HOME not set"))
-            .join(".ariso/run/sage-mcp.sock");
+        let home_dir = std::env::var_os("HOME")
+            .or_else(|| std::env::var_os("USERPROFILE"))
+            .expect("Neither HOME nor USERPROFILE is set");
+        let socket_path = std::path::PathBuf::from(home_dir).join(".ariso/run/sage-mcp.sock");
         if let Some(dir) = socket_path.parent() {
             std::fs::create_dir_all(dir).expect("failed to create MCP socket dir");
         }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -83,10 +83,15 @@ fn main() {
 
     #[cfg(all(debug_assertions, feature = "mcp"))]
     {
+        let socket_path = std::path::PathBuf::from(std::env::var("HOME").expect("HOME not set"))
+            .join(".ariso/run/sage-mcp.sock");
+        if let Some(dir) = socket_path.parent() {
+            std::fs::create_dir_all(dir).expect("failed to create MCP socket dir");
+        }
         builder = builder.plugin(tauri_plugin_mcp::init_with_config(
             tauri_plugin_mcp::PluginConfig::new("Ariso".to_string())
                 .start_socket_server(true)
-                .socket_path("/tmp/ariso-mcp.sock".into()),
+                .socket_path(socket_path),
         ));
     }
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -84,17 +84,35 @@ fn main() {
     #[cfg(all(debug_assertions, feature = "mcp"))]
     {
         let home_dir = std::env::var_os("HOME")
-            .or_else(|| std::env::var_os("USERPROFILE"))
-            .expect("Neither HOME nor USERPROFILE is set");
-        let socket_path = std::path::PathBuf::from(home_dir).join(".ariso/run/sage-mcp.sock");
-        if let Some(dir) = socket_path.parent() {
-            std::fs::create_dir_all(dir).expect("failed to create MCP socket dir");
+            .or_else(|| std::env::var_os("USERPROFILE"));
+        if let Some(home_dir) = home_dir {
+            let socket_path = std::path::PathBuf::from(home_dir).join(".ariso/run/sage-mcp.sock");
+            let dir_ready = match socket_path.parent() {
+                Some(dir) => match std::fs::create_dir_all(dir) {
+                    Ok(()) => true,
+                    Err(e) => {
+                        eprintln!(
+                            "Warning: failed to create MCP socket directory {}: {}. MCP plugin will not be initialized.",
+                            dir.display(),
+                            e
+                        );
+                        false
+                    }
+                },
+                None => true,
+            };
+            if dir_ready {
+                builder = builder.plugin(tauri_plugin_mcp::init_with_config(
+                    tauri_plugin_mcp::PluginConfig::new("Ariso".to_string())
+                        .start_socket_server(true)
+                        .socket_path(socket_path),
+                ));
+            }
+        } else {
+            eprintln!(
+                "Warning: neither HOME nor USERPROFILE is set; MCP plugin will not be initialized."
+            );
         }
-        builder = builder.plugin(tauri_plugin_mcp::init_with_config(
-            tauri_plugin_mcp::PluginConfig::new("Ariso".to_string())
-                .start_socket_server(true)
-                .socket_path(socket_path),
-        ));
     }
 
     builder


### PR DESCRIPTION
## Summary
- Replaces the hardcoded home-dir path in `.mcp.json` (a local clone under `/Users/shawn/...`) with a project-relative path to the `tauri-plugin-mcp-server` dev dependency.
- The package is already listed in `devDependencies`, so the server runs via `node node_modules/tauri-plugin-mcp-server/build/index.js` after `npm install`.

## Why
- The previous path only worked on one machine. This makes the MCP config portable and shareable with the team.

## Notes
- Teammates must have run `npm install` so `node_modules/tauri-plugin-mcp-server` exists (path resolves from the project root, where Claude Code launches the server).
- Kept the config in the root `.mcp.json` (project scope) — MCP server definitions can only live there or in `~/.claude.json`, not under `.claude/`.

## Testing
- Verified `node node_modules/tauri-plugin-mcp-server/build/index.js` starts and attempts the IPC socket connection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a local MCP server entry to support IPC via a per-user socket.
  * Updated debug startup to derive the IPC socket location from the user's home, ensure the socket directory exists, and skip initialization with a warning if the socket can't be prepared.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->