### PR TITLE
chore: bump version to 0.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ariso-ai/desktop",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -58,7 +58,7 @@ dependencies = [
 
 [[package]]
 name = "ariso-desktop"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "block2",
  "futures-util",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ariso-desktop"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2024"
 
 [dependencies]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicoverbruggen/tauri-v2-schema/main/tauri.schema.json",
   "productName": "Ariso",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "identifier": "ai.ariso.desktop",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Summary

Bumps the app version from `0.2.1` → `0.3.0` across all four declaration sites:

- `package.json` — also feeds the Settings window version via Vite's `__APP_VERSION__` global
- `src-tauri/tauri.conf.json` — the version used in the updater `latest.json` manifest
- `src-tauri/Cargo.toml`
- `src-tauri/Cargo.lock` (`ariso-desktop` package entry)

## Why a minor bump

The 125 commits since `v0.2.0` are dominated by a major new feature — **local on-device meeting notes**: the `ariso-stt` Swift sidecar (real FluidAudio transcription + model download), a backend selector with Local/Ariso implementations, the read-only Library view, and the Meetings audio player. New user-facing functionality, no breaking changes.

> Note: `0.2.1` was set in the files but never tagged/released, so this supersedes it.

## Next step

Merging this does **not** publish a release. After merge, cut the release to trigger signing/notarization:

```bash
gh release create v0.3.0 --target main --generate-notes
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 0.3.0 across application configuration files

<!-- end of auto-generated comment: release notes by coderabbit.ai -->