### PR TITLE
chore: bump version to 0.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ariso-ai/desktop",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -58,7 +58,7 @@ dependencies = [
 
 [[package]]
 name = "ariso-desktop"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "block2",
  "futures-util",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ariso-desktop"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 
 [dependencies]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicoverbruggen/tauri-v2-schema/main/tauri.schema.json",
   "productName": "Ariso",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "identifier": "ai.ariso.desktop",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
Bumps the release version from `0.3.0` to `0.3.1` across all version-tracked files:

- `package.json`
- `src-tauri/tauri.conf.json`
- `src-tauri/Cargo.toml`
- `src-tauri/Cargo.lock` (`ariso-desktop` package)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 0.3.1

<!-- end of auto-generated comment: release notes by coderabbit.ai -->