### PR TITLE
fix(recorder): reset panel state when stopRecording throws

### DIFF
--- a/src/views/RecorderPanel.vue
+++ b/src/views/RecorderPanel.vue
@@ -123,7 +123,18 @@ async function handleStop() {
   const endAt = new Date().toISOString();
   const startAt = recorder.startedAt.value;
   isUploading.value = true;
-  const mp3Blob = await recorder.stopRecording();
+  let mp3Blob: Blob;
+  try {
+    mp3Blob = await recorder.stopRecording();
+  } catch (err) {
+    // A stop failure would otherwise leave the panel stuck on the uploading
+    // template, which has no Close button. Reset state and bail to the parent.
+    console.error('Stop failed:', err);
+    isUploading.value = false;
+    isStopping.value = false;
+    emit('done');
+    return;
+  }
 
   if (mp3Blob.size > 0 && backend.value) {
     // Bound only the UI wait; a timed-out local transcription keeps running


### PR DESCRIPTION
## What

Guards `await recorder.stopRecording()` in `RecorderPanel.handleStop` with a `try/catch`. On failure it resets `isUploading`/`isStopping`, logs the error, and `emit('done')`.

## Why

The call was unguarded. If `stopRecording()` rejects, execution stops before `isUploading.value = false`, leaving `isUploading === true`. The panel then renders the uploading template — which only shows a spinner and **has no Close button**, so the user is stuck with no way out.

The realistic throw path is narrow (`stopRecording`'s internal `cleanup()` swallows its own errors; the main risk is the synchronous lamejs `flush()`), so this is low-probability defensive hardening rather than a likely-to-bite bug. But the stuck-state with no escape hatch makes it cheap and worthwhile to handle.

Raised by CodeRabbit on #24 (https://github.com/ariso-ai/sage/pull/24#discussion_r3383587746); split into its own PR.

Note: unlike CodeRabbit's suggestion, this does not also reset `isStopping` on the success path — the panel is single-use (success shows a Close button; the else branch already emits `done`), so that reset is unnecessary.

## Test

- `npm run vite:build` passes.

Supersedes #25, which could not be reopened/retargeted after its original base branch (`feat/ux-main-window`) was merged into `main` and deleted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Improved error handling when stopping recordings to gracefully recover from failures and prevent the UI from remaining in an uploading state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->