### PR TITLE
feat(meetings): group library list by date + working Today tab + start-recording picker

### DIFF
--- a/docs/superpowers/specs/2026-06-10-library-meetings-date-grouping-design.md
+++ b/docs/superpowers/specs/2026-06-10-library-meetings-date-grouping-design.md
@@ -1,0 +1,114 @@
+# Library meetings: date grouping, working "Today" tab, start-recording → picker
+
+**Date:** 2026-06-10
+**Status:** Approved
+**Branch:** `feat/group-meeting-by-date`
+**Figma:** Features / node `2827:34482` (meeting list with `UPCOMING` divider)
+
+## Problem
+
+The main meetings window (`LibraryView`) shows meetings in two flat buckets —
+`earlier` (most-recent first) and a single `UPCOMING` divider — with no
+per-date structure. The bottom nav pill (`Today` / `Meetings` / `Todo`) is
+decorative: every tab is hardcoded and none has a click handler. The sidebar
+`+` (start-recording) button opens the floating recorder directly, skipping the
+meeting picker. The Ariso list window only reaches **+1 day forward**, so the
+`UPCOMING` section is almost always empty.
+
+## Goals
+
+1. Group the meetings list under **per-calendar-date headers** (TODAY,
+   YESTERDAY, TOMORROW, else `MON JUN 9`), newest date first, with a single
+   `UPCOMING` section for all future meetings — matching the Figma's single
+   divider.
+2. Make the **Today** nav tab work: filter the list to only today's meetings.
+   Keep **Meetings** as the full date-grouped view. **Todo** stays a
+   non-functional placeholder.
+3. Show real future meetings: extend the Ariso forward window from **+1 day**
+   to **+7 days** (keep 7 days back).
+4. Make the sidebar **start-recording `+` button** open the **meeting-picker**
+   window for backends that use a picker (Ariso); keep opening the recorder
+   directly for Local (which has no picker).
+
+Non-goals: redesigning the picker window's visuals, the detail panel, the
+recording flow, the Todo tab, or the dark Figma palette (Library stays light).
+
+## Design
+
+### 1. Date grouping (`LibraryView.vue` + a pure helper)
+
+Extract a pure, testable helper (e.g. `src/composables/groupMeetingsByDate.ts`):
+
+```ts
+interface MeetingSection { key: string; label: string; items: MeetingListItem[] }
+function groupMeetingsByDate(meetings: MeetingListItem[], now: Date): MeetingSection[]
+```
+
+Behavior:
+- Partition by `new Date(m.timestamp) > now` → **upcoming** vs **history**.
+- **History**: bucket by local calendar date (`YYYY-MM-DD`), sections ordered
+  newest date first; within a day, newest first. Label via `dateLabel(key, now)`
+  → `TODAY` / `YESTERDAY` (relative) else `MON JUN 9` (uppercased
+  weekday+month+day). Future-but-not-today relative label `TOMORROW` only
+  applies inside the upcoming bucket, which is collapsed, so it is unused here.
+- **Upcoming**: a single section `{ key: 'upcoming', label: 'UPCOMING', items }`
+  sorted soonest-first, appended **after** all history sections.
+- Invalid/`NaN` timestamps sort to the bottom of history under a stable bucket
+  (keep them visible rather than dropping).
+
+`LibraryView` renders `sections` as: for each section, a `.group-label` header
+(reusing the existing UPCOMING style) followed by its `.meeting-item` rows. The
+existing scroll-fade mask, selection highlight, and `itemSub` formatting are
+unchanged.
+
+### 2. Today tab (`LibraryView.vue`)
+
+- Add `const activeView = ref<'today' | 'meetings'>('meetings')`.
+- Bind `nav-tab--active` to `activeView` and add `@click` on the Today and
+  Meetings tabs to set it. Todo tab unchanged (no handler).
+- A `displayedSections` computed:
+  - `meetings` → `groupMeetingsByDate(meetings, now)`.
+  - `today` → filter `meetings` to today's calendar date, returned as a single
+    chronological (soonest-first) section with **no header** (a date header is
+    redundant when every row is today). Empty → render the existing
+    "No meetings today." hint style.
+
+### 3. Forward window (`useBackend.ts`)
+
+In `arisoMeetingWindow`, change `end.setDate(end.getDate() + 1)` to `+ 7`. This
+is the only data-layer change; `listMeetingsInWindow` already sorts and the
+grouping handles the wider range.
+
+### 4. Start-recording → picker (`LibraryView.vue` + Rust)
+
+Frontend `startRecording()`:
+- Resolve the active backend; if `backend.usesMeetingPicker`, invoke a new
+  `open_meeting_picker` command; else keep `invoke('start_recording_window', {})`
+  (Local recorder-direct path). Do **not** flip `recording`/hide the panel for
+  the picker path — recording hasn't started; the picker drives that next.
+
+Rust (`commands.rs`):
+- Extract `open_meeting_picker_window(app: &AppHandle) -> Result<(), String>`
+  that shows+focuses an existing `meeting-picker` window or builds it
+  (`/#/meeting-picker`, 400×500, non-resizable, centered, skip_taskbar) — the
+  same parameters the tray uses today.
+- Add `#[tauri::command] open_meeting_picker(app)` delegating to the helper;
+  register it in `main.rs`'s `generate_handler!`.
+- Refactor `tray.rs` to call `crate::commands::open_meeting_picker_window(&app_main)`
+  after its session gate (DRY; behavior unchanged).
+
+## Testing
+
+- Unit-test `groupMeetingsByDate` (Vitest): TODAY/YESTERDAY/relative + absolute
+  labels, newest-date-first ordering, upcoming bucket placement and sorting,
+  today-filter, empty input, NaN-timestamp handling. Use a fixed `now`.
+- Extend/verify `LibraryView.test.ts`: Today vs Meetings toggle changes the
+  rendered sections; start-recording button calls `open_meeting_picker` under
+  the Ariso backend and `start_recording_window` under Local.
+
+## Risks / notes
+
+- Today's not-yet-started meetings appear under `UPCOMING`, not `TODAY` — this
+  is intentional and matches the Figma's single-divider layout.
+- `now` is captured once per session (existing pattern); acceptable for labels.
+- Local backend gains date headers across its full history "for free."

--- a/docs/superpowers/specs/2026-06-10-library-meetings-date-grouping-design.md
+++ b/docs/superpowers/specs/2026-06-10-library-meetings-date-grouping-design.md
@@ -18,7 +18,7 @@ meeting picker. The Ariso list window only reaches **+1 day forward**, so the
 ## Goals
 
 1. Group the meetings list under **per-calendar-date headers** (TODAY,
-   YESTERDAY, TOMORROW, else `MON JUN 9`), newest date first, with a single
+   YESTERDAY, TOMORROW, else `MON, JUN 9`), newest date first, with a single
    `UPCOMING` section for all future meetings — matching the Figma's single
    divider.
 2. Make the **Today** nav tab work: filter the list to only today's meetings.
@@ -48,7 +48,7 @@ Behavior:
 - Partition by `new Date(m.timestamp) > now` → **upcoming** vs **history**.
 - **History**: bucket by local calendar date (`YYYY-MM-DD`), sections ordered
   newest date first; within a day, newest first. Label via `dateLabel(key, now)`
-  → `TODAY` / `YESTERDAY` (relative) else `MON JUN 9` (uppercased
+  → `TODAY` / `YESTERDAY` (relative) else `MON, JUN 9` (uppercased
   weekday+month+day). Future-but-not-today relative label `TOMORROW` only
   applies inside the upcoming bucket, which is collapsed, so it is unused here.
 - **Upcoming**: a single section `{ key: 'upcoming', label: 'UPCOMING', items }`

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -474,6 +474,35 @@ pub async fn start_recording_window(
     open_waveform_window(&app, meeting_id)
 }
 
+/// Show/focus the meeting-picker window, building it if absent. Shared by the
+/// tray (Ariso path) and the `open_meeting_picker` command so both open the
+/// picker identically.
+pub(crate) fn open_meeting_picker_window(app: &tauri::AppHandle) -> Result<(), String> {
+    use tauri::{WebviewUrl, WebviewWindowBuilder};
+
+    if let Some(picker) = app.get_webview_window("meeting-picker") {
+        let _ = picker.show();
+        let _ = picker.set_focus();
+        return Ok(());
+    }
+    WebviewWindowBuilder::new(app, "meeting-picker", WebviewUrl::App("/#/meeting-picker".into()))
+        .title("Select a meeting")
+        .inner_size(400.0, 500.0)
+        .resizable(false)
+        .center()
+        .skip_taskbar(true)
+        .build()
+        .map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+/// Open (or focus) the meeting-picker window. Invoked by the library's
+/// start-recording button for picker-using backends.
+#[tauri::command]
+pub async fn open_meeting_picker(app: tauri::AppHandle) -> Result<(), String> {
+    open_meeting_picker_window(&app)
+}
+
 /// PUT binary data to a presigned URL (bypasses CORS via native HTTP client)
 #[tauri::command]
 pub async fn put_presigned(

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -26,6 +26,7 @@ fn main() {
             commands::set_tray_recording,
             commands::create_settings_window,
             commands::start_recording_window,
+            commands::open_meeting_picker,
             commands::put_presigned,
             commands::get_desktop_config,
             commands::list_local_recordings,

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -68,22 +68,7 @@ pub fn create_tray(app: &AppHandle) -> tauri::Result<()> {
                                 let _ = app_main.emit("tray://show-sign-in-prompt", ());
                                 return;
                             }
-                            if let Some(picker) = app_main.get_webview_window("meeting-picker") {
-                                let _ = picker.show();
-                                let _ = picker.set_focus();
-                                return;
-                            }
-                            let _ = WebviewWindowBuilder::new(
-                                &app_main,
-                                "meeting-picker",
-                                tauri::WebviewUrl::App("/#/meeting-picker".into()),
-                            )
-                            .title("Select a meeting")
-                            .inner_size(400.0, 500.0)
-                            .resizable(false)
-                            .center()
-                            .skip_taskbar(true)
-                            .build();
+                            let _ = crate::commands::open_meeting_picker_window(&app_main);
                         });
                     });
                 }

--- a/src/composables/groupMeetingsByDate.test.ts
+++ b/src/composables/groupMeetingsByDate.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import { groupMeetingsByDate, todaysMeetings, dateLabel } from './groupMeetingsByDate';
+import type { MeetingListItem } from './useBackend';
+
+// Fixed "now": Wed 2026-06-10 15:00 local.
+const NOW = new Date(2026, 5, 10, 15, 0, 0);
+
+function m(id: string, iso: string): MeetingListItem {
+  return { id, title: `M${id}`, timestamp: iso };
+}
+
+describe('dateLabel', () => {
+  it('uses relative labels for today/yesterday/tomorrow', () => {
+    expect(dateLabel('2026-06-10', NOW)).toBe('TODAY');
+    expect(dateLabel('2026-06-09', NOW)).toBe('YESTERDAY');
+    expect(dateLabel('2026-06-11', NOW)).toBe('TOMORROW');
+  });
+
+  it('uses an uppercased weekday/month/day for other dates', () => {
+    // 2026-06-07 is a Sunday.
+    expect(dateLabel('2026-06-07', NOW)).toBe('SUN, JUN 7');
+  });
+});
+
+describe('groupMeetingsByDate', () => {
+  it('buckets history by calendar date newest-first, with UPCOMING last', () => {
+    const meetings = [
+      m('past1', '2026-06-09T09:00:00'),
+      m('today1', '2026-06-10T09:00:00'),
+      m('today2', '2026-06-10T11:00:00'),
+      m('soon', '2026-06-10T18:00:00'),
+      m('future', '2026-06-12T10:00:00'),
+    ];
+    const sections = groupMeetingsByDate(meetings, NOW);
+    expect(sections.map((s) => s.label)).toEqual(['TODAY', 'YESTERDAY', 'UPCOMING']);
+    expect(sections[0].items.map((x) => x.id)).toEqual(['today2', 'today1']);
+    expect(sections[2].items.map((x) => x.id)).toEqual(['soon', 'future']);
+  });
+
+  it('returns an empty array for no meetings', () => {
+    expect(groupMeetingsByDate([], NOW)).toEqual([]);
+  });
+
+  it('keeps NaN-timestamp meetings under an UNDATED bucket at the end of history', () => {
+    const sections = groupMeetingsByDate([m('bad', 'not-a-date'), m('t', '2026-06-10T09:00:00')], NOW);
+    const labels = sections.map((s) => s.label);
+    expect(labels).toContain('UNDATED');
+    expect(labels.indexOf('UNDATED')).toBeGreaterThan(labels.indexOf('TODAY'));
+  });
+});
+
+describe('todaysMeetings', () => {
+  it('returns only today, soonest-first, dropping other days and NaN', () => {
+    const meetings = [
+      m('y', '2026-06-09T09:00:00'),
+      m('t2', '2026-06-10T18:00:00'),
+      m('t1', '2026-06-10T08:00:00'),
+      m('bad', 'nope'),
+    ];
+    expect(todaysMeetings(meetings, NOW).map((x) => x.id)).toEqual(['t1', 't2']);
+  });
+});

--- a/src/composables/groupMeetingsByDate.ts
+++ b/src/composables/groupMeetingsByDate.ts
@@ -1,0 +1,78 @@
+import type { MeetingListItem } from './useBackend';
+
+export interface MeetingSection {
+  key: string;
+  label: string;
+  items: MeetingListItem[];
+}
+
+function localDateKey(d: Date): string {
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+}
+
+export function dateLabel(key: string, now: Date): string {
+  const yesterday = new Date(now);
+  yesterday.setDate(yesterday.getDate() - 1);
+  const tomorrow = new Date(now);
+  tomorrow.setDate(tomorrow.getDate() + 1);
+
+  if (key === localDateKey(now)) return 'TODAY';
+  if (key === localDateKey(yesterday)) return 'YESTERDAY';
+  if (key === localDateKey(tomorrow)) return 'TOMORROW';
+
+  const [y, mo, d] = key.split('-').map(Number);
+  return new Date(y, mo - 1, d)
+    .toLocaleDateString(undefined, { weekday: 'short', month: 'short', day: 'numeric' })
+    .toUpperCase();
+}
+
+/** Bucket meetings under per-calendar-date headers (newest date first) with a
+ *  single trailing UPCOMING section for everything starting after `now`. */
+export function groupMeetingsByDate(meetings: MeetingListItem[], now: Date): MeetingSection[] {
+  const nowMs = now.getTime();
+  const history: MeetingListItem[] = [];
+  const upcoming: MeetingListItem[] = [];
+  for (const meeting of meetings) {
+    const ts = new Date(meeting.timestamp).getTime();
+    if (!Number.isNaN(ts) && ts > nowMs) upcoming.push(meeting);
+    else history.push(meeting);
+  }
+
+  const buckets = new Map<string, MeetingListItem[]>();
+  for (const meeting of history) {
+    const d = new Date(meeting.timestamp);
+    const key = Number.isNaN(d.getTime()) ? 'unknown' : localDateKey(d);
+    const bucket = buckets.get(key);
+    if (bucket) bucket.push(meeting);
+    else buckets.set(key, [meeting]);
+  }
+
+  const sections: MeetingSection[] = [];
+  const datedKeys = [...buckets.keys()].filter((k) => k !== 'unknown').sort().reverse();
+  for (const key of datedKeys) {
+    const items = [...buckets.get(key)!].sort(
+      (a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime()
+    );
+    sections.push({ key, label: dateLabel(key, now), items });
+  }
+  if (buckets.has('unknown')) {
+    sections.push({ key: 'unknown', label: 'UNDATED', items: buckets.get('unknown')! });
+  }
+  if (upcoming.length) {
+    upcoming.sort((a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime());
+    sections.push({ key: 'upcoming', label: 'UPCOMING', items: upcoming });
+  }
+  return sections;
+}
+
+/** Today's meetings only, soonest-first; drops other days and invalid dates. */
+export function todaysMeetings(meetings: MeetingListItem[], now: Date): MeetingListItem[] {
+  const today = localDateKey(now);
+  return meetings
+    .filter((meeting) => {
+      const d = new Date(meeting.timestamp);
+      return !Number.isNaN(d.getTime()) && localDateKey(d) === today;
+    })
+    .sort((a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime());
+}

--- a/src/composables/groupMeetingsByDate.ts
+++ b/src/composables/groupMeetingsByDate.ts
@@ -49,6 +49,8 @@ export function groupMeetingsByDate(meetings: MeetingListItem[], now: Date): Mee
   }
 
   const sections: MeetingSection[] = [];
+  // Lexical sort == chronological because keys are zero-padded YYYY-MM-DD;
+  // .reverse() then puts the newest date first.
   const datedKeys = [...buckets.keys()].filter((k) => k !== 'unknown').sort().reverse();
   for (const key of datedKeys) {
     const items = [...buckets.get(key)!].sort(

--- a/src/composables/useBackend.test.ts
+++ b/src/composables/useBackend.test.ts
@@ -122,12 +122,12 @@ describe('getActiveBackend', () => {
 });
 
 describe('arisoMeetingWindow', () => {
-  it('spans 7 days back to 1 day forward, date-only', () => {
+  it('spans 7 days back to 7 days forward, date-only', () => {
     // Local midday avoids any tz boundary ambiguity.
     const now = new Date(2026, 5, 9, 12, 0, 0); // 2026-06-09 local
     expect(arisoMeetingWindow(now)).toEqual({
       startDate: '2026-06-02',
-      endDate: '2026-06-10',
+      endDate: '2026-06-16',
     });
   });
 
@@ -135,7 +135,7 @@ describe('arisoMeetingWindow', () => {
     const now = new Date(2026, 0, 3, 12, 0, 0); // 2026-01-03 local
     expect(arisoMeetingWindow(now)).toEqual({
       startDate: '2025-12-27',
-      endDate: '2026-01-04',
+      endDate: '2026-01-10',
     });
   });
 });

--- a/src/composables/useBackend.ts
+++ b/src/composables/useBackend.ts
@@ -316,15 +316,15 @@ export class LocalBackend implements Backend {
   }
 }
 
-/** Inclusive day window for the Ariso meetings list: 7 days back … 1 day
- * forward (covers the next ~24h), formatted as local `YYYY-MM-DD`. */
+/** Inclusive day window for the Ariso meetings list: 7 days back … 7 days
+ * forward, formatted as local `YYYY-MM-DD`. */
 export function arisoMeetingWindow(now: Date): { startDate: string; endDate: string } {
   const pad = (n: number) => String(n).padStart(2, '0');
   const ymd = (d: Date) => `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
   const start = new Date(now);
   start.setDate(start.getDate() - 7);
   const end = new Date(now);
-  end.setDate(end.getDate() + 1);
+  end.setDate(end.getDate() + 7);
   return { startDate: ymd(start), endDate: ymd(end) };
 }
 

--- a/src/views/LibraryView.test.ts
+++ b/src/views/LibraryView.test.ts
@@ -60,41 +60,41 @@ describe('LibraryView', () => {
     expect(wrapper.findAll('.recording-row')).toHaveLength(0);
   });
 
-  it('renders a row per meeting in the order returned', async () => {
+  it('renders a meeting-item row per meeting', async () => {
     listMeetings.mockResolvedValue([
-      item({ id: 'b', title: 'Second', durationSeconds: 75, status: 'done' }),
-      item({ id: 'a', title: 'First', durationSeconds: 3661, status: 'failed' }),
+      item({ id: 'b', title: 'Second', durationSeconds: 75 }),
+      item({ id: 'a', title: 'First', durationSeconds: 3661 }),
     ]);
     const wrapper = mount(LibraryView);
     await flushPromises();
-    const rows = wrapper.findAll('.recording-row');
+    const rows = wrapper.findAll('.meeting-item');
     expect(rows).toHaveLength(2);
     expect(rows[0].text()).toContain('Second');
-    expect(rows[0].text()).toContain('01:15');
     expect(rows[1].text()).toContain('First');
-    expect(rows[1].text()).toContain('61:01');
-    expect(rows[1].text()).toContain('failed');
   });
 
-  it('enables/disables Note and Transcript per file-presence flags', async () => {
+  it('clicking a meeting item selects it (aria-pressed becomes true)', async () => {
     listMeetings.mockResolvedValue([
-      item({ id: 'a', files: { hasAudio: false, hasNote: true, hasTranscript: false } }),
+      item({ id: 'a', title: 'Standup' }),
     ]);
     const wrapper = mount(LibraryView);
     await flushPromises();
-    expect((wrapper.find('.btn-note').element as HTMLButtonElement).disabled).toBe(false);
-    expect((wrapper.find('.btn-transcript').element as HTMLButtonElement).disabled).toBe(true);
+    const btn = wrapper.find('.meeting-item');
+    expect(btn.attributes('aria-pressed')).toBe('false');
+    await btn.trigger('click');
+    expect(btn.attributes('aria-pressed')).toBe('true');
+    expect(btn.classes()).toContain('selected');
   });
 
-  it('clicking an enabled Note button opens the note file', async () => {
-    openRecordingFile.mockResolvedValue(undefined);
+  it('shows the meeting title and time subtitle in each row', async () => {
     listMeetings.mockResolvedValue([
-      item({ id: 'a', files: { hasAudio: false, hasNote: true, hasTranscript: false } }),
+      item({ id: 'a', title: 'Morning Sync', durationSeconds: 300 }),
     ]);
     const wrapper = mount(LibraryView);
     await flushPromises();
-    await wrapper.find('.btn-note').trigger('click');
-    expect(openRecordingFile).toHaveBeenCalledWith('a', 'note');
+    const row = wrapper.find('.meeting-item');
+    expect(row.find('.mi-title').text()).toBe('Morning Sync');
+    expect(row.find('.mi-sub').text()).toContain('min');
   });
 
   it('omits file controls for items without files (ariso meetings)', async () => {
@@ -106,31 +106,31 @@ describe('LibraryView', () => {
     expect(wrapper.find('.row-controls').exists()).toBe(false);
   });
 
-  it('opens the floating recorder window when Record is clicked (no in-window dock)', async () => {
+  it('opens the floating recorder window when the add button is clicked', async () => {
     listMeetings.mockResolvedValue([]);
     const wrapper = mount(LibraryView);
     await flushPromises();
-    await wrapper.find('.record-btn').trigger('click');
+    await wrapper.find('.add-btn').trigger('click');
     await flushPromises();
     expect(invoke).toHaveBeenCalledWith('start_recording_window', {});
   });
 
-  it('hides the Record button while a recording (waveform window) is active', async () => {
+  it('hides the sidebar (and add button) while a recording (waveform window) is active', async () => {
     listMeetings.mockResolvedValue([]);
     getAllWebviewWindows.mockResolvedValue([{ label: 'waveform' }]);
     const wrapper = mount(LibraryView);
     await flushPromises();
-    expect(wrapper.find('.record-btn').exists()).toBe(false);
+    expect(wrapper.find('.add-btn').exists()).toBe(false);
   });
 
-  it('hides the Record button immediately after clicking it', async () => {
+  it('hides the sidebar immediately after clicking the add button', async () => {
     listMeetings.mockResolvedValue([]);
     const wrapper = mount(LibraryView);
     await flushPromises();
-    expect(wrapper.find('.record-btn').exists()).toBe(true);
-    await wrapper.find('.record-btn').trigger('click');
+    expect(wrapper.find('.add-btn').exists()).toBe(true);
+    await wrapper.find('.add-btn').trigger('click');
     await flushPromises();
-    expect(wrapper.find('.record-btn').exists()).toBe(false);
+    expect(wrapper.find('.add-btn').exists()).toBe(false);
   });
 
   it('reloads meetings when the window regains focus (recorder finished)', async () => {

--- a/src/views/LibraryView.test.ts
+++ b/src/views/LibraryView.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { mount, flushPromises, enableAutoUnmount } from '@vue/test-utils';
 
 const listMeetings = vi.fn();
+const usesMeetingPicker = vi.fn(() => false);
 const openRecordingFile = vi.fn();
 const readRecordingAudio = vi.fn();
 const invoke = vi.fn(() => Promise.resolve());
@@ -13,7 +14,8 @@ vi.mock('@tauri-apps/api/webviewWindow', () => ({
   getAllWebviewWindows: () => getAllWebviewWindows(),
 }));
 vi.mock('../composables/useBackend', () => ({
-  getActiveBackend: () => Promise.resolve({ id: 'local', listMeetings: () => listMeetings() }),
+  getActiveBackend: () =>
+    Promise.resolve({ id: 'local', usesMeetingPicker: usesMeetingPicker(), listMeetings: () => listMeetings() }),
 }));
 // RecordingAudioPlayer (rendered for local rows) and openNote/openTranscript go
 // through ../tauri; keep those mocked so jsdom never touches real IPC.
@@ -45,6 +47,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   getAllWebviewWindows.mockResolvedValue([]);
   invoke.mockResolvedValue(undefined);
+  usesMeetingPicker.mockReturnValue(false);
 });
 afterEach(() => {
   vi.unstubAllGlobals();
@@ -172,5 +175,25 @@ describe('LibraryView', () => {
     await wrapper.get('button[title="Today"]').trigger('click');
     expect(wrapper.findAll('.meeting-item')).toHaveLength(0);
     expect(wrapper.text()).toContain('No meetings today.');
+  });
+
+  it('start-recording button opens the meeting picker for picker backends', async () => {
+    usesMeetingPicker.mockReturnValue(true);
+    listMeetings.mockResolvedValue([]);
+    const wrapper = mount(LibraryView);
+    await flushPromises();
+    await wrapper.get('.add-btn').trigger('click');
+    await flushPromises();
+    expect(invoke).toHaveBeenCalledWith('open_meeting_picker', {});
+  });
+
+  it('start-recording button opens the recorder directly for local backend', async () => {
+    usesMeetingPicker.mockReturnValue(false);
+    listMeetings.mockResolvedValue([]);
+    const wrapper = mount(LibraryView);
+    await flushPromises();
+    await wrapper.get('.add-btn').trigger('click');
+    await flushPromises();
+    expect(invoke).toHaveBeenCalledWith('start_recording_window', {});
   });
 });

--- a/src/views/LibraryView.test.ts
+++ b/src/views/LibraryView.test.ts
@@ -57,7 +57,6 @@ describe('LibraryView', () => {
     const wrapper = mount(LibraryView);
     await flushPromises();
     expect(wrapper.text()).toContain('No meetings yet');
-    expect(wrapper.findAll('.recording-row')).toHaveLength(0);
   });
 
   it('renders a meeting-item row per meeting', async () => {
@@ -95,15 +94,6 @@ describe('LibraryView', () => {
     const row = wrapper.find('.meeting-item');
     expect(row.find('.mi-title').text()).toBe('Morning Sync');
     expect(row.find('.mi-sub').text()).toContain('min');
-  });
-
-  it('omits file controls for items without files (ariso meetings)', async () => {
-    listMeetings.mockResolvedValue([
-      { id: '7', title: 'Standup', timestamp: '2026-06-08T09:00:00Z' },
-    ]);
-    const wrapper = mount(LibraryView);
-    await flushPromises();
-    expect(wrapper.find('.row-controls').exists()).toBe(false);
   });
 
   it('opens the floating recorder window when the add button is clicked', async () => {
@@ -150,5 +140,37 @@ describe('LibraryView', () => {
     await flushPromises();
     expect(wrapper.text()).toContain('Could not load meetings');
     expect(wrapper.text()).not.toContain('No meetings yet');
+  });
+
+  function todayAt(hour: number): string {
+    const d = new Date();
+    return new Date(d.getFullYear(), d.getMonth(), d.getDate(), hour, 0, 0).toISOString();
+  }
+
+  it("Today tab filters the list to today's meetings and moves the active class", async () => {
+    listMeetings.mockResolvedValue([
+      item({ id: 'today', title: 'Today Standup', timestamp: todayAt(9) }),
+      item({ id: 'old', title: 'Old Sync', timestamp: '2020-01-02T10:00:00Z' }),
+    ]);
+    const wrapper = mount(LibraryView);
+    await flushPromises();
+    expect(wrapper.findAll('.meeting-item')).toHaveLength(2);
+    expect(wrapper.get('button[title="Meetings"]').classes()).toContain('nav-tab--active');
+
+    await wrapper.get('button[title="Today"]').trigger('click');
+    expect(wrapper.findAll('.meeting-item')).toHaveLength(1);
+    expect(wrapper.text()).toContain('Today Standup');
+    expect(wrapper.text()).not.toContain('Old Sync');
+    expect(wrapper.get('button[title="Today"]').classes()).toContain('nav-tab--active');
+    expect(wrapper.get('button[title="Meetings"]').classes()).not.toContain('nav-tab--active');
+  });
+
+  it('Today tab shows the empty hint when there are no meetings today', async () => {
+    listMeetings.mockResolvedValue([item({ id: 'old', title: 'Old Sync', timestamp: '2020-01-02T10:00:00Z' })]);
+    const wrapper = mount(LibraryView);
+    await flushPromises();
+    await wrapper.get('button[title="Today"]').trigger('click');
+    expect(wrapper.findAll('.meeting-item')).toHaveLength(0);
+    expect(wrapper.text()).toContain('No meetings today.');
   });
 });

--- a/src/views/LibraryView.vue
+++ b/src/views/LibraryView.vue
@@ -179,10 +179,17 @@ async function refreshRecordingState(): Promise<void> {
 // Open the floating recorder pill (its own always-on-top window).
 async function startRecording(): Promise<void> {
   try {
+    const backend = await getActiveBackend();
+    if (backend.usesMeetingPicker) {
+      // Picker-using backends (Ariso) choose a meeting first; the picker then
+      // starts the recorder itself.
+      await invoke('open_meeting_picker', {});
+      return;
+    }
     await invoke('start_recording_window', {});
     setRecording(true);
   } catch (e) {
-    console.error('Failed to start recording window', e);
+    console.error('Failed to start recording', e);
   }
 }
 

--- a/src/views/LibraryView.vue
+++ b/src/views/LibraryView.vue
@@ -69,7 +69,7 @@
             <svg viewBox="0 0 24 24" class="nav-ic"><path d="M4 6h10a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2z" /><path d="m16 10 5-3v10l-5-3" /></svg>
             <span>Meetings</span>
           </button>
-          <button class="nav-tab" type="button" title="Todo">
+          <button class="nav-tab" type="button" title="Todo" disabled>
             <svg viewBox="0 0 24 24" class="nav-ic"><path d="M9 6h11M9 12h11M9 18h11" /><path d="m3 6 1.5 1.5L7 5M3 12l1.5 1.5L7 11M3 18l1.5 1.5L7 17" /></svg>
             <span>Todo</span>
           </button>
@@ -364,6 +364,8 @@ onUnmounted(() => {
 .nav-tab:hover { color: #1c1c1c; }
 .nav-tab--active { background: #1c1c1c; color: #ffffff; }
 .nav-tab--active:hover { color: #ffffff; }
+.nav-tab:disabled { opacity: 0.45; cursor: default; }
+.nav-tab:disabled:hover { color: #6f6f6f; }
 .nav-icon-btn {
   width: 32px;
   height: 32px;

--- a/src/views/LibraryView.vue
+++ b/src/views/LibraryView.vue
@@ -41,41 +41,31 @@
 
       <!-- Scrollable list with top/bottom fade mask -->
       <div v-else class="meeting-list">
-        <button
-          v-for="m in groups.earlier"
-          :key="m.id"
-          class="meeting-item"
-          :class="{ selected: selectedItem?.id === m.id }"
-          :aria-pressed="selectedItem?.id === m.id"
-          @click="selectMeeting(m)"
-        >
-          <span class="mi-title">{{ m.title }}</span>
-          <span class="mi-sub">{{ itemSub(m) }}</span>
-        </button>
-
-        <div v-if="groups.upcoming.length" class="group-label">UPCOMING</div>
-
-        <button
-          v-for="m in groups.upcoming"
-          :key="m.id"
-          class="meeting-item"
-          :class="{ selected: selectedItem?.id === m.id }"
-          :aria-pressed="selectedItem?.id === m.id"
-          @click="selectMeeting(m)"
-        >
-          <span class="mi-title">{{ m.title }}</span>
-          <span class="mi-sub">{{ itemSub(m) }}</span>
-        </button>
+        <template v-for="section in displayedSections" :key="section.key">
+          <div v-if="section.label" class="group-label">{{ section.label }}</div>
+          <button
+            v-for="m in section.items"
+            :key="m.id"
+            class="meeting-item"
+            :class="{ selected: selectedItem?.id === m.id }"
+            :aria-pressed="selectedItem?.id === m.id"
+            @click="selectMeeting(m)"
+          >
+            <span class="mi-title">{{ m.title }}</span>
+            <span class="mi-sub">{{ itemSub(m) }}</span>
+          </button>
+        </template>
+        <p v-if="displayedSections.length === 0" class="hint">No meetings today.</p>
       </div>
 
       <!-- Floating bottom navigation -->
       <nav class="bottom-nav">
         <div class="nav-pill">
-          <button class="nav-tab" type="button" title="Today">
+          <button class="nav-tab" :class="{ 'nav-tab--active': activeView === 'today' }" type="button" title="Today" @click="activeView = 'today'">
             <svg viewBox="0 0 24 24" class="nav-ic"><path d="M3 10.5 12 4l9 6.5V20a1 1 0 0 1-1 1h-5v-6H9v6H4a1 1 0 0 1-1-1z" /></svg>
             <span>Today</span>
           </button>
-          <button class="nav-tab nav-tab--active" type="button" title="Meetings">
+          <button class="nav-tab" :class="{ 'nav-tab--active': activeView === 'meetings' }" type="button" title="Meetings" @click="activeView = 'meetings'">
             <svg viewBox="0 0 24 24" class="nav-ic"><path d="M4 6h10a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2z" /><path d="m16 10 5-3v10l-5-3" /></svg>
             <span>Meetings</span>
           </button>
@@ -102,6 +92,7 @@ import { ref, computed, onMounted, onUnmounted } from 'vue';
 import { invoke } from '@tauri-apps/api/core';
 import { getAllWebviewWindows } from '@tauri-apps/api/webviewWindow';
 import { getActiveBackend, type MeetingListItem } from '../composables/useBackend';
+import { groupMeetingsByDate, todaysMeetings, type MeetingSection } from '../composables/groupMeetingsByDate';
 import MeetingDetailView from './MeetingDetailView.vue';
 
 const meetings = ref<MeetingListItem[]>([]);
@@ -115,18 +106,14 @@ const now = new Date();
 const dayNum = now.getDate();
 const monthName = now.toLocaleString(undefined, { month: 'long' }).toUpperCase();
 
-// Split into "earlier/today" (already most-recent-first from the backend) and
-// "upcoming" (future, soonest-first) so the list mirrors the design's two
-// sections with an UPCOMING divider.
-const groups = computed(() => {
-  const ts = Date.now();
-  const earlier: MeetingListItem[] = [];
-  const upcoming: MeetingListItem[] = [];
-  for (const m of meetings.value) {
-    (new Date(m.timestamp).getTime() > ts ? upcoming : earlier).push(m);
+const activeView = ref<'today' | 'meetings'>('meetings');
+
+const displayedSections = computed<MeetingSection[]>(() => {
+  if (activeView.value === 'today') {
+    const items = todaysMeetings(meetings.value, now);
+    return items.length ? [{ key: 'today', label: '', items }] : [];
   }
-  upcoming.sort((a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime());
-  return { earlier, upcoming };
+  return groupMeetingsByDate(meetings.value, now);
 });
 
 function itemSub(m: MeetingListItem): string {


### PR DESCRIPTION

<img width="1236" height="999" alt="Screenshot 2026-06-10 at 14 15 29" src="https://github.com/user-attachments/assets/edc31937-39be-4e29-829a-c8678d537151" />
<img width="1236" height="999" alt="Screenshot 2026-06-10 at 14 15 39" src="https://github.com/user-attachments/assets/b19ae7c9-69c6-4941-a508-ff104cae23ab" />


## Summary

Reworks the main meetings window (`LibraryView`) to match the Figma date-grouped list, makes the nav pill functional, and wires the start-recording button to the meeting picker.

- **Group by calendar date** — the meetings list now renders per-date headers (`TODAY` / `YESTERDAY` / `TOMORROW`, else `MON, JUN 9`), newest date first, with a single trailing `UPCOMING` section for future meetings. Logic lives in a pure, unit-tested helper `src/composables/groupMeetingsByDate.ts`.
- **Working Today/Meetings tabs** — `Today` filters the list to today's meetings only (with a "No meetings today." empty state); `Meetings` shows the full grouped list. The `Todo` tab is **disabled** for now.
- **Wider upcoming window** — `arisoMeetingWindow` now spans 7 days back → **+7 days forward** (was +1) so planned future meetings actually appear under `UPCOMING`.
- **Start-recording → picker** — the sidebar `+` button opens the meeting-picker window for picker-using backends (Ariso) via a new reusable Rust command `open_meeting_picker` (extracted from the tray's inline window build; the tray now reuses it). Local backend still opens the recorder directly.

Spec: `docs/superpowers/specs/2026-06-10-library-meetings-date-grouping-design.md`

## Test Plan

- [x] `npx vitest run` — 74 passing (new coverage: `groupMeetingsByDate` grouping/labels/NaN, Today↔Meetings toggle + active-class move, empty-today hint, start-recording picker-vs-recorder branch)
- [x] `npm run vite:build` — clean
- [x] `cd src-tauri && cargo build` — clean, no warnings
- [ ] Manual: Meetings tab shows date headers + UPCOMING; Today tab filters to today; `+` opens the picker (Ariso) / recorder (Local); Todo tab is disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Meetings in the library view are now grouped by date with contextual labels (TODAY, YESTERDAY, TOMORROW, UPCOMING, etc.)
  * Added "Today" tab in bottom navigation to quickly filter meetings for the current date
  * Ariso backend now displays meetings up to 7 days ahead instead of 1 day
  * New meeting picker window for selecting meetings to record

* **Documentation**
  * Added design specification for date-grouping behavior and meeting picker integration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->