### PR TITLE
ci(desktop): extract release publish into script + guard required secrets

### DIFF
--- a/.github/scripts/release-publish.sh
+++ b/.github/scripts/release-publish.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+#
+# Build the Tauri updater manifest (latest.json) and publish the release
+# artifacts (updater tarball, DMG, manifest) to Cloudflare R2.
+#
+# Invoked by the release job in .github/workflows/desktop.yaml after the
+# bundler has produced its outputs under src-tauri/target/release/bundle/.
+#
+# Required environment:
+#   RELEASE_TAG    release tag (e.g. v0.3.1); leading 'v' is stripped for VERSION
+#   R2_ENDPOINT    https://<account-id>.r2.cloudflarestorage.com
+#   R2_BUCKET      bucket backing the public pub-...r2.dev domain
+#   AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY    R2 API token credentials
+# Optional environment:
+#   RELEASE_BODY   release notes (may be multi-line); defaults to empty
+#   RELEASE_NAME   release title; "[mandatory]" in it marks a forced update
+set -euo pipefail
+
+# Fail fast with an actionable message if a required secret is missing. An
+# empty R2_ENDPOINT otherwise surfaces deep inside the AWS CLI as the opaque
+# 'Bad value for --endpoint-url "": scheme is missing.', which gives no hint
+# that the real problem is an unset secret in the 'release' environment.
+require_env() {
+  local missing=0 name
+  for name in "$@"; do
+    if [[ -z "${!name:-}" ]]; then
+      echo "Missing required environment variable: ${name}" >&2
+      missing=1
+    fi
+  done
+  if [[ "$missing" -ne 0 ]]; then
+    echo "Set these as secrets in the 'release' GitHub environment" \
+      "(see README -> Signing & Notarization)." >&2
+    exit 1
+  fi
+}
+
+require_env RELEASE_TAG R2_ENDPOINT R2_BUCKET AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
+
+# Ensure the AWS CLI is available on the self-hosted runner.
+if ! command -v aws >/dev/null 2>&1; then
+  echo "AWS CLI not found on runner; install with 'brew install awscli'." >&2
+  exit 1
+fi
+
+BUNDLE_DIR="src-tauri/target/release/bundle"
+
+# Locate the updater artifacts the bundler produced. Tauri v2 writes these to
+# bundle/macos/. Cached builds can leave stale tarballs alongside the fresh
+# one, so require exactly one match and fail loudly otherwise.
+mapfile -t TARBALLS < <(find "${BUNDLE_DIR}/macos" -maxdepth 1 -type f -name '*.app.tar.gz' | sort)
+if [[ "${#TARBALLS[@]}" -ne 1 ]]; then
+  echo "Expected exactly 1 updater tarball, found ${#TARBALLS[@]}:" >&2
+  printf ' - %s\n' "${TARBALLS[@]}" >&2
+  exit 1
+fi
+TARBALL="${TARBALLS[0]}"
+SIGFILE="${TARBALL}.sig"
+
+mapfile -t DMGS < <(find "${BUNDLE_DIR}/dmg" -maxdepth 1 -type f -name '*.dmg' | sort)
+if [[ "${#DMGS[@]}" -ne 1 ]]; then
+  echo "Expected exactly 1 DMG, found ${#DMGS[@]}." >&2
+  exit 1
+fi
+DMG="${DMGS[0]}"
+
+# The version in tauri.conf.json (strip leading 'v' from tag).
+VERSION="${RELEASE_TAG#v}"
+
+# Asset URL is the stable R2 path the updater downloads the payload from. The
+# object at this key is overwritten by the upload below.
+ASSET_URL="https://pub-dd2807d512d34e55b8a863f675ea8e6e.r2.dev/desktop/Ariso.app.tar.gz"
+
+# Read the detached signature contents (single line of base64).
+SIG=$(cat "$SIGFILE")
+
+# Mandatory flag: derived from the release title containing "[mandatory]".
+if [[ "${RELEASE_NAME:-}" == *"[mandatory]"* ]]; then
+  MANDATORY="true"
+else
+  MANDATORY="false"
+fi
+
+# Build the manifest using jq to ensure valid JSON escaping of the
+# (possibly multi-line) release body.
+jq -n \
+  --arg version "$VERSION" \
+  --arg notes "${RELEASE_BODY:-}" \
+  --arg pub_date "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+  --argjson mandatory "$MANDATORY" \
+  --arg signature "$SIG" \
+  --arg url "$ASSET_URL" \
+  '{
+    version: $version,
+    notes: $notes,
+    pub_date: $pub_date,
+    mandatory: $mandatory,
+    platforms: {
+      "darwin-aarch64": {
+        signature: $signature,
+        url: $url
+      }
+    }
+  }' > latest.json
+
+NOCACHE="no-cache, max-age=0, must-revalidate"
+
+# Upload payloads BEFORE the manifest that references them, so a client reading
+# the new latest.json never points at a missing object.
+aws s3 cp "$TARBALL" "s3://${R2_BUCKET}/desktop/Ariso.app.tar.gz" \
+  --endpoint-url "$R2_ENDPOINT" \
+  --content-type application/gzip \
+  --cache-control "$NOCACHE"
+
+aws s3 cp "$DMG" "s3://${R2_BUCKET}/desktop/Ariso.dmg" \
+  --endpoint-url "$R2_ENDPOINT" \
+  --content-type application/x-apple-diskimage \
+  --cache-control "$NOCACHE"
+
+aws s3 cp latest.json "s3://${R2_BUCKET}/desktop/latest.json" \
+  --endpoint-url "$R2_ENDPOINT" \
+  --content-type application/json \
+  --cache-control "$NOCACHE"

--- a/.github/workflows/desktop.yaml
+++ b/.github/workflows/desktop.yaml
@@ -180,109 +180,12 @@ jobs:
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         run: npm run tauri:build -- -- --features prod-api
 
-      - name: Generate latest.json updater manifest
+      - name: Generate manifest and publish artifacts to R2
         env:
           RELEASE_TAG: ${{ github.event.release.tag_name }}
           RELEASE_BODY: ${{ github.event.release.body }}
           RELEASE_NAME: ${{ github.event.release.name }}
-        run: |
-          set -euo pipefail
-
-          # Locate the updater artifacts the bundler produced. Tauri v2
-          # writes these to src-tauri/target/release/bundle/macos/. Cached
-          # builds can leave stale tarballs alongside the fresh one, so
-          # require exactly one match and fail loudly otherwise.
-          mapfile -t TARBALLS < <(find src-tauri/target/release/bundle/macos -maxdepth 1 -type f -name '*.app.tar.gz' | sort)
-          if [[ "${#TARBALLS[@]}" -ne 1 ]]; then
-            echo "Expected exactly 1 updater tarball, found ${#TARBALLS[@]}:" >&2
-            printf ' - %s\n' "${TARBALLS[@]}" >&2
-            exit 1
-          fi
-          TARBALL="${TARBALLS[0]}"
-          SIGFILE="${TARBALL}.sig"
-
-          # The version in tauri.conf.json (strip leading 'v' from tag).
-          VERSION="${RELEASE_TAG#v}"
-
-          # Asset URL is the stable R2 path the updater downloads the payload
-          # from. The object at this key is overwritten by the Publish to R2 step.
-          ASSET_URL="https://pub-dd2807d512d34e55b8a863f675ea8e6e.r2.dev/desktop/Ariso.app.tar.gz"
-
-          # Read the detached signature contents (single line of base64).
-          SIG=$(cat "$SIGFILE")
-
-          # Mandatory flag: derived from the release title containing "[mandatory]".
-          if [[ "$RELEASE_NAME" == *"[mandatory]"* ]]; then
-            MANDATORY="true"
-          else
-            MANDATORY="false"
-          fi
-
-          # Build the manifest using jq to ensure valid JSON escaping
-          # of the (possibly multi-line) release body.
-          jq -n \
-            --arg version "$VERSION" \
-            --arg notes "$RELEASE_BODY" \
-            --arg pub_date "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
-            --argjson mandatory "$MANDATORY" \
-            --arg signature "$SIG" \
-            --arg url "$ASSET_URL" \
-            '{
-              version: $version,
-              notes: $notes,
-              pub_date: $pub_date,
-              mandatory: $mandatory,
-              platforms: {
-                "darwin-aarch64": {
-                  signature: $signature,
-                  url: $url
-                }
-              }
-            }' > latest.json
-
-      - name: Publish artifacts to R2
-        run: |
-          set -euo pipefail
-
-          # Ensure the AWS CLI is available on the self-hosted runner.
-          if ! command -v aws >/dev/null 2>&1; then
-            echo "AWS CLI not found on runner; install with 'brew install awscli'." >&2
-            exit 1
-          fi
-
-          # Re-locate the bundler outputs (same logic as the manifest step).
-          mapfile -t TARBALLS < <(find src-tauri/target/release/bundle/macos -maxdepth 1 -type f -name '*.app.tar.gz' | sort)
-          if [[ "${#TARBALLS[@]}" -ne 1 ]]; then
-            echo "Expected exactly 1 updater tarball, found ${#TARBALLS[@]}." >&2
-            exit 1
-          fi
-          TARBALL="${TARBALLS[0]}"
-
-          mapfile -t DMGS < <(find src-tauri/target/release/bundle/dmg -maxdepth 1 -type f -name '*.dmg' | sort)
-          if [[ "${#DMGS[@]}" -ne 1 ]]; then
-            echo "Expected exactly 1 DMG, found ${#DMGS[@]}." >&2
-            exit 1
-          fi
-          DMG="${DMGS[0]}"
-
-          NOCACHE="no-cache, max-age=0, must-revalidate"
-
-          # Upload payloads BEFORE the manifest that references them, so a client
-          # reading the new latest.json never points at a missing object.
-          aws s3 cp "$TARBALL" "s3://${R2_BUCKET}/desktop/Ariso.app.tar.gz" \
-            --endpoint-url "$R2_ENDPOINT" \
-            --content-type application/gzip \
-            --cache-control "$NOCACHE"
-
-          aws s3 cp "$DMG" "s3://${R2_BUCKET}/desktop/Ariso.dmg" \
-            --endpoint-url "$R2_ENDPOINT" \
-            --content-type application/x-apple-diskimage \
-            --cache-control "$NOCACHE"
-
-          aws s3 cp latest.json "s3://${R2_BUCKET}/desktop/latest.json" \
-            --endpoint-url "$R2_ENDPOINT" \
-            --content-type application/json \
-            --cache-control "$NOCACHE"
+        run: .github/scripts/release-publish.sh
 
       - name: Add R2 download link to GitHub Release
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
## Summary
- Fixes the release build failure `Bad value for --endpoint-url "": scheme is missing.`, which was caused by an empty `R2_ENDPOINT` secret being passed straight to `aws s3 cp`.
- Extracts the `latest.json` manifest generation and R2 upload steps from `desktop.yaml` into `.github/scripts/release-publish.sh`, collapsing two inline `run:` blocks (and their duplicated tarball-location logic) into one.
- Adds a `require_env` guard so a missing/empty `R2_ENDPOINT` (or `R2_BUCKET` / AWS creds) fails fast with an actionable message instead of the opaque AWS CLI error.

## ⚠️ Required follow-up
This makes the failure clear and early, but the build only fully passes once the secret exists. Add `R2_ENDPOINT` (and confirm `R2_BUCKET`, `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY`) in the **`release`** GitHub environment:

```
R2_ENDPOINT = https://<cloudflare-account-id>.r2.cloudflarestorage.com
```

## Test plan
- [x] `bash -n .github/scripts/release-publish.sh` passes
- [x] `desktop.yaml` parses as valid YAML
- [ ] Cut a release once `R2_ENDPOINT` is set in the `release` environment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refactored macOS release publishing automation by consolidating artifact handling, manifest generation, and deployment into a dedicated script, improving process maintainability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->