### PR TITLE
feat: Meetings main window (split layout + embedded recorder)

### DIFF
--- a/docs/superpowers/specs/2026-06-09-meetings-main-window-design.md
+++ b/docs/superpowers/specs/2026-06-09-meetings-main-window-design.md
@@ -1,0 +1,150 @@
+# Meetings Main Window — Split Layout + Embedded Recorder
+
+**Date:** 2026-06-09
+**Status:** Approved (design)
+
+## Summary
+
+Evolve the existing `library` window into a two-pane main window for meetings.
+The left pane shows a backend-driven meeting list; the right pane is an (empty for
+now) detail area with a **Record** button in its top-right corner. Clicking Record
+starts capturing immediately and docks an embedded recorder at the bottom of the
+right pane. The recorder is hidden whenever recording is not active.
+
+This is the first increment of a larger consolidation of the app's transient
+tray-spawned windows into a single main window. The right-pane detail, row
+selection, and retirement of the floating recorder / meeting-picker / tray
+"Start Recording" flow are intentionally deferred.
+
+## Context
+
+The app is a macOS menubar/tray app with **no persistent main window**. It spawns
+transient `WebviewWindow`s on demand (`src-tauri/src/commands.rs`):
+
+- `library` → `LibraryView.vue` (route `/library`): today a single-column
+  "Meetings" list of **local recordings** via `list_local_recordings`.
+- `waveform` → `WaveformView.vue` (route `/waveform`): the recorder — a floating,
+  always-on-top, transparent 320×56 window that manages tray state
+  (`set_tray_recording`), handles the upload/transcribe UI, listens to
+  `tray://*` events, and **closes itself** on stop.
+- plus `settings`, `meeting-picker`, `oauth`, `update`, `bootstrap`.
+
+Backends are abstracted behind the `Backend` interface (`src/composables/useBackend.ts`):
+`ArisoBackend` (server, needs auth) and `LocalBackend` (on-device). The active
+backend is resolved via `getActiveBackend()` from the `settings.json` store.
+
+## Decisions
+
+1. **Evolve `LibraryView.vue` in place** (keep route `/library`, the
+   `create_library_window` command, and the window label) rather than adding a
+   separate `main` window. Avoids a duplicate meetings window.
+2. **Left list is backend-driven**:
+   - Ariso → `GET /meetings?start_date=…&end_date=…` covering **now − 7 days …
+     now + 24 h**.
+   - Local → `list_local_recordings`.
+3. **Record button starts recording immediately**: clicking the top-right button
+   reveals the embedded recorder at the bottom of the right pane *and* begins
+   capture. Stopping hides the recorder again. ("When not recording, do not show
+   the recorder.")
+4. **Build a separate `RecorderPanel.vue`** for the embedded case rather than
+   refactoring the floating `WaveformView.vue`, so the working tray recorder is
+   left untouched.
+
+## Design
+
+### 1. Layout (`LibraryView.vue`)
+
+`LibraryView` becomes a horizontal flex split filling the window:
+
+- **Left panel** — fixed width (~300px), the existing scrollable meeting list with
+  current row styling reused. `min-height: 0` / `overflow-y: auto` preserved.
+- **Right panel** — flex-grow. Contains:
+  - a header bar with a circular **Record** button pinned top-right;
+  - an empty body (placeholder for future meeting detail);
+  - the embedded `RecorderPanel` docked at the bottom, mounted only while recording.
+- `create_library_window` default inner size bumped 460×560 → **~900×600** so the
+  split has room. Window stays `resizable(true)`, `skip_taskbar(true)`, title
+  "Meetings".
+
+### 2. Backend-driven list (`useBackend.ts`)
+
+Add to the `Backend` interface:
+
+```ts
+interface MeetingListItem {
+  id: string;            // string for uniform :key; local ids are strings, ariso numeric ids stringified
+  title: string;
+  subtitle: string;      // formatted date/time
+  status?: RecordingSummary['status'];  // present for local; omitted for ariso for now
+}
+
+interface Backend {
+  // …existing…
+  listMeetings(): Promise<MeetingListItem[]>;
+}
+```
+
+- `LocalBackend.listMeetings()` → `local.listRecordings()`, map each
+  `RecordingSummary` to `{ id, title, subtitle: formatDate(createdAt) +
+  duration, status }`.
+- `ArisoBackend.listMeetings()` → `GET /meetings?start_date=<YYYY-MM-DD>&
+  end_date=<YYYY-MM-DD>` with `start_date = today − 7d`, `end_date = today + 1d`;
+  map `{ meetings: [{ id, title, start_at }] }` to
+  `{ id: String(id), title: title || 'Untitled meeting', subtitle: formatTime(start_at) }`.
+- `LibraryView` calls `getActiveBackend().listMeetings()` on mount instead of
+  `local.listRecordings()` directly. Loading / empty / error states preserved.
+
+**Open contract detail (confirm during build):** existing working code
+(`useMeetingApi.listScheduledMeetings`) calls `/meetings?startDate=<ISO>&
+endDate=<ISO>` (camelCase, ISO datetime). This spec follows the literal request
+form `start_date`/`end_date` (snake_case, date-only). If the backend rejects the
+snake_case/date-only form, fall back to the proven camelCase ISO variant with the
+same (now−7d … now+24h) window — a one-line change.
+
+### 3. Embedded recorder (`RecorderPanel.vue`)
+
+New component reusing the real recording logic, **without** the floating-window /
+tray lifecycle:
+
+- Uses `useRecorder`, `useWaveform`, and `getActiveBackend()`.
+- On mount: resolve active backend, `recorder.startRecording(mode)` (mode derived
+  from recording settings as in `WaveformView`), start the waveform analyser, and
+  show REC state + pause/stop controls. Reuse `WaveformView`'s bar/timer markup.
+- **No** `set_tray_recording`, **no** `tray://*` listeners, **no** window close.
+- On stop: `recorder.stopRecording()` → `backend.finalizeRecording(blob, meta)`
+  with `meetingId` undefined (a fresh meeting/recording). Show a brief
+  uploading/transcribing → success/failed state inline, then emit a `done` event.
+- `LibraryView` owns visibility: `recording` ref toggled true by the Record
+  button, false on the panel's `done` event; on `done` it refreshes the left list.
+- Recording-source guard (both sources disabled / settings unreadable) mirrors
+  `WaveformView.startRecording`: abort and collapse the panel instead of recording
+  silence.
+
+The floating `WaveformView` + tray "Start Recording" flow is unchanged and still
+available.
+
+### 4. Files touched
+
+- `src/views/LibraryView.vue` — split layout, backend-driven list, record toggle.
+- `src/composables/useBackend.ts` — `MeetingListItem`, interface method, two impls.
+- `src/views/RecorderPanel.vue` — **new** embedded recorder.
+- `src-tauri/src/commands.rs` — `create_library_window` size bump only.
+
+Unchanged: `/library` route, window label, `WaveformView.vue`, tray flow,
+meeting-picker.
+
+### 5. Testing (vitest)
+
+- Unit-test `LocalBackend.listMeetings` and `ArisoBackend.listMeetings`
+  normalizers: shape mapping, and the Ariso date window (`start_date` = −7d,
+  `end_date` = +1d) and param form.
+- `LibraryView` test: recorder panel hidden on load, shown after the Record button
+  is clicked, hidden again after the panel emits `done`, and the list refreshes.
+- Existing `LibraryView.test.ts` updated for the backend-driven data source.
+
+## Out of scope (deferred)
+
+- Right-pane meeting detail and row selection.
+- Retiring the floating recorder, meeting-picker, or tray "Start Recording" flow.
+- Editing/attaching the embedded recording to a pre-existing meeting (always
+  creates a new one for now).

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -595,7 +595,7 @@ pub async fn create_library_window(app: tauri::AppHandle) -> Result<(), String> 
     }
     WebviewWindowBuilder::new(&app, "library", WebviewUrl::App("/#/library".into()))
         .title("Meetings")
-        .inner_size(460.0, 560.0)
+        .inner_size(900.0, 600.0)
         .resizable(true)
         .center()
         .skip_taskbar(true)

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -134,21 +134,13 @@ pub fn create_tray(app: &AppHandle) -> tauri::Result<()> {
                     }
                 }
                 "library" => {
+                    // The Meetings window is backend-aware: its list is
+                    // populated from the active backend (Ariso server meetings
+                    // or local recordings), so open the in-app window for both
+                    // rather than sending Ariso users out to the browser.
                     let app_async = app.clone();
                     tauri::async_runtime::spawn(async move {
-                        if crate::commands::active_backend(&app_async) == "local" {
-                            // Local backend: reuse the in-app Library window
-                            // (titled "Meetings").
-                            let _ = crate::commands::create_library_window(app_async).await;
-                        } else {
-                            // Ariso backend: meetings live in the web app.
-                            use tauri_plugin_opener::OpenerExt;
-                            let url = format!(
-                                "{}/my/meetings",
-                                crate::commands::WEB_APP_BASE_URL
-                            );
-                            let _ = app_async.opener().open_url(url, None::<&str>);
-                        }
+                        let _ = crate::commands::create_library_window(app_async).await;
                     });
                 }
                 "check_updates" => {

--- a/src/composables/useBackend.test.ts
+++ b/src/composables/useBackend.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 const localFinalize = vi.fn();
+const listRecordings = vi.fn();
+const listMeetingsInWindow = vi.fn();
 const apiRequest = vi.fn();
 const putPresigned = vi.fn();
 const checkSession = vi.fn();
@@ -12,6 +14,7 @@ vi.mock('../tauri', () => ({
   local: {
     finalizeRecording: (...a: unknown[]) => localFinalize(...a),
     modelStatus: () => modelStatus(),
+    listRecordings: () => listRecordings(),
   },
   auth: { checkSession: () => checkSession() },
   api: {
@@ -22,10 +25,13 @@ vi.mock('../tauri', () => ({
 }));
 
 vi.mock('./useMeetingApi', () => ({
-  useMeetingApi: () => ({ uploadAudio: (...a: unknown[]) => uploadAudio(...a) }),
+  useMeetingApi: () => ({
+    uploadAudio: (...a: unknown[]) => uploadAudio(...a),
+    listMeetingsInWindow: (...a: unknown[]) => listMeetingsInWindow(...a),
+  }),
 }));
 
-import { ArisoBackend, LocalBackend, getActiveBackend } from './useBackend';
+import { ArisoBackend, LocalBackend, getActiveBackend, arisoMeetingWindow } from './useBackend';
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -112,5 +118,59 @@ describe('getActiveBackend', () => {
   it('defaults to Ariso when the setting read throws', async () => {
     getBackendSetting.mockRejectedValue(new Error('store unavailable'));
     expect((await getActiveBackend()).id).toBe('ariso');
+  });
+});
+
+describe('arisoMeetingWindow', () => {
+  it('spans 7 days back to 1 day forward, date-only', () => {
+    // Local midday avoids any tz boundary ambiguity.
+    const now = new Date(2026, 5, 9, 12, 0, 0); // 2026-06-09 local
+    expect(arisoMeetingWindow(now)).toEqual({
+      startDate: '2026-06-02',
+      endDate: '2026-06-10',
+    });
+  });
+});
+
+describe('LocalBackend.listMeetings', () => {
+  it('maps recordings to list items with file affordances', async () => {
+    listRecordings.mockResolvedValue([
+      {
+        id: 'a',
+        title: 'First',
+        createdAt: '2026-06-02T10:00:00Z',
+        durationSeconds: 75,
+        status: 'done',
+        hasAudio: true,
+        hasNote: false,
+        hasTranscript: true,
+      },
+    ]);
+    const items = await new LocalBackend().listMeetings();
+    expect(items).toEqual([
+      {
+        id: 'a',
+        title: 'First',
+        timestamp: '2026-06-02T10:00:00Z',
+        durationSeconds: 75,
+        status: 'done',
+        files: { hasAudio: true, hasNote: false, hasTranscript: true },
+      },
+    ]);
+  });
+});
+
+describe('ArisoBackend.listMeetings', () => {
+  it('queries the date window and maps meetings (no file affordances)', async () => {
+    listMeetingsInWindow.mockResolvedValue([
+      { id: 7, title: 'Standup', start_at: '2026-06-08T09:00:00Z' },
+      { id: 8, title: null, start_at: '2026-06-09T09:00:00Z' },
+    ]);
+    const items = await new ArisoBackend().listMeetings();
+    expect(listMeetingsInWindow).toHaveBeenCalledTimes(1);
+    expect(items).toEqual([
+      { id: '7', title: 'Standup', timestamp: '2026-06-08T09:00:00Z' },
+      { id: '8', title: 'Untitled meeting', timestamp: '2026-06-09T09:00:00Z' },
+    ]);
   });
 });

--- a/src/composables/useBackend.test.ts
+++ b/src/composables/useBackend.test.ts
@@ -130,6 +130,14 @@ describe('arisoMeetingWindow', () => {
       endDate: '2026-06-10',
     });
   });
+
+  it('rolls back across a month/year boundary', () => {
+    const now = new Date(2026, 0, 3, 12, 0, 0); // 2026-01-03 local
+    expect(arisoMeetingWindow(now)).toEqual({
+      startDate: '2025-12-27',
+      endDate: '2026-01-04',
+    });
+  });
 });
 
 describe('LocalBackend.listMeetings', () => {
@@ -168,6 +176,10 @@ describe('ArisoBackend.listMeetings', () => {
     ]);
     const items = await new ArisoBackend().listMeetings();
     expect(listMeetingsInWindow).toHaveBeenCalledTimes(1);
+    expect(listMeetingsInWindow).toHaveBeenCalledWith(
+      expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/),
+      expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/)
+    );
     expect(items).toEqual([
       { id: '7', title: 'Standup', timestamp: '2026-06-08T09:00:00Z' },
       { id: '8', title: 'Untitled meeting', timestamp: '2026-06-09T09:00:00Z' },

--- a/src/composables/useBackend.ts
+++ b/src/composables/useBackend.ts
@@ -1,4 +1,4 @@
-import { local, auth, getBackendSetting } from '../tauri';
+import { local, auth, getBackendSetting, type RecordingSummary } from '../tauri';
 import { useMeetingApi } from './useMeetingApi';
 
 export type BackendId = 'ariso' | 'local';
@@ -20,12 +20,26 @@ export interface FinalizeResult {
   [k: string]: unknown;
 }
 
+export interface MeetingListItem {
+  id: string;
+  title: string;
+  /** ISO timestamp: local `createdAt` or ariso `start_at`. View formats it. */
+  timestamp: string;
+  /** Local recordings only. */
+  durationSeconds?: number;
+  /** Local recordings only. */
+  status?: RecordingSummary['status'];
+  /** Local recordings only — drives the row's audio/note/transcript controls. */
+  files?: { hasAudio: boolean; hasNote: boolean; hasTranscript: boolean };
+}
+
 export interface Backend {
   id: BackendId;
   needsAuth: boolean;
   usesMeetingPicker: boolean;
   isReady(): Promise<Readiness>;
   finalizeRecording(blob: Blob, meta: RecordingMeta): Promise<FinalizeResult>;
+  listMeetings(): Promise<MeetingListItem[]>;
 }
 
 async function blobToBytes(blob: Blob): Promise<number[]> {
@@ -63,6 +77,17 @@ export class ArisoBackend implements Backend {
     });
     return { backend: 'ariso', meetingId };
   }
+
+  async listMeetings(): Promise<MeetingListItem[]> {
+    const { listMeetingsInWindow } = useMeetingApi();
+    const { startDate, endDate } = arisoMeetingWindow(new Date());
+    const meetings = await listMeetingsInWindow(startDate, endDate);
+    return meetings.map((m) => ({
+      id: String(m.id),
+      title: m.title || 'Untitled meeting',
+      timestamp: m.start_at,
+    }));
+  }
 }
 
 export class LocalBackend implements Backend {
@@ -89,6 +114,34 @@ export class LocalBackend implements Backend {
     );
     return { backend: 'local', ...res };
   }
+
+  async listMeetings(): Promise<MeetingListItem[]> {
+    const recs = await local.listRecordings();
+    return recs.map((r) => ({
+      id: r.id,
+      title: r.title,
+      timestamp: r.createdAt,
+      durationSeconds: r.durationSeconds,
+      status: r.status,
+      files: {
+        hasAudio: r.hasAudio,
+        hasNote: r.hasNote,
+        hasTranscript: r.hasTranscript,
+      },
+    }));
+  }
+}
+
+/** Inclusive day window for the Ariso meetings list: 7 days back … 1 day
+ * forward (covers the next ~24h), formatted as local `YYYY-MM-DD`. */
+export function arisoMeetingWindow(now: Date): { startDate: string; endDate: string } {
+  const pad = (n: number) => String(n).padStart(2, '0');
+  const ymd = (d: Date) => `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+  const start = new Date(now);
+  start.setDate(start.getDate() - 7);
+  const end = new Date(now);
+  end.setDate(end.getDate() + 1);
+  return { startDate: ymd(start), endDate: ymd(end) };
 }
 
 export async function getActiveBackend(): Promise<Backend> {

--- a/src/composables/useBackend.ts
+++ b/src/composables/useBackend.ts
@@ -1,5 +1,5 @@
 import { local, auth, getBackendSetting, type RecordingSummary } from '../tauri';
-import { useMeetingApi } from './useMeetingApi';
+import { useMeetingApi, type ScheduledMeeting } from './useMeetingApi';
 
 export type BackendId = 'ariso' | 'local';
 
@@ -81,7 +81,7 @@ export class ArisoBackend implements Backend {
   async listMeetings(): Promise<MeetingListItem[]> {
     const { listMeetingsInWindow } = useMeetingApi();
     const { startDate, endDate } = arisoMeetingWindow(new Date());
-    const meetings = await listMeetingsInWindow(startDate, endDate);
+    const meetings: ScheduledMeeting[] = await listMeetingsInWindow(startDate, endDate);
     return meetings.map((m) => ({
       id: String(m.id),
       title: m.title || 'Untitled meeting',
@@ -116,6 +116,7 @@ export class LocalBackend implements Backend {
   }
 
   async listMeetings(): Promise<MeetingListItem[]> {
+    // No date window: the local library shows the full recording history.
     const recs = await local.listRecordings();
     return recs.map((r) => ({
       id: r.id,

--- a/src/composables/useMeetingApi.ts
+++ b/src/composables/useMeetingApi.ts
@@ -91,6 +91,22 @@ export function useMeetingApi() {
     );
   }
 
+  async function listMeetingsInWindow(
+    startDate: string,
+    endDate: string
+  ): Promise<ScheduledMeeting[]> {
+    const params = new URLSearchParams({
+      start_date: startDate,
+      end_date: endDate,
+    });
+    const res = await api.request('GET', `/meetings?${params.toString()}`);
+    assertOk(res, 200, 'list meetings');
+    const data = res.data as ScheduledMeetingsResponse | null;
+    return [...(data?.meetings ?? [])].sort(
+      (a, b) => new Date(b.start_at).getTime() - new Date(a.start_at).getTime()
+    );
+  }
+
   async function getMeeting(
     meetingId: number
   ): Promise<{ meeting: Meeting }> {
@@ -224,6 +240,7 @@ export function useMeetingApi() {
     createMeeting,
     listMeetings,
     listScheduledMeetings,
+    listMeetingsInWindow,
     getMeeting,
     updateMeeting,
     endMeeting,

--- a/src/composables/useMeetingApi.ts
+++ b/src/composables/useMeetingApi.ts
@@ -100,8 +100,9 @@ export function useMeetingApi() {
       end_date: endDate,
     });
     const res = await api.request('GET', `/meetings?${params.toString()}`);
-    assertOk(res, 200, 'list meetings');
+    assertOk(res, 200, 'list meetings in window');
     const data = res.data as ScheduledMeetingsResponse | null;
+    // Descending: soonest / most-recent meetings sit at the top of the list.
     return [...(data?.meetings ?? [])].sort(
       (a, b) => new Date(b.start_at).getTime() - new Date(a.start_at).getTime()
     );

--- a/src/views/LibraryView.test.ts
+++ b/src/views/LibraryView.test.ts
@@ -2,82 +2,89 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { mount, flushPromises } from '@vue/test-utils';
 
-const listRecordings = vi.fn();
-const readRecordingAudio = vi.fn();
+const listMeetings = vi.fn();
 const openRecordingFile = vi.fn();
+const readRecordingAudio = vi.fn();
+
+vi.mock('../composables/useBackend', () => ({
+  getActiveBackend: () => Promise.resolve({ id: 'local', listMeetings: () => listMeetings() }),
+}));
+// RecordingAudioPlayer (rendered for local rows) and openNote/openTranscript go
+// through ../tauri; keep those mocked so jsdom never touches real IPC.
 vi.mock('../tauri', () => ({
   local: {
-    listRecordings: () => listRecordings(),
-    readRecordingAudio: (id: string) => readRecordingAudio(id),
     openRecordingFile: (id: string, kind: string) => openRecordingFile(id, kind),
+    readRecordingAudio: (id: string) => readRecordingAudio(id),
+  },
+}));
+// Stub the recorder so mounting it never starts a real AudioContext.
+vi.mock('./RecorderPanel.vue', () => ({
+  default: {
+    name: 'RecorderPanel',
+    emits: ['done'],
+    template: '<div class="recorder-stub"><button class="stub-done" @click="$emit(\'done\')">done</button></div>',
   },
 }));
 
 import LibraryView from './LibraryView.vue';
 
-function rec(over: Record<string, unknown>) {
+function item(over: Record<string, unknown>) {
   return {
     id: 'x',
     title: 'T',
-    createdAt: '2026-06-02T10:00:00Z',
+    timestamp: '2026-06-02T10:00:00Z',
     durationSeconds: 10,
     status: 'done',
-    hasAudio: false,
-    hasNote: false,
-    hasTranscript: false,
+    files: { hasAudio: false, hasNote: false, hasTranscript: false },
     ...over,
   };
 }
 
 beforeEach(() => vi.clearAllMocks());
-// Always restore URL stubs and the HTMLMediaElement.play spy, even if a test
-// throws before reaching its inline teardown, so they can't leak across specs.
 afterEach(() => {
   vi.unstubAllGlobals();
   vi.restoreAllMocks();
 });
 
 describe('LibraryView', () => {
-  it('shows an empty state when there are no recordings', async () => {
-    listRecordings.mockResolvedValue([]);
+  it('shows an empty state when there are no meetings', async () => {
+    listMeetings.mockResolvedValue([]);
     const wrapper = mount(LibraryView);
     await flushPromises();
-    expect(wrapper.text()).toContain('No recordings yet');
+    expect(wrapper.text()).toContain('No meetings yet');
     expect(wrapper.findAll('.recording-row')).toHaveLength(0);
   });
 
-  it('renders a row per recording in the order returned', async () => {
-    listRecordings.mockResolvedValue([
-      rec({ id: 'b', title: 'Second', createdAt: '2026-06-02T10:00:00Z', durationSeconds: 75, status: 'done' }),
-      rec({ id: 'a', title: 'First', createdAt: '2026-06-01T10:00:00Z', durationSeconds: 3661, status: 'failed' }),
+  it('renders a row per meeting in the order returned', async () => {
+    listMeetings.mockResolvedValue([
+      item({ id: 'b', title: 'Second', durationSeconds: 75, status: 'done' }),
+      item({ id: 'a', title: 'First', durationSeconds: 3661, status: 'failed' }),
     ]);
     const wrapper = mount(LibraryView);
     await flushPromises();
     const rows = wrapper.findAll('.recording-row');
     expect(rows).toHaveLength(2);
     expect(rows[0].text()).toContain('Second');
-    expect(rows[0].text()).toContain('01:15'); // 75s
+    expect(rows[0].text()).toContain('01:15');
     expect(rows[1].text()).toContain('First');
-    expect(rows[1].text()).toContain('61:01'); // 3661s
+    expect(rows[1].text()).toContain('61:01');
     expect(rows[1].text()).toContain('failed');
   });
 
   it('enables/disables Note and Transcript per file-presence flags', async () => {
-    listRecordings.mockResolvedValue([
-      rec({ id: 'a', hasNote: true, hasTranscript: false }),
+    listMeetings.mockResolvedValue([
+      item({ id: 'a', files: { hasAudio: false, hasNote: true, hasTranscript: false } }),
     ]);
     const wrapper = mount(LibraryView);
     await flushPromises();
-    const note = wrapper.find('.btn-note');
-    const transcript = wrapper.find('.btn-transcript');
-    expect((note.element as HTMLButtonElement).disabled).toBe(false);
-    expect((transcript.element as HTMLButtonElement).disabled).toBe(true);
+    expect((wrapper.find('.btn-note').element as HTMLButtonElement).disabled).toBe(false);
+    expect((wrapper.find('.btn-transcript').element as HTMLButtonElement).disabled).toBe(true);
   });
 
   it('clicking an enabled Note button opens the note file', async () => {
     openRecordingFile.mockResolvedValue(undefined);
-    listRecordings.mockResolvedValue([
-      rec({ id: 'a', hasNote: true }),
+    listMeetings.mockResolvedValue([
+      item({ id: 'a', files: { hasAudio: false, hasNote: true, hasTranscript: false } }),
     ]);
     const wrapper = mount(LibraryView);
     await flushPromises();
@@ -85,66 +92,28 @@ describe('LibraryView', () => {
     expect(openRecordingFile).toHaveBeenCalledWith('a', 'note');
   });
 
-  it('clicking an enabled Transcript button opens the transcript file', async () => {
-    openRecordingFile.mockResolvedValue(undefined);
-    listRecordings.mockResolvedValue([
-      rec({ id: 'a', hasTranscript: true }),
+  it('omits file controls for items without files (ariso meetings)', async () => {
+    listMeetings.mockResolvedValue([
+      { id: '7', title: 'Standup', timestamp: '2026-06-08T09:00:00Z' },
     ]);
     const wrapper = mount(LibraryView);
     await flushPromises();
-    await wrapper.find('.btn-transcript').trigger('click');
-    expect(openRecordingFile).toHaveBeenCalledWith('a', 'transcript');
+    expect(wrapper.find('.row-controls').exists()).toBe(false);
   });
 
-  it('shows a disabled play control when hasAudio is false', async () => {
-    listRecordings.mockResolvedValue([rec({ id: 'a', hasAudio: false })]);
+  it('hides the recorder until Record is clicked, then hides + reloads on done', async () => {
+    listMeetings.mockResolvedValue([]);
     const wrapper = mount(LibraryView);
     await flushPromises();
-    const play = wrapper.find('.play-btn');
-    expect((play.element as HTMLButtonElement).disabled).toBe(true);
-    expect(play.text()).toContain('No audio');
-  });
+    expect(wrapper.find('.recorder-stub').exists()).toBe(false);
+    expect(listMeetings).toHaveBeenCalledTimes(1);
 
-  it('shows an enabled play trigger and loads audio on click when hasAudio is true', async () => {
-    vi.stubGlobal('URL', {
-      createObjectURL: vi.fn(() => 'blob:x'),
-      revokeObjectURL: vi.fn(),
-    });
-    // jsdom does not implement HTMLMediaElement.play(); stub it so the
-    // best-effort programmatic play does not log a noisy "Not implemented".
-    vi.spyOn(window.HTMLMediaElement.prototype, 'play').mockResolvedValue(undefined);
-    readRecordingAudio.mockResolvedValue(new ArrayBuffer(8));
-    listRecordings.mockResolvedValue([rec({ id: 'a', hasAudio: true })]);
-    const wrapper = mount(LibraryView);
-    await flushPromises();
-    const play = wrapper.find('.play-btn');
-    expect((play.element as HTMLButtonElement).disabled).toBe(false);
-    // Lazy: nothing fetched on mount.
-    expect(readRecordingAudio).not.toHaveBeenCalled();
-    await play.trigger('click');
-    await flushPromises();
-    expect(readRecordingAudio).toHaveBeenCalledWith('a');
-    expect(wrapper.find('audio.audio-el').exists()).toBe(true);
-  });
+    await wrapper.find('.record-btn').trigger('click');
+    expect(wrapper.find('.recorder-stub').exists()).toBe(true);
 
-  it('shows the error state and creates no blob URL when audio fails to load', async () => {
-    const createObjectURL = vi.fn(() => 'blob:x');
-    vi.stubGlobal('URL', {
-      createObjectURL,
-      revokeObjectURL: vi.fn(),
-    });
-    readRecordingAudio.mockRejectedValue(new Error('boom'));
-    listRecordings.mockResolvedValue([rec({ id: 'a', hasAudio: true })]);
-    const wrapper = mount(LibraryView);
+    await wrapper.find('.stub-done').trigger('click');
     await flushPromises();
-    const play = wrapper.find('.play-btn');
-    await play.trigger('click');
-    await flushPromises();
-    expect(readRecordingAudio).toHaveBeenCalledWith('a');
-    expect(createObjectURL).not.toHaveBeenCalled();
-    expect(wrapper.find('audio.audio-el').exists()).toBe(false);
-    const playAfter = wrapper.find('.play-btn');
-    expect(playAfter.classes()).toContain('play-btn--error');
-    expect(playAfter.text()).toContain('Failed');
+    expect(wrapper.find('.recorder-stub').exists()).toBe(false);
+    expect(listMeetings).toHaveBeenCalledTimes(2); // reloaded after recording
   });
 });

--- a/src/views/LibraryView.test.ts
+++ b/src/views/LibraryView.test.ts
@@ -116,4 +116,12 @@ describe('LibraryView', () => {
     expect(wrapper.find('.recorder-stub').exists()).toBe(false);
     expect(listMeetings).toHaveBeenCalledTimes(2); // reloaded after recording
   });
+
+  it('shows a distinct error message (not the empty state) when loading fails', async () => {
+    listMeetings.mockRejectedValue(new Error('boom'));
+    const wrapper = mount(LibraryView);
+    await flushPromises();
+    expect(wrapper.text()).toContain('Could not load meetings');
+    expect(wrapper.text()).not.toContain('No meetings yet');
+  });
 });

--- a/src/views/LibraryView.vue
+++ b/src/views/LibraryView.vue
@@ -3,8 +3,10 @@
     <aside class="left-panel">
       <h1 class="title">Meetings</h1>
       <p v-if="loading" class="hint">Loading…</p>
+      <p v-else-if="error" class="hint">{{ error }}</p>
       <p v-else-if="meetings.length === 0" class="hint">No meetings yet.</p>
       <ul v-else class="list">
+          <!-- key is backend-scoped: the list always comes from a single backend at a time -->
         <li v-for="m in meetings" :key="m.id" class="recording-row">
           <div class="row-main">
             <span class="row-title">{{ m.title }}</span>
@@ -49,6 +51,7 @@ import RecorderPanel from './RecorderPanel.vue';
 
 const meetings = ref<MeetingListItem[]>([]);
 const loading = ref(true);
+const error = ref<string | null>(null);
 const recording = ref(false);
 
 function formatDuration(secs: number): string {
@@ -64,10 +67,12 @@ function formatDate(iso: string): string {
 
 async function loadMeetings(): Promise<void> {
   loading.value = true;
+  error.value = null;
   try {
     meetings.value = await (await getActiveBackend()).listMeetings();
   } catch (e) {
     console.error('Failed to list meetings', e);
+    error.value = 'Could not load meetings.';
   } finally {
     loading.value = false;
   }

--- a/src/views/LibraryView.vue
+++ b/src/views/LibraryView.vue
@@ -1,35 +1,55 @@
 <template>
   <div class="library">
-    <h1 class="title">Meetings</h1>
-    <p v-if="loading" class="hint">Loading…</p>
-    <p v-else-if="recordings.length === 0" class="hint">No recordings yet.</p>
-    <ul v-else class="list">
-      <li v-for="r in recordings" :key="r.id" class="recording-row">
-        <div class="row-main">
-          <span class="row-title">{{ r.title }}</span>
-          <span class="row-status" :class="`status-${r.status}`">{{ r.status }}</span>
-        </div>
-        <div class="row-sub">
-          <span>{{ formatDate(r.createdAt) }}</span>
-          <span>{{ formatDuration(r.durationSeconds) }}</span>
-        </div>
-        <div class="row-controls">
-          <RecordingAudioPlayer :id="r.id" :has-audio="r.hasAudio" />
-          <button class="btn-note" :disabled="!r.hasNote" @click="openNote(r.id)">Note</button>
-          <button class="btn-transcript" :disabled="!r.hasTranscript" @click="openTranscript(r.id)">Transcript</button>
-        </div>
-      </li>
-    </ul>
+    <aside class="left-panel">
+      <h1 class="title">Meetings</h1>
+      <p v-if="loading" class="hint">Loading…</p>
+      <p v-else-if="meetings.length === 0" class="hint">No meetings yet.</p>
+      <ul v-else class="list">
+        <li v-for="m in meetings" :key="m.id" class="recording-row">
+          <div class="row-main">
+            <span class="row-title">{{ m.title }}</span>
+            <span v-if="m.status" class="row-status" :class="`status-${m.status}`">{{ m.status }}</span>
+          </div>
+          <div class="row-sub">
+            <span>{{ formatDate(m.timestamp) }}</span>
+            <span v-if="m.durationSeconds != null">{{ formatDuration(m.durationSeconds) }}</span>
+          </div>
+          <div v-if="m.files" class="row-controls">
+            <RecordingAudioPlayer :id="m.id" :has-audio="m.files.hasAudio" />
+            <button class="btn-note" :disabled="!m.files.hasNote" @click="openNote(m.id)">Note</button>
+            <button class="btn-transcript" :disabled="!m.files.hasTranscript" @click="openTranscript(m.id)">Transcript</button>
+          </div>
+        </li>
+      </ul>
+    </aside>
+
+    <section class="right-panel">
+      <header class="right-header">
+        <button
+          class="record-btn"
+          :disabled="recording"
+          aria-label="Start recording"
+          @click="startRecording"
+        >
+          <span class="record-dot" />
+        </button>
+      </header>
+      <div class="right-body" />
+      <RecorderPanel v-if="recording" class="recorder-dock" @done="onRecorderDone" />
+    </section>
   </div>
 </template>
 
 <script setup lang="ts">
 import { ref, onMounted } from 'vue';
-import { local, type RecordingSummary } from '../tauri';
+import { local } from '../tauri';
+import { getActiveBackend, type MeetingListItem } from '../composables/useBackend';
 import RecordingAudioPlayer from './RecordingAudioPlayer.vue';
+import RecorderPanel from './RecorderPanel.vue';
 
-const recordings = ref<RecordingSummary[]>([]);
+const meetings = ref<MeetingListItem[]>([]);
 const loading = ref(true);
+const recording = ref(false);
 
 function formatDuration(secs: number): string {
   const m = Math.floor(secs / 60).toString().padStart(2, '0');
@@ -42,7 +62,18 @@ function formatDate(iso: string): string {
   return Number.isNaN(d.getTime()) ? iso : d.toLocaleString();
 }
 
-async function openNote(id: string) {
+async function loadMeetings(): Promise<void> {
+  loading.value = true;
+  try {
+    meetings.value = await (await getActiveBackend()).listMeetings();
+  } catch (e) {
+    console.error('Failed to list meetings', e);
+  } finally {
+    loading.value = false;
+  }
+}
+
+async function openNote(id: string): Promise<void> {
   try {
     await local.openRecordingFile(id, 'note');
   } catch (e) {
@@ -50,7 +81,7 @@ async function openNote(id: string) {
   }
 }
 
-async function openTranscript(id: string) {
+async function openTranscript(id: string): Promise<void> {
   try {
     await local.openRecordingFile(id, 'transcript');
   } catch (e) {
@@ -58,31 +89,39 @@ async function openTranscript(id: string) {
   }
 }
 
-onMounted(async () => {
-  try {
-    recordings.value = await local.listRecordings();
-  } catch (e) {
-    console.error('Failed to list recordings', e);
-  } finally {
-    loading.value = false;
-  }
-});
+function startRecording(): void {
+  recording.value = true;
+}
+
+async function onRecorderDone(): Promise<void> {
+  recording.value = false;
+  await loadMeetings();
+}
+
+onMounted(loadMeetings);
 </script>
 
 <style scoped>
 .library {
-  padding: 24px;
-  font-family: -apple-system, system-ui, sans-serif;
-  background: #f5f5f7;
+  display: flex;
   height: 100vh;
+  font-family: -apple-system, system-ui, sans-serif;
+  box-sizing: border-box;
+}
+
+/* Left panel: meetings list */
+.left-panel {
+  width: 300px;
+  flex-shrink: 0;
+  background: #f5f5f7;
+  border-right: 1px solid #e5e5ea;
+  padding: 24px;
   box-sizing: border-box;
   display: flex;
   flex-direction: column;
 }
 .title { font-size: 20px; font-weight: 700; margin-bottom: 16px; color: #1d1d1f; flex-shrink: 0; }
 .hint { font-size: 14px; color: #86868b; }
-/* Scrolls vertically when the recordings overflow the window. min-height: 0 lets
-   this flex child shrink below its content height so overflow-y can engage. */
 .list { list-style: none; margin: 0; padding: 0 4px 0 0; display: flex; flex-direction: column; gap: 8px; flex: 1; min-height: 0; overflow-y: auto; }
 .recording-row { background: #fff; border-radius: 10px; padding: 12px 14px; box-shadow: 0 1px 3px rgba(0,0,0,0.06); }
 .row-main { display: flex; justify-content: space-between; align-items: center; }
@@ -93,9 +132,6 @@ onMounted(async () => {
 .status-transcribing { color: #4f46e5; }
 .status-recording { color: #86868b; }
 .row-sub { display: flex; justify-content: space-between; margin-top: 4px; font-size: 12px; color: #86868b; }
-/* nowrap keeps the player + both buttons on one line; the player flexes to fill
-   the remaining width (see RecordingAudioPlayer .audio-el) while the buttons
-   keep their size. */
 .row-controls { display: flex; align-items: center; gap: 8px; margin-top: 10px; flex-wrap: nowrap; }
 .btn-note, .btn-transcript {
   font-size: 13px;
@@ -108,8 +144,39 @@ onMounted(async () => {
   flex-shrink: 0;
   white-space: nowrap;
 }
-.btn-note:disabled, .btn-transcript:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
+.btn-note:disabled, .btn-transcript:disabled { opacity: 0.5; cursor: not-allowed; }
+
+/* Right panel: (empty) detail + record control + docked recorder */
+.right-panel {
+  flex: 1;
+  min-width: 0;
+  background: #ffffff;
+  display: flex;
+  flex-direction: column;
+  box-sizing: border-box;
 }
+.right-header {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  padding: 16px 20px;
+  flex-shrink: 0;
+}
+.record-btn {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  border: 1px solid #e5e5ea;
+  background: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: background 0.15s, box-shadow 0.15s;
+}
+.record-btn:hover:not(:disabled) { background: #f5f5f7; box-shadow: 0 1px 4px rgba(0,0,0,0.08); }
+.record-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+.record-dot { width: 14px; height: 14px; border-radius: 50%; background: #f43f5e; }
+.right-body { flex: 1; min-height: 0; }
+.recorder-dock { margin: 0 20px 20px; flex-shrink: 0; }
 </style>

--- a/src/views/RecorderPanel.test.ts
+++ b/src/views/RecorderPanel.test.ts
@@ -1,0 +1,78 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mount, flushPromises } from '@vue/test-utils';
+
+const startRecording = vi.fn();
+const stopRecording = vi.fn();
+const pauseRecording = vi.fn();
+const resumeRecording = vi.fn();
+const getAnalyser = vi.fn(() => null);
+const waveformStart = vi.fn();
+const waveformStop = vi.fn();
+const finalizeRecording = vi.fn();
+const loadRecordingEnabled = vi.fn();
+
+vi.mock('../composables/useRecorder', () => ({
+  useRecorder: () => ({
+    isPaused: { value: false },
+    durationSeconds: { value: 0 },
+    startedAt: { value: '2026-06-09T10:00:00Z' },
+    getAnalyser,
+    startRecording: (...a: unknown[]) => startRecording(...a),
+    stopRecording: () => stopRecording(),
+    pauseRecording: () => pauseRecording(),
+    resumeRecording: () => resumeRecording(),
+  }),
+}));
+vi.mock('../composables/useWaveform', () => ({
+  useWaveform: () => ({
+    levels: { value: new Array(32).fill(0) },
+    start: (...a: unknown[]) => waveformStart(...a),
+    stop: () => waveformStop(),
+  }),
+}));
+vi.mock('../composables/useBackend', () => ({
+  getActiveBackend: () =>
+    Promise.resolve({ id: 'local', finalizeRecording: (...a: unknown[]) => finalizeRecording(...a) }),
+}));
+vi.mock('../composables/useRecordingPermissions', () => ({
+  loadRecordingEnabled: () => loadRecordingEnabled(),
+}));
+
+import RecorderPanel from './RecorderPanel.vue';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  loadRecordingEnabled.mockResolvedValue({ mic: true, systemAudio: false });
+});
+afterEach(() => vi.restoreAllMocks());
+
+describe('RecorderPanel', () => {
+  it('starts recording on mount with the derived mode', async () => {
+    const wrapper = mount(RecorderPanel);
+    await flushPromises();
+    expect(startRecording).toHaveBeenCalledWith('mic');
+  });
+
+  it('emits done immediately when no recording source is enabled', async () => {
+    loadRecordingEnabled.mockResolvedValue({ mic: false, systemAudio: false });
+    const wrapper = mount(RecorderPanel);
+    await flushPromises();
+    expect(startRecording).not.toHaveBeenCalled();
+    expect(wrapper.emitted('done')).toHaveLength(1);
+  });
+
+  it('stops, finalizes, shows success, and emits done on close', async () => {
+    stopRecording.mockResolvedValue(new Blob([new Uint8Array([1, 2, 3])], { type: 'audio/mpeg' }));
+    finalizeRecording.mockResolvedValue({ backend: 'local' });
+    const wrapper = mount(RecorderPanel);
+    await flushPromises();
+    await wrapper.find('.stop-btn').trigger('click');
+    await flushPromises();
+    expect(stopRecording).toHaveBeenCalled();
+    expect(finalizeRecording).toHaveBeenCalledTimes(1);
+    expect(wrapper.text()).toContain('Transcription complete');
+    await wrapper.find('.close-btn').trigger('click');
+    expect(wrapper.emitted('done')).toHaveLength(1);
+  });
+});

--- a/src/views/RecorderPanel.test.ts
+++ b/src/views/RecorderPanel.test.ts
@@ -14,6 +14,7 @@ const loadRecordingEnabled = vi.fn();
 
 vi.mock('../composables/useRecorder', () => ({
   useRecorder: () => ({
+    isRecording: { value: true },
     isPaused: { value: false },
     durationSeconds: { value: 0 },
     startedAt: { value: '2026-06-09T10:00:00Z' },
@@ -74,5 +75,13 @@ describe('RecorderPanel', () => {
     expect(wrapper.text()).toContain('Transcription complete');
     await wrapper.find('.close-btn').trigger('click');
     expect(wrapper.emitted('done')).toHaveLength(1);
+  });
+
+  it('stops the recorder when unmounted mid-recording', async () => {
+    stopRecording.mockResolvedValue(new Blob([], { type: 'audio/mpeg' }));
+    const wrapper = mount(RecorderPanel);
+    await flushPromises();
+    wrapper.unmount();
+    expect(stopRecording).toHaveBeenCalled();
   });
 });

--- a/src/views/RecorderPanel.vue
+++ b/src/views/RecorderPanel.vue
@@ -82,6 +82,7 @@ const failLabel = computed(() => (isLocal.value ? 'Transcription failed' : 'Uplo
 const progressLabel = computed(() => (isLocal.value ? 'Transcribing…' : 'Uploading…'));
 const isUploading = ref(false);
 const uploadResult = ref<'success' | 'failed' | null>(null);
+const isStopping = ref(false);
 
 const formattedDuration = computed(() => {
   const s = recorder.durationSeconds.value;
@@ -116,6 +117,8 @@ async function startRecording() {
 }
 
 async function handleStop() {
+  if (isStopping.value) return;
+  isStopping.value = true;
   waveform.stop();
   const endAt = new Date().toISOString();
   const startAt = recorder.startedAt.value;
@@ -143,6 +146,9 @@ async function handleStop() {
       uploadResult.value = 'failed';
     }
   } else {
+    if (mp3Blob.size > 0 && !backend.value) {
+      console.warn('RecorderPanel: backend not initialized; discarding recording');
+    }
     emit('done');
   }
   isUploading.value = false;
@@ -166,7 +172,14 @@ onMounted(async () => {
 });
 
 onUnmounted(() => {
-  waveform.stop();
+  // useWaveform cleans itself up via its own onUnmounted hook. If the component
+  // is torn down mid-recording, stop the recorder too so the AudioContext, mic
+  // stream, timer, and system-audio listener don't leak (mic indicator staying lit).
+  if (recorder.isRecording.value) {
+    recorder.stopRecording().catch(() => {
+      /* best-effort cleanup */
+    });
+  }
 });
 </script>
 

--- a/src/views/RecorderPanel.vue
+++ b/src/views/RecorderPanel.vue
@@ -1,0 +1,206 @@
+<template>
+  <div class="recorder">
+    <template v-if="uploadResult">
+      <div class="upload-info">
+        <span :class="uploadResult === 'success' ? 'upload-check' : 'upload-error-icon'">
+          {{ uploadResult === 'success' ? '✓' : '✗' }}
+        </span>
+        <span class="upload-label">
+          {{ uploadResult === 'success' ? successLabel : failLabel }}
+        </span>
+        <button class="close-btn" @click.stop.prevent="close">Close</button>
+      </div>
+    </template>
+    <template v-else-if="isUploading">
+      <div class="upload-info">
+        <span class="upload-spinner" />
+        <span class="upload-label">{{ progressLabel }}</span>
+      </div>
+    </template>
+    <template v-else>
+      <div class="bars">
+        <div
+          v-for="(level, i) in waveform.levels.value"
+          :key="i"
+          class="bar"
+          :class="{ paused: recorder.isPaused.value }"
+          :style="{ height: `${Math.max(8, level * 100)}%` }"
+        />
+      </div>
+      <div class="info">
+        <template v-if="!recorder.isPaused.value">
+          <span class="rec-dot" />
+          <span class="rec-label">REC</span>
+        </template>
+        <span v-else class="paused-label">PAUSED</span>
+        <span class="timer">{{ formattedDuration }}</span>
+      </div>
+      <div class="controls">
+        <button
+          class="ctrl-btn pause-resume-btn"
+          :aria-label="recorder.isPaused.value ? 'Resume recording' : 'Pause recording'"
+          @click.stop.prevent="recorder.isPaused.value ? handleResume() : handlePause()"
+        >
+          <svg v-if="!recorder.isPaused.value" width="14" height="14" viewBox="0 0 14 14">
+            <rect x="2" y="1" width="3.5" height="12" rx="1" fill="currentColor" />
+            <rect x="8.5" y="1" width="3.5" height="12" rx="1" fill="currentColor" />
+          </svg>
+          <svg v-else width="14" height="14" viewBox="0 0 14 14">
+            <circle cx="7" cy="7" r="5.5" fill="currentColor" />
+          </svg>
+        </button>
+        <button
+          class="ctrl-btn stop-btn"
+          aria-label="Stop recording"
+          @click.stop.prevent="handleStop"
+        >
+          <svg width="12" height="12" viewBox="0 0 12 12">
+            <rect x="1" y="1" width="10" height="10" rx="2" fill="currentColor" />
+          </svg>
+        </button>
+      </div>
+    </template>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref, onMounted, onUnmounted } from 'vue';
+import { useRecorder } from '../composables/useRecorder';
+import { useWaveform } from '../composables/useWaveform';
+import { getActiveBackend, type Backend } from '../composables/useBackend';
+import { loadRecordingEnabled } from '../composables/useRecordingPermissions';
+import { deriveRecordingMode } from './recordingSettings';
+
+const emit = defineEmits<{ done: [] }>();
+
+const recorder = useRecorder();
+const waveform = useWaveform();
+const backend = ref<Backend | null>(null);
+const isLocal = computed(() => backend.value?.id === 'local');
+const successLabel = computed(() => (isLocal.value ? 'Transcription complete' : 'Upload successful'));
+const failLabel = computed(() => (isLocal.value ? 'Transcription failed' : 'Upload failed'));
+const progressLabel = computed(() => (isLocal.value ? 'Transcribing…' : 'Uploading…'));
+const isUploading = ref(false);
+const uploadResult = ref<'success' | 'failed' | null>(null);
+
+const formattedDuration = computed(() => {
+  const s = recorder.durationSeconds.value;
+  const mins = Math.floor(s / 60).toString().padStart(2, '0');
+  const secs = (s % 60).toString().padStart(2, '0');
+  return `${mins}:${secs}`;
+});
+
+async function startRecording() {
+  let mode: ReturnType<typeof deriveRecordingMode>;
+  try {
+    mode = deriveRecordingMode(await loadRecordingEnabled());
+  } catch {
+    emit('done');
+    return;
+  }
+  if (mode === null) {
+    // Both recording sources disabled — nothing to capture.
+    emit('done');
+    return;
+  }
+  try {
+    await recorder.startRecording(mode);
+  } catch {
+    emit('done');
+    return;
+  }
+  const analyser = recorder.getAnalyser();
+  if (analyser) {
+    waveform.start(analyser);
+  }
+}
+
+async function handleStop() {
+  waveform.stop();
+  const endAt = new Date().toISOString();
+  const startAt = recorder.startedAt.value;
+  isUploading.value = true;
+  const mp3Blob = await recorder.stopRecording();
+
+  if (mp3Blob.size > 0 && backend.value) {
+    // Bound only the UI wait; a timed-out local transcription keeps running
+    // natively and still records its final status (the list is the source of truth).
+    const timeout = new Promise<never>((_, reject) =>
+      setTimeout(() => reject(new Error('Operation timed out')), 120_000)
+    );
+    try {
+      await Promise.race([
+        backend.value.finalizeRecording(mp3Blob, {
+          startAt,
+          endAt,
+          durationSeconds: recorder.durationSeconds.value,
+        }),
+        timeout,
+      ]);
+      uploadResult.value = 'success';
+    } catch (err) {
+      console.error('Finalize failed:', err);
+      uploadResult.value = 'failed';
+    }
+  } else {
+    emit('done');
+  }
+  isUploading.value = false;
+}
+
+function handlePause() {
+  recorder.pauseRecording();
+}
+
+function handleResume() {
+  recorder.resumeRecording();
+}
+
+function close() {
+  emit('done');
+}
+
+onMounted(async () => {
+  backend.value = await getActiveBackend();
+  await startRecording();
+});
+
+onUnmounted(() => {
+  waveform.stop();
+});
+</script>
+
+<style scoped>
+.recorder {
+  height: 56px;
+  background: #0f0f1a;
+  border-radius: 12px;
+  display: flex;
+  align-items: center;
+  padding: 0 12px;
+  overflow: hidden;
+}
+.bars { display: flex; align-items: center; gap: 2px; height: 36px; flex: 1; min-width: 0; }
+.bar { width: 2px; border-radius: 2px; background: #ffffff; transition: height 75ms, width 150ms, background 150ms; }
+.bar.paused { width: 3px; background: #4b5563; }
+.info { display: flex; align-items: center; gap: 6px; margin-left: 10px; flex-shrink: 0; }
+.rec-dot { width: 6px; height: 6px; border-radius: 50%; background: #f87171; animation: pulse 1s infinite; }
+.rec-label { font-size: 10px; font-weight: 600; color: #f87171; letter-spacing: 0.5px; }
+.paused-label { font-size: 10px; font-weight: 600; color: #9ca3af; letter-spacing: 0.5px; }
+.timer { font-size: 11px; color: #999; font-family: monospace; }
+.controls { display: flex; align-items: center; gap: 6px; margin-left: 10px; flex-shrink: 0; }
+.ctrl-btn { width: 28px; height: 28px; border-radius: 6px; border: none; display: flex; align-items: center; justify-content: center; cursor: pointer; transition: background 0.15s; }
+.pause-resume-btn { background: #1e1e2e; color: #d1d5db; }
+.pause-resume-btn:hover { background: #2a2a3e; }
+.stop-btn { background: #1e1e2e; color: #f87171; }
+.stop-btn:hover { background: #2a2a3e; }
+.upload-info { display: flex; align-items: center; gap: 8px; width: 100%; justify-content: center; }
+.upload-spinner { width: 14px; height: 14px; border: 2px solid #4b5563; border-top-color: #818cf8; border-radius: 50%; animation: spin 0.8s linear infinite; }
+.upload-label { font-size: 12px; font-weight: 600; color: #9ca3af; letter-spacing: 0.5px; }
+.upload-check { font-size: 14px; font-weight: 700; color: #34d399; }
+.upload-error-icon { font-size: 14px; font-weight: 700; color: #f87171; }
+.close-btn { margin-left: 8px; padding: 2px 10px; border-radius: 6px; border: none; background: #1e1e2e; color: #d1d5db; font-size: 11px; font-weight: 600; cursor: pointer; transition: background 0.15s; }
+.close-btn:hover { background: #2a2a3e; }
+@keyframes pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.4; } }
+@keyframes spin { to { transform: rotate(360deg); } }
+</style>


### PR DESCRIPTION

<img width="899" height="598" alt="Screenshot 2026-06-09 at 16 10 15" src="https://github.com/user-attachments/assets/4e432dc2-7f3c-495a-bf91-0983199f6826" />


## Summary
Evolves the `library` window into a two-pane Meetings window: a backend-driven meeting list on the left, an (empty for now) detail pane on the right with a top-right Record button that reveals an embedded recorder docked at the bottom while recording.

- **Backend-aware list** — `Backend.listMeetings()`: Ariso → `GET /meetings?start_date&end_date` (last 7d … next 24h); Local → `list_local_recordings`, normalized to one `MeetingListItem` shape.
- **Embedded recorder** — new `RecorderPanel.vue` reuses the recorder composables without the floating-window/tray lifecycle; starts on click, finalizes via the active backend, emits `done`, reloads the list. The floating `WaveformView` + tray flow is untouched.
- **Tray fix** — "Meetings…" now opens the in-app window for the Ariso backend too (previously opened the browser).
- Widened the window (460×560 → 900×600) for the split layout.

Right-pane detail and row selection are intentionally deferred.

## Test plan
- [x] `npm test` — 51/51 green (normalizers, recorder lifecycle, list render + record toggle + error state)
- [x] Manual: tray **Meetings…** on Ariso opens the in-app window (not the browser); Record → capture → stop → meeting appears in the list

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Redesigned Meetings window with an improved two-pane layout featuring a meeting list on the left and recording controls on the right.
  * Record new meetings directly from the Meetings window with live waveform display and automatic transcription.
  * Unified meetings view supporting both local recordings and server-based meetings in a single interface.
  * Enhanced meeting items displaying available content types and recording status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->