### PR TITLE
feat: backend-aware Meetings… menu item

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -528,7 +528,7 @@ pub async fn create_library_window(app: tauri::AppHandle) -> Result<(), String> 
         return Ok(());
     }
     WebviewWindowBuilder::new(&app, "library", WebviewUrl::App("/#/library".into()))
-        .title("Library")
+        .title("Meetings")
         .inner_size(460.0, 560.0)
         .resizable(true)
         .center()

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -136,7 +136,19 @@ pub fn create_tray(app: &AppHandle) -> tauri::Result<()> {
                 "library" => {
                     let app_async = app.clone();
                     tauri::async_runtime::spawn(async move {
-                        let _ = crate::commands::create_library_window(app_async).await;
+                        if crate::commands::active_backend(&app_async) == "local" {
+                            // Local backend: reuse the in-app Library window
+                            // (titled "Meetings").
+                            let _ = crate::commands::create_library_window(app_async).await;
+                        } else {
+                            // Ariso backend: meetings live in the web app.
+                            use tauri_plugin_opener::OpenerExt;
+                            let url = format!(
+                                "{}/my/meetings",
+                                crate::commands::WEB_APP_BASE_URL
+                            );
+                            let _ = app_async.opener().open_url(url, None::<&str>);
+                        }
                     });
                 }
                 "check_updates" => {
@@ -159,7 +171,7 @@ pub fn create_tray(app: &AppHandle) -> tauri::Result<()> {
 pub fn build_idle_menu(app: &AppHandle) -> tauri::Result<tauri::menu::Menu<tauri::Wry>> {
     let start = MenuItemBuilder::with_id("start_recording", "Start Recording").build(app)?;
     let settings = MenuItemBuilder::with_id("settings", "Settings...").build(app)?;
-    let library = MenuItemBuilder::with_id("library", "Library...").build(app)?;
+    let library = MenuItemBuilder::with_id("library", "Meetings...").build(app)?;
     let check_updates = MenuItemBuilder::with_id("check_updates", "Check for Updates…").build(app)?;
     let quit = MenuItemBuilder::with_id("quit", "Quit Ariso").build(app)?;
 

--- a/src/views/LibraryView.vue
+++ b/src/views/LibraryView.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="library">
-    <h1 class="title">Library</h1>
+    <h1 class="title">Meetings</h1>
     <p v-if="loading" class="hint">Loading…</p>
     <p v-else-if="recordings.length === 0" class="hint">No recordings yet.</p>
     <ul v-else class="list">


### PR DESCRIPTION
Make the tray **Meetings…** item behave per active backend:

- **Ariso**: opens the browser to `${WEB_APP_BASE_URL}/my/meetings`.
- **Local**: opens the in-app Library window, now titled **Meetings** (window title bar + heading).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Updates**
  * Renamed "Library" to "Meetings" throughout the application interface, including window titles, menu labels, and page headers.
  * Tray menu now provides context-specific routing based on your configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->