### PR TITLE
Audio player + Note/Transcript buttons in Meetings window

### DIFF
--- a/.github/workflows/desktop.yaml
+++ b/.github/workflows/desktop.yaml
@@ -22,8 +22,7 @@ concurrency:
 jobs:
   validate:
     name: Validate (frontend + cargo build)
-    #runs-on: [self-hosted, macOS, ARM64]
-    runs-on: macos-26
+    runs-on: [self-hosted, macOS, ARM64]
     permissions:
       contents: read
     steps:

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -521,8 +521,14 @@ pub fn list_local_recordings() -> Result<Vec<crate::storage::RecordingSummary>, 
 /// guarding against path traversal. Ids are normally sanitized timestamps
 /// (e.g. `2026-06-02T14-30-05Z`), so the guard never rejects legitimate ids.
 fn recording_dir(id: &str) -> Result<std::path::PathBuf, String> {
-    // Reject ids that could escape the recordings dir.
-    if id.is_empty() || id.contains('/') || id.contains('\\') || id.contains("..") {
+    // Reject ids that could escape the recordings dir. `:` is blocked too so a
+    // Windows drive-relative form (e.g. `C:foo`) can never slip past the guard.
+    if id.is_empty()
+        || id.contains('/')
+        || id.contains('\\')
+        || id.contains(':')
+        || id.contains("..")
+    {
         return Err(format!("invalid recording id: {id}"));
     }
     let root = crate::storage::ariso_root()?;
@@ -561,7 +567,7 @@ pub fn open_recording_file(app: tauri::AppHandle, id: String, kind: String) -> R
         return Err(format!("recording file not found: {}", path.display()));
     }
     app.opener()
-        .open_path(path.to_string_lossy().to_string(), None::<&str>)
+        .open_path(path.to_string_lossy().into_owned(), None::<&str>)
         .map_err(|e| e.to_string())
 }
 
@@ -614,6 +620,7 @@ mod tests {
         assert!(recording_dir("../foo").is_err());
         assert!(recording_dir("a/b").is_err());
         assert!(recording_dir("a\\b").is_err());
+        assert!(recording_dir("C:foo").is_err());
         assert!(recording_dir("foo/../bar").is_err());
     }
 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -517,6 +517,54 @@ pub fn list_local_recordings() -> Result<Vec<crate::storage::RecordingSummary>, 
     crate::storage::list_recordings(&root)
 }
 
+/// Resolve a recording's directory under `<ariso_root>/recordings/<id>`,
+/// guarding against path traversal. Ids are normally sanitized timestamps
+/// (e.g. `2026-06-02T14-30-05Z`), so the guard never rejects legitimate ids.
+fn recording_dir(id: &str) -> Result<std::path::PathBuf, String> {
+    // Reject ids that could escape the recordings dir.
+    if id.is_empty() || id.contains('/') || id.contains('\\') || id.contains("..") {
+        return Err(format!("invalid recording id: {id}"));
+    }
+    let root = crate::storage::ariso_root()?;
+    Ok(crate::storage::recordings_dir(&root).join(id))
+}
+
+/// Map an openable file `kind` to its on-disk filename. Only `note` and
+/// `transcript` are valid; anything else is an error.
+fn note_or_transcript_filename(kind: &str) -> Result<&'static str, String> {
+    match kind {
+        "note" => Ok("note.md"),
+        "transcript" => Ok("transcript.md"),
+        other => Err(format!("invalid recording file kind: {other}")),
+    }
+}
+
+/// Read the raw bytes of a recording's `recording.mp3`, returned as a raw
+/// binary IPC response so the frontend can build a Blob URL for an `<audio>`
+/// element (avoids JSON-array bloat from a `Vec<u8>` return).
+#[tauri::command]
+pub fn read_recording_audio(id: String) -> Result<tauri::ipc::Response, String> {
+    let path = recording_dir(&id)?.join("recording.mp3");
+    let bytes = std::fs::read(&path).map_err(|e| format!("read recording audio: {e}"))?;
+    Ok(tauri::ipc::Response::new(bytes))
+}
+
+/// Open a recording's `note.md` or `transcript.md` in the OS default app.
+/// `kind` must be `"note"` or `"transcript"`.
+#[tauri::command]
+pub fn open_recording_file(app: tauri::AppHandle, id: String, kind: String) -> Result<(), String> {
+    use tauri_plugin_opener::OpenerExt;
+
+    let filename = note_or_transcript_filename(&kind)?;
+    let path = recording_dir(&id)?.join(filename);
+    if !path.exists() {
+        return Err(format!("recording file not found: {}", path.display()));
+    }
+    app.opener()
+        .open_path(path.to_string_lossy().to_string(), None::<&str>)
+        .map_err(|e| e.to_string())
+}
+
 #[tauri::command]
 pub async fn create_library_window(app: tauri::AppHandle) -> Result<(), String> {
     use tauri::{WebviewUrl, WebviewWindowBuilder};
@@ -536,4 +584,51 @@ pub async fn create_library_window(app: tauri::AppHandle) -> Result<(), String> 
         .build()
         .map_err(|e| e.to_string())?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn note_or_transcript_filename_maps_known_kinds() {
+        assert_eq!(note_or_transcript_filename("note").unwrap(), "note.md");
+        assert_eq!(
+            note_or_transcript_filename("transcript").unwrap(),
+            "transcript.md"
+        );
+    }
+
+    #[test]
+    fn note_or_transcript_filename_rejects_unknown_kind() {
+        assert!(note_or_transcript_filename("").is_err());
+        assert!(note_or_transcript_filename("audio").is_err());
+        assert!(note_or_transcript_filename("note.md").is_err());
+    }
+
+    #[test]
+    fn recording_dir_rejects_traversal_ids() {
+        // These guards are pure (no env read), so no ARISO_ROOT needed.
+        assert!(recording_dir("").is_err());
+        assert!(recording_dir("..").is_err());
+        assert!(recording_dir("../foo").is_err());
+        assert!(recording_dir("a/b").is_err());
+        assert!(recording_dir("a\\b").is_err());
+        assert!(recording_dir("foo/../bar").is_err());
+    }
+
+    #[test]
+    fn recording_dir_accepts_normal_id() {
+        let tmp = tempfile::tempdir().unwrap();
+        // `recording_dir` reads ARISO_ROOT; set it for this test. The other
+        // `recording_dir` tests only exercise the pre-env guard branch, so
+        // they don't depend on this value.
+        // SAFETY: env mutation requires `--test-threads=1` so no concurrent
+        // env access races with these calls (same convention as transcribe).
+        unsafe { std::env::set_var("ARISO_ROOT", tmp.path()); }
+        let id = "2026-06-02T14-30-05Z";
+        let dir = recording_dir(id).unwrap();
+        assert_eq!(dir, crate::storage::recordings_dir(tmp.path()).join(id));
+        unsafe { std::env::remove_var("ARISO_ROOT"); }
+    }
 }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -545,12 +545,24 @@ fn note_or_transcript_filename(kind: &str) -> Result<&'static str, String> {
     }
 }
 
+/// Upper bound on the audio we'll load into memory for playback. The whole file
+/// is read into RAM and copied across IPC into a JS Blob, so this guards against
+/// OOM on a corrupt or pathologically large file. ~1 GB is far above any real
+/// meeting recording (mp3 at this app's bitrate is well under 1 MB/min).
+const MAX_AUDIO_BYTES: u64 = 1024 * 1024 * 1024;
+
 /// Read the raw bytes of a recording's `recording.mp3`, returned as a raw
 /// binary IPC response so the frontend can build a Blob URL for an `<audio>`
 /// element (avoids JSON-array bloat from a `Vec<u8>` return).
 #[tauri::command]
 pub fn read_recording_audio(id: String) -> Result<tauri::ipc::Response, String> {
     let path = recording_dir(&id)?.join("recording.mp3");
+    let size = std::fs::metadata(&path)
+        .map_err(|e| format!("read recording audio: {e}"))?
+        .len();
+    if size > MAX_AUDIO_BYTES {
+        return Err(format!("recording audio too large to play: {size} bytes"));
+    }
     let bytes = std::fs::read(&path).map_err(|e| format!("read recording audio: {e}"))?;
     Ok(tauri::ipc::Response::new(bytes))
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -30,6 +30,8 @@ fn main() {
             commands::get_desktop_config,
             commands::list_local_recordings,
             commands::create_library_window,
+            commands::read_recording_audio,
+            commands::open_recording_file,
             transcribe::local_finalize_recording,
             model_manager::local_model_status,
             model_manager::download_local_stt,

--- a/src-tauri/src/storage.rs
+++ b/src-tauri/src/storage.rs
@@ -58,6 +58,12 @@ pub struct RecordingSummary {
     pub created_at: String,
     pub duration_seconds: u64,
     pub status: RecordingStatus,
+    /// Whether `recording.mp3` exists in the recording's directory.
+    pub has_audio: bool,
+    /// Whether `note.md` exists in the recording's directory.
+    pub has_note: bool,
+    /// Whether `transcript.md` exists in the recording's directory.
+    pub has_transcript: bool,
 }
 
 /// Resolve the `~/.ariso` root. `ARISO_ROOT` overrides (used by tests/dev);
@@ -200,13 +206,19 @@ pub fn list_recordings(root: &Path) -> Result<Vec<RecordingSummary>, String> {
             continue;
         }
         match read_meta(&entry.path()) {
-            Ok(m) => out.push(RecordingSummary {
-                id: m.id,
-                title: m.title,
-                created_at: m.created_at,
-                duration_seconds: m.duration_seconds,
-                status: m.status,
-            }),
+            Ok(m) => {
+                let dir = entry.path();
+                out.push(RecordingSummary {
+                    id: m.id,
+                    title: m.title,
+                    created_at: m.created_at,
+                    duration_seconds: m.duration_seconds,
+                    status: m.status,
+                    has_audio: dir.join("recording.mp3").exists(),
+                    has_note: dir.join("note.md").exists(),
+                    has_transcript: dir.join("transcript.md").exists(),
+                });
+            }
             Err(_) => continue,
         }
     }
@@ -274,6 +286,45 @@ mod tests {
         assert_eq!(list.len(), 2);
         assert_eq!(list[0].id, "2026-06-02T10-00-00Z");
         assert_eq!(list[1].id, "2026-06-01T10-00-00Z");
+        // Artifact files absent — all flags should be false.
+        assert!(!list[0].has_audio);
+        assert!(!list[0].has_note);
+        assert!(!list[0].has_transcript);
+        assert!(!list[1].has_audio);
+        assert!(!list[1].has_note);
+        assert!(!list[1].has_transcript);
+    }
+
+    #[test]
+    fn lists_recordings_artifact_flags_reflect_file_existence() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+
+        // Recording with all three artifact files present.
+        let id_full = "2026-06-03T10-00-00Z";
+        let dir_full = create_recording_dir(root, id_full).unwrap();
+        write_meta(&dir_full, &meta_with(id_full, "2026-06-03T10:00:00Z")).unwrap();
+        std::fs::write(dir_full.join("recording.mp3"), b"audio").unwrap();
+        std::fs::write(dir_full.join("note.md"), b"notes").unwrap();
+        std::fs::write(dir_full.join("transcript.md"), b"transcript").unwrap();
+
+        // Recording with no artifact files.
+        let id_empty = "2026-06-02T10-00-00Z";
+        let dir_empty = create_recording_dir(root, id_empty).unwrap();
+        write_meta(&dir_empty, &meta_with(id_empty, "2026-06-02T10:00:00Z")).unwrap();
+
+        let list = list_recordings(root).unwrap();
+        assert_eq!(list.len(), 2);
+        // Newest first: id_full at index 0.
+        assert_eq!(list[0].id, id_full);
+        assert!(list[0].has_audio);
+        assert!(list[0].has_note);
+        assert!(list[0].has_transcript);
+
+        assert_eq!(list[1].id, id_empty);
+        assert!(!list[1].has_audio);
+        assert!(!list[1].has_note);
+        assert!(!list[1].has_transcript);
     }
 
     #[test]

--- a/src-tauri/src/storage.rs
+++ b/src-tauri/src/storage.rs
@@ -214,9 +214,9 @@ pub fn list_recordings(root: &Path) -> Result<Vec<RecordingSummary>, String> {
                     created_at: m.created_at,
                     duration_seconds: m.duration_seconds,
                     status: m.status,
-                    has_audio: recording_dir.join("recording.mp3").exists(),
-                    has_note: recording_dir.join("note.md").exists(),
-                    has_transcript: recording_dir.join("transcript.md").exists(),
+                    has_audio: recording_dir.join("recording.mp3").is_file(),
+                    has_note: recording_dir.join("note.md").is_file(),
+                    has_transcript: recording_dir.join("transcript.md").is_file(),
                 });
             }
             Err(_) => continue,

--- a/src-tauri/src/storage.rs
+++ b/src-tauri/src/storage.rs
@@ -207,16 +207,16 @@ pub fn list_recordings(root: &Path) -> Result<Vec<RecordingSummary>, String> {
         }
         match read_meta(&entry.path()) {
             Ok(m) => {
-                let dir = entry.path();
+                let recording_dir = entry.path();
                 out.push(RecordingSummary {
                     id: m.id,
                     title: m.title,
                     created_at: m.created_at,
                     duration_seconds: m.duration_seconds,
                     status: m.status,
-                    has_audio: dir.join("recording.mp3").exists(),
-                    has_note: dir.join("note.md").exists(),
-                    has_transcript: dir.join("transcript.md").exists(),
+                    has_audio: recording_dir.join("recording.mp3").exists(),
+                    has_note: recording_dir.join("note.md").exists(),
+                    has_transcript: recording_dir.join("transcript.md").exists(),
                 });
             }
             Err(_) => continue,

--- a/src/tauri.ts
+++ b/src/tauri.ts
@@ -146,6 +146,9 @@ export interface RecordingSummary {
   createdAt: string;
   durationSeconds: number;
   status: 'recording' | 'transcribing' | 'done' | 'failed';
+  hasAudio: boolean;
+  hasNote: boolean;
+  hasTranscript: boolean;
 }
 
 export interface LocalFinalizeResult {
@@ -178,6 +181,12 @@ export const local = {
   },
   listRecordings(): Promise<RecordingSummary[]> {
     return invoke<RecordingSummary[]>('list_local_recordings');
+  },
+  readRecordingAudio(id: string): Promise<ArrayBuffer> {
+    return invoke<ArrayBuffer>('read_recording_audio', { id });
+  },
+  openRecordingFile(id: string, kind: 'note' | 'transcript'): Promise<void> {
+    return invoke('open_recording_file', { id, kind });
   },
   modelStatus(): Promise<ModelStatus> {
     return invoke<ModelStatus>('local_model_status');

--- a/src/views/LibraryView.test.ts
+++ b/src/views/LibraryView.test.ts
@@ -42,8 +42,8 @@ describe('LibraryView', () => {
 
   it('renders a row per recording in the order returned', async () => {
     listRecordings.mockResolvedValue([
-      { id: 'b', title: 'Second', createdAt: '2026-06-02T10:00:00Z', durationSeconds: 75, status: 'done' },
-      { id: 'a', title: 'First', createdAt: '2026-06-01T10:00:00Z', durationSeconds: 3661, status: 'failed' },
+      rec({ id: 'b', title: 'Second', createdAt: '2026-06-02T10:00:00Z', durationSeconds: 75, status: 'done' }),
+      rec({ id: 'a', title: 'First', createdAt: '2026-06-01T10:00:00Z', durationSeconds: 3661, status: 'failed' }),
     ]);
     const wrapper = mount(LibraryView);
     await flushPromises();
@@ -104,6 +104,9 @@ describe('LibraryView', () => {
       createObjectURL: vi.fn(() => 'blob:x'),
       revokeObjectURL: vi.fn(),
     });
+    // jsdom does not implement HTMLMediaElement.play(); stub it so the
+    // best-effort programmatic play does not log a noisy "Not implemented".
+    vi.spyOn(window.HTMLMediaElement.prototype, 'play').mockResolvedValue(undefined);
     readRecordingAudio.mockResolvedValue(new ArrayBuffer(8));
     listRecordings.mockResolvedValue([rec({ id: 'a', hasAudio: true })]);
     const wrapper = mount(LibraryView);
@@ -116,6 +119,28 @@ describe('LibraryView', () => {
     await flushPromises();
     expect(readRecordingAudio).toHaveBeenCalledWith('a');
     expect(wrapper.find('audio.audio-el').exists()).toBe(true);
+    vi.unstubAllGlobals();
+  });
+
+  it('shows the error state and creates no blob URL when audio fails to load', async () => {
+    const createObjectURL = vi.fn(() => 'blob:x');
+    vi.stubGlobal('URL', {
+      createObjectURL,
+      revokeObjectURL: vi.fn(),
+    });
+    readRecordingAudio.mockRejectedValue(new Error('boom'));
+    listRecordings.mockResolvedValue([rec({ id: 'a', hasAudio: true })]);
+    const wrapper = mount(LibraryView);
+    await flushPromises();
+    const play = wrapper.find('.play-btn');
+    await play.trigger('click');
+    await flushPromises();
+    expect(readRecordingAudio).toHaveBeenCalledWith('a');
+    expect(createObjectURL).not.toHaveBeenCalled();
+    expect(wrapper.find('audio.audio-el').exists()).toBe(false);
+    const playAfter = wrapper.find('.play-btn');
+    expect(playAfter.classes()).toContain('play-btn--error');
+    expect(playAfter.text()).toContain('Failed');
     vi.unstubAllGlobals();
   });
 });

--- a/src/views/LibraryView.test.ts
+++ b/src/views/LibraryView.test.ts
@@ -3,11 +3,31 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { mount, flushPromises } from '@vue/test-utils';
 
 const listRecordings = vi.fn();
+const readRecordingAudio = vi.fn();
+const openRecordingFile = vi.fn();
 vi.mock('../tauri', () => ({
-  local: { listRecordings: () => listRecordings() },
+  local: {
+    listRecordings: () => listRecordings(),
+    readRecordingAudio: (id: string) => readRecordingAudio(id),
+    openRecordingFile: (id: string, kind: string) => openRecordingFile(id, kind),
+  },
 }));
 
 import LibraryView from './LibraryView.vue';
+
+function rec(over: Record<string, unknown>) {
+  return {
+    id: 'x',
+    title: 'T',
+    createdAt: '2026-06-02T10:00:00Z',
+    durationSeconds: 10,
+    status: 'done',
+    hasAudio: false,
+    hasNote: false,
+    hasTranscript: false,
+    ...over,
+  };
+}
 
 beforeEach(() => vi.clearAllMocks());
 
@@ -34,5 +54,68 @@ describe('LibraryView', () => {
     expect(rows[1].text()).toContain('First');
     expect(rows[1].text()).toContain('61:01'); // 3661s
     expect(rows[1].text()).toContain('failed');
+  });
+
+  it('enables/disables Note and Transcript per file-presence flags', async () => {
+    listRecordings.mockResolvedValue([
+      rec({ id: 'a', hasNote: true, hasTranscript: false }),
+    ]);
+    const wrapper = mount(LibraryView);
+    await flushPromises();
+    const note = wrapper.find('.btn-note');
+    const transcript = wrapper.find('.btn-transcript');
+    expect((note.element as HTMLButtonElement).disabled).toBe(false);
+    expect((transcript.element as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it('clicking an enabled Note button opens the note file', async () => {
+    openRecordingFile.mockResolvedValue(undefined);
+    listRecordings.mockResolvedValue([
+      rec({ id: 'a', hasNote: true }),
+    ]);
+    const wrapper = mount(LibraryView);
+    await flushPromises();
+    await wrapper.find('.btn-note').trigger('click');
+    expect(openRecordingFile).toHaveBeenCalledWith('a', 'note');
+  });
+
+  it('clicking an enabled Transcript button opens the transcript file', async () => {
+    openRecordingFile.mockResolvedValue(undefined);
+    listRecordings.mockResolvedValue([
+      rec({ id: 'a', hasTranscript: true }),
+    ]);
+    const wrapper = mount(LibraryView);
+    await flushPromises();
+    await wrapper.find('.btn-transcript').trigger('click');
+    expect(openRecordingFile).toHaveBeenCalledWith('a', 'transcript');
+  });
+
+  it('shows a disabled play control when hasAudio is false', async () => {
+    listRecordings.mockResolvedValue([rec({ id: 'a', hasAudio: false })]);
+    const wrapper = mount(LibraryView);
+    await flushPromises();
+    const play = wrapper.find('.play-btn');
+    expect((play.element as HTMLButtonElement).disabled).toBe(true);
+    expect(play.text()).toContain('No audio');
+  });
+
+  it('shows an enabled play trigger and loads audio on click when hasAudio is true', async () => {
+    vi.stubGlobal('URL', {
+      createObjectURL: vi.fn(() => 'blob:x'),
+      revokeObjectURL: vi.fn(),
+    });
+    readRecordingAudio.mockResolvedValue(new ArrayBuffer(8));
+    listRecordings.mockResolvedValue([rec({ id: 'a', hasAudio: true })]);
+    const wrapper = mount(LibraryView);
+    await flushPromises();
+    const play = wrapper.find('.play-btn');
+    expect((play.element as HTMLButtonElement).disabled).toBe(false);
+    // Lazy: nothing fetched on mount.
+    expect(readRecordingAudio).not.toHaveBeenCalled();
+    await play.trigger('click');
+    await flushPromises();
+    expect(readRecordingAudio).toHaveBeenCalledWith('a');
+    expect(wrapper.find('audio.audio-el').exists()).toBe(true);
+    vi.unstubAllGlobals();
   });
 });

--- a/src/views/LibraryView.test.ts
+++ b/src/views/LibraryView.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { mount, flushPromises } from '@vue/test-utils';
 
 const listRecordings = vi.fn();
@@ -30,6 +30,12 @@ function rec(over: Record<string, unknown>) {
 }
 
 beforeEach(() => vi.clearAllMocks());
+// Always restore URL stubs and the HTMLMediaElement.play spy, even if a test
+// throws before reaching its inline teardown, so they can't leak across specs.
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
 
 describe('LibraryView', () => {
   it('shows an empty state when there are no recordings', async () => {
@@ -119,7 +125,6 @@ describe('LibraryView', () => {
     await flushPromises();
     expect(readRecordingAudio).toHaveBeenCalledWith('a');
     expect(wrapper.find('audio.audio-el').exists()).toBe(true);
-    vi.unstubAllGlobals();
   });
 
   it('shows the error state and creates no blob URL when audio fails to load', async () => {
@@ -141,6 +146,5 @@ describe('LibraryView', () => {
     const playAfter = wrapper.find('.play-btn');
     expect(playAfter.classes()).toContain('play-btn--error');
     expect(playAfter.text()).toContain('Failed');
-    vi.unstubAllGlobals();
   });
 });

--- a/src/views/LibraryView.vue
+++ b/src/views/LibraryView.vue
@@ -13,6 +13,11 @@
           <span>{{ formatDate(r.createdAt) }}</span>
           <span>{{ formatDuration(r.durationSeconds) }}</span>
         </div>
+        <div class="row-controls">
+          <RecordingAudioPlayer :id="r.id" :has-audio="r.hasAudio" />
+          <button class="btn-note" :disabled="!r.hasNote" @click="openNote(r.id)">Note</button>
+          <button class="btn-transcript" :disabled="!r.hasTranscript" @click="openTranscript(r.id)">Transcript</button>
+        </div>
       </li>
     </ul>
   </div>
@@ -21,6 +26,7 @@
 <script setup lang="ts">
 import { ref, onMounted } from 'vue';
 import { local, type RecordingSummary } from '../tauri';
+import RecordingAudioPlayer from './RecordingAudioPlayer.vue';
 
 const recordings = ref<RecordingSummary[]>([]);
 const loading = ref(true);
@@ -34,6 +40,22 @@ function formatDuration(secs: number): string {
 function formatDate(iso: string): string {
   const d = new Date(iso);
   return Number.isNaN(d.getTime()) ? iso : d.toLocaleString();
+}
+
+async function openNote(id: string) {
+  try {
+    await local.openRecordingFile(id, 'note');
+  } catch (e) {
+    console.error('Failed to open note', e);
+  }
+}
+
+async function openTranscript(id: string) {
+  try {
+    await local.openRecordingFile(id, 'transcript');
+  } catch (e) {
+    console.error('Failed to open transcript', e);
+  }
 }
 
 onMounted(async () => {
@@ -66,4 +88,18 @@ onMounted(async () => {
 .status-transcribing { color: #4f46e5; }
 .status-recording { color: #86868b; }
 .row-sub { display: flex; justify-content: space-between; margin-top: 4px; font-size: 12px; color: #86868b; }
+.row-controls { display: flex; align-items: center; gap: 8px; margin-top: 10px; flex-wrap: wrap; }
+.btn-note, .btn-transcript {
+  font-size: 13px;
+  padding: 5px 14px;
+  border-radius: 6px;
+  border: 1px solid #d1d5db;
+  background: white;
+  color: #1d1d1f;
+  cursor: pointer;
+}
+.btn-note:disabled, .btn-transcript:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
 </style>

--- a/src/views/LibraryView.vue
+++ b/src/views/LibraryView.vue
@@ -74,11 +74,16 @@ onMounted(async () => {
   padding: 24px;
   font-family: -apple-system, system-ui, sans-serif;
   background: #f5f5f7;
-  min-height: 100vh;
+  height: 100vh;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
 }
-.title { font-size: 20px; font-weight: 700; margin-bottom: 16px; color: #1d1d1f; }
+.title { font-size: 20px; font-weight: 700; margin-bottom: 16px; color: #1d1d1f; flex-shrink: 0; }
 .hint { font-size: 14px; color: #86868b; }
-.list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 8px; }
+/* Scrolls vertically when the recordings overflow the window. min-height: 0 lets
+   this flex child shrink below its content height so overflow-y can engage. */
+.list { list-style: none; margin: 0; padding: 0 4px 0 0; display: flex; flex-direction: column; gap: 8px; flex: 1; min-height: 0; overflow-y: auto; }
 .recording-row { background: #fff; border-radius: 10px; padding: 12px 14px; box-shadow: 0 1px 3px rgba(0,0,0,0.06); }
 .row-main { display: flex; justify-content: space-between; align-items: center; }
 .row-title { font-size: 14px; font-weight: 500; color: #1d1d1f; }
@@ -88,7 +93,10 @@ onMounted(async () => {
 .status-transcribing { color: #4f46e5; }
 .status-recording { color: #86868b; }
 .row-sub { display: flex; justify-content: space-between; margin-top: 4px; font-size: 12px; color: #86868b; }
-.row-controls { display: flex; align-items: center; gap: 8px; margin-top: 10px; flex-wrap: wrap; }
+/* nowrap keeps the player + both buttons on one line; the player flexes to fill
+   the remaining width (see RecordingAudioPlayer .audio-el) while the buttons
+   keep their size. */
+.row-controls { display: flex; align-items: center; gap: 8px; margin-top: 10px; flex-wrap: nowrap; }
 .btn-note, .btn-transcript {
   font-size: 13px;
   padding: 5px 14px;
@@ -97,6 +105,8 @@ onMounted(async () => {
   background: white;
   color: #1d1d1f;
   cursor: pointer;
+  flex-shrink: 0;
+  white-space: nowrap;
 }
 .btn-note:disabled, .btn-transcript:disabled {
   opacity: 0.5;

--- a/src/views/RecordingAudioPlayer.vue
+++ b/src/views/RecordingAudioPlayer.vue
@@ -83,6 +83,8 @@ onBeforeUnmount(() => {
   background: white;
   color: #1d1d1f;
   cursor: pointer;
+  flex-shrink: 0;
+  white-space: nowrap;
 }
 .play-btn:disabled {
   opacity: 0.5;
@@ -92,8 +94,11 @@ onBeforeUnmount(() => {
   color: #dc2626;
   border-color: #fca5a5;
 }
+/* Flex to fill the remaining row width beside the Note/Transcript buttons;
+   min-width: 0 lets it shrink instead of pushing the buttons off the line. */
 .audio-el {
   height: 32px;
-  max-width: 100%;
+  flex: 1 1 auto;
+  min-width: 0;
 }
 </style>

--- a/src/views/RecordingAudioPlayer.vue
+++ b/src/views/RecordingAudioPlayer.vue
@@ -1,10 +1,10 @@
 <template>
   <audio
     v-if="blobUrl"
+    ref="audioEl"
     class="audio-el"
     :src="blobUrl"
     controls
-    autoplay
   ></audio>
   <button
     v-else
@@ -21,7 +21,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, onBeforeUnmount } from 'vue';
+import { ref, onBeforeUnmount, nextTick } from 'vue';
 import { local } from '../tauri';
 
 const props = defineProps<{ id: string; hasAudio: boolean }>();
@@ -29,6 +29,11 @@ const props = defineProps<{ id: string; hasAudio: boolean }>();
 const blobUrl = ref<string | null>(null);
 const loading = ref(false);
 const errored = ref(false);
+const audioEl = ref<HTMLAudioElement | null>(null);
+
+// Tracks whether the component unmounted while a load was in flight, so a URL
+// created after onBeforeUnmount ran gets revoked instead of leaking.
+let destroyed = false;
 
 async function onPlay() {
   if (!props.hasAudio || loading.value || blobUrl.value) return;
@@ -36,17 +41,33 @@ async function onPlay() {
   errored.value = false;
   try {
     const buf = await local.readRecordingAudio(props.id);
+    // Backend writes recording.mp3 (see src-tauri/src/commands.rs); keep MIME in sync.
     const blob = new Blob([buf], { type: 'audio/mpeg' });
-    blobUrl.value = URL.createObjectURL(blob);
+    const url = URL.createObjectURL(blob);
+    if (destroyed) {
+      URL.revokeObjectURL(url);
+      return;
+    }
+    blobUrl.value = url;
+    // autoplay is unreliable in WKWebView (the user-gesture token is lost across
+    // the await), so play programmatically as a best effort; the native
+    // <audio controls> remains usable if the webview blocks it.
+    await nextTick();
+    audioEl.value?.play().catch(() => {});
   } catch (e) {
-    console.error('Failed to load recording audio', e);
-    errored.value = true;
+    if (!destroyed) {
+      console.error('Failed to load recording audio', e);
+      errored.value = true;
+    }
   } finally {
-    loading.value = false;
+    if (!destroyed) {
+      loading.value = false;
+    }
   }
 }
 
 onBeforeUnmount(() => {
+  destroyed = true;
   if (blobUrl.value) {
     URL.revokeObjectURL(blobUrl.value);
   }

--- a/src/views/RecordingAudioPlayer.vue
+++ b/src/views/RecordingAudioPlayer.vue
@@ -1,0 +1,78 @@
+<template>
+  <audio
+    v-if="blobUrl"
+    class="audio-el"
+    :src="blobUrl"
+    controls
+    autoplay
+  ></audio>
+  <button
+    v-else
+    class="play-btn"
+    :class="{ 'play-btn--error': errored }"
+    :disabled="!hasAudio || loading"
+    @click="onPlay"
+  >
+    <span v-if="!hasAudio">▶ No audio</span>
+    <span v-else-if="loading">Loading…</span>
+    <span v-else-if="errored">Failed</span>
+    <span v-else>▶ Play</span>
+  </button>
+</template>
+
+<script setup lang="ts">
+import { ref, onBeforeUnmount } from 'vue';
+import { local } from '../tauri';
+
+const props = defineProps<{ id: string; hasAudio: boolean }>();
+
+const blobUrl = ref<string | null>(null);
+const loading = ref(false);
+const errored = ref(false);
+
+async function onPlay() {
+  if (!props.hasAudio || loading.value || blobUrl.value) return;
+  loading.value = true;
+  errored.value = false;
+  try {
+    const buf = await local.readRecordingAudio(props.id);
+    const blob = new Blob([buf], { type: 'audio/mpeg' });
+    blobUrl.value = URL.createObjectURL(blob);
+  } catch (e) {
+    console.error('Failed to load recording audio', e);
+    errored.value = true;
+  } finally {
+    loading.value = false;
+  }
+}
+
+onBeforeUnmount(() => {
+  if (blobUrl.value) {
+    URL.revokeObjectURL(blobUrl.value);
+  }
+});
+</script>
+
+<style scoped>
+.play-btn {
+  font-size: 13px;
+  padding: 5px 14px;
+  border-radius: 6px;
+  border: 1px solid #d1d5db;
+  background: white;
+  color: #1d1d1f;
+  cursor: pointer;
+}
+.play-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+.play-btn--error {
+  color: #dc2626;
+  border-color: #fca5a5;
+}
+.audio-el {
+  height: 32px;
+  max-width: 100%;
+}
+</style>


### PR DESCRIPTION
## Summary
- Each recording row in the **Meetings** window now has an audio player to play the recording, plus **Note** and **Transcript** buttons that open `note.md` / `transcript.md` in the OS default app.
- The player and both buttons are always shown but **disabled (greyed out)** when the underlying file isn't present (e.g. a recording still transcribing has no `note.md` yet).
- **Backend:** `RecordingSummary` now reports `hasAudio`/`hasNote`/`hasTranscript`; new Tauri commands `read_recording_audio` (streams `recording.mp3` as a raw binary IPC response, with a path-traversal guard and a size cap) and `open_recording_file` (traversal-guarded, opens `note.md`/`transcript.md` via the opener plugin).
- **Frontend:** new lazy-loading `RecordingAudioPlayer.vue` (native `<audio controls>` fed by a blob URL, created on first play and revoked on unmount — leak-safe across mid-load unmount); Note/Transcript buttons wired in `LibraryView.vue`.

## Test Plan
- [x] `cargo test -- --test-threads=1` (33 passed) — storage flags, traversal-guard rejection, kind→filename mapping
- [x] `npm test` (33 passed) — button disabled-state per flag, click → `openRecordingFile` with correct kind, lazy-load behavior, error path
- [ ] Manual: open Meetings window, play a recording, click Note/Transcript on a completed recording, confirm buttons greyed for an in-progress one

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Audio playback per recording with integrated player and safe loading/cleanup.
  * Note and Transcript buttons to open associated files; buttons enable/disable based on availability.
  * Recording list now shows availability flags for audio, notes, and transcripts.
* **Tests**
  * Expanded UI and backend tests covering playback, file-opening, and availability flags.
* **Chores**
  * CI runner selection updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->