### PR TITLE
feat(meetings): inline-edit meeting title in detail view

### DIFF
--- a/src/composables/useMeetingApi.ts
+++ b/src/composables/useMeetingApi.ts
@@ -153,6 +153,17 @@ export function useMeetingApi() {
     return res.data as MeetingNotes;
   }
 
+  // Rename a meeting via the shared meeting-notes endpoint (the same one the web
+  // app uses). Used by the desktop detail panel's inline title editing.
+  async function updateMeetingNotesTitle(
+    meetingId: number | string,
+    title: string
+  ): Promise<void> {
+    const encodedMeetingId = encodeURIComponent(String(meetingId));
+    const res = await api.request('PATCH', `/meeting-notes/${encodedMeetingId}`, { title });
+    assertOk(res, 200, 'update meeting title');
+  }
+
   // Fetch a meeting's stored transcript. Resolves to null on 404 (no transcript
   // stored yet) so callers can treat "absent" distinctly from a real error.
   async function getMeetingTranscript(
@@ -322,6 +333,7 @@ export function useMeetingApi() {
     listMeetingsInWindow,
     getMeeting,
     getMeetingNotes,
+    updateMeetingNotesTitle,
     getMeetingTranscript,
     getMeetingIndividualNote,
     updateMeeting,

--- a/src/views/LibraryView.vue
+++ b/src/views/LibraryView.vue
@@ -89,7 +89,12 @@
 
     <!-- Floating detail card on the backdrop -->
     <section class="detail-wrap">
-      <MeetingDetailView v-if="selectedItem" :item="selectedItem" @close="selectedItem = null" />
+      <MeetingDetailView
+        v-if="selectedItem"
+        :item="selectedItem"
+        @close="selectedItem = null"
+        @title-updated="onTitleUpdated"
+      />
       <div v-else class="empty-card">
         <p>Select a meeting to view its notes.</p>
       </div>
@@ -140,6 +145,16 @@ function itemSub(m: MeetingListItem): string {
 
 function selectMeeting(m: MeetingListItem): void {
   selectedItem.value = m;
+}
+
+// Keep the sidebar (and the selected reference) in sync after an inline rename
+// in the detail panel, so the list label updates without a full reload.
+function onTitleUpdated(payload: { id: string; title: string }): void {
+  const m = meetings.value.find((x) => x.id === payload.id);
+  if (m) m.title = payload.title;
+  if (selectedItem.value?.id === payload.id) {
+    selectedItem.value = { ...selectedItem.value, title: payload.title };
+  }
 }
 
 function toggleLeftPanel(): void {

--- a/src/views/MeetingDetailView.test.ts
+++ b/src/views/MeetingDetailView.test.ts
@@ -1,0 +1,117 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mount, flushPromises } from '@vue/test-utils';
+import type { MeetingDetail, MeetingListItem } from '../composables/useBackend';
+
+const getMeetingDetail = vi.fn();
+const updateMeetingNotesTitle = vi.fn();
+
+vi.mock('../composables/useBackend', () => ({
+  getActiveBackend: () => Promise.resolve({ getMeetingDetail: (i: MeetingListItem) => getMeetingDetail(i) }),
+}));
+vi.mock('../composables/useMeetingApi', () => ({
+  useMeetingApi: () => ({ updateMeetingNotesTitle: (...a: unknown[]) => updateMeetingNotesTitle(...a) }),
+}));
+
+import MeetingDetailView from './MeetingDetailView.vue';
+
+function detail(over: Partial<MeetingDetail> = {}): MeetingDetail {
+  return {
+    id: '7',
+    title: 'Old title',
+    startAt: '2026-06-02T10:00:00Z',
+    participants: [],
+    actionItems: [],
+    isLocal: false,
+    ...over,
+  };
+}
+
+const item: MeetingListItem = { id: '7', title: 'Old title', timestamp: '2026-06-02T10:00:00Z' };
+
+async function mountWith(d: MeetingDetail) {
+  getMeetingDetail.mockResolvedValue(d);
+  const wrapper = mount(MeetingDetailView, { props: { item } });
+  await flushPromises();
+  return wrapper;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  updateMeetingNotesTitle.mockResolvedValue(undefined);
+});
+
+describe('MeetingDetailView inline title editing', () => {
+  it('renders an editable title for an Ariso meeting', async () => {
+    const wrapper = await mountWith(detail());
+    expect(wrapper.find('.head-title--editable').exists()).toBe(true);
+    expect(wrapper.find('.head-title').text()).toBe('Old title');
+  });
+
+  it('commits a renamed title: calls the API, updates the heading, and emits titleUpdated', async () => {
+    const wrapper = await mountWith(detail());
+
+    await wrapper.find('.head-title').trigger('click');
+    const input = wrapper.find('input.head-title--input');
+    expect(input.exists()).toBe(true);
+
+    await input.setValue('New title');
+    await input.trigger('keydown', { key: 'Enter' });
+    await flushPromises();
+
+    expect(updateMeetingNotesTitle).toHaveBeenCalledWith('7', 'New title');
+    expect(wrapper.emitted('titleUpdated')?.[0]).toEqual([{ id: '7', title: 'New title' }]);
+    expect(wrapper.find('.head-title').text()).toBe('New title');
+    expect(wrapper.find('input.head-title--input').exists()).toBe(false);
+  });
+
+  it('does not call the API for an unchanged or whitespace-only title', async () => {
+    const wrapper = await mountWith(detail());
+    await wrapper.find('.head-title').trigger('click');
+    const input = wrapper.find('input.head-title--input');
+
+    await input.setValue('   ');
+    await input.trigger('keydown', { key: 'Enter' });
+    await flushPromises();
+
+    expect(updateMeetingNotesTitle).not.toHaveBeenCalled();
+    expect(wrapper.find('.head-title').text()).toBe('Old title');
+  });
+
+  it('cancels editing on Escape without calling the API', async () => {
+    const wrapper = await mountWith(detail());
+    await wrapper.find('.head-title').trigger('click');
+    const input = wrapper.find('input.head-title--input');
+
+    await input.setValue('Discarded');
+    await input.trigger('keydown', { key: 'Escape' });
+    await flushPromises();
+
+    expect(updateMeetingNotesTitle).not.toHaveBeenCalled();
+    expect(wrapper.find('input.head-title--input').exists()).toBe(false);
+    expect(wrapper.find('.head-title').text()).toBe('Old title');
+  });
+
+  it('keeps the title plain (not editable) for a local recording', async () => {
+    const wrapper = await mountWith(detail({ isLocal: true, note: 'hi' }));
+    expect(wrapper.find('.head-title--editable').exists()).toBe(false);
+    await wrapper.find('.head-title').trigger('click');
+    expect(wrapper.find('input.head-title--input').exists()).toBe(false);
+  });
+
+  it('keeps the editor open and does not emit when the API fails', async () => {
+    updateMeetingNotesTitle.mockRejectedValue(new Error('boom'));
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    const wrapper = await mountWith(detail());
+
+    await wrapper.find('.head-title').trigger('click');
+    const input = wrapper.find('input.head-title--input');
+    await input.setValue('New title');
+    await input.trigger('keydown', { key: 'Enter' });
+    await flushPromises();
+
+    expect(updateMeetingNotesTitle).toHaveBeenCalledOnce();
+    expect(wrapper.emitted('titleUpdated')).toBeUndefined();
+    expect(wrapper.find('input.head-title--input').exists()).toBe(true);
+  });
+});

--- a/src/views/MeetingDetailView.vue
+++ b/src/views/MeetingDetailView.vue
@@ -10,7 +10,28 @@
       <!-- Header: title + subtitle, share / link / close -->
       <header class="card-head">
         <div class="head-titles">
-          <h1 class="head-title">{{ detail.title }}</h1>
+          <input
+            v-if="editingTitle"
+            ref="titleInput"
+            v-model="titleDraft"
+            class="head-title head-title--input"
+            type="text"
+            :disabled="savingTitle"
+            aria-label="Meeting title"
+            @keydown.enter.prevent="commitTitle"
+            @keydown.esc.prevent="cancelTitleEdit"
+            @blur="commitTitle"
+          />
+          <h1
+            v-else
+            class="head-title"
+            :class="{ 'head-title--editable': canEditTitle }"
+            :role="canEditTitle ? 'button' : undefined"
+            :tabindex="canEditTitle ? 0 : undefined"
+            :title="canEditTitle ? 'Click to rename' : undefined"
+            @click="startTitleEdit"
+            @keydown.enter="startTitleEdit"
+          >{{ detail.title }}</h1>
           <p class="head-sub">{{ subtitle }}</p>
         </div>
         <div class="head-actions">
@@ -163,8 +184,9 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, watch } from 'vue';
+import { ref, computed, watch, nextTick } from 'vue';
 import { renderMarkdown } from '../utils/markdown';
+import { useMeetingApi } from '../composables/useMeetingApi';
 import {
   getActiveBackend,
   type MeetingListItem,
@@ -174,13 +196,24 @@ import {
 } from '../composables/useBackend';
 
 const props = defineProps<{ item: MeetingListItem | null }>();
-const emit = defineEmits<{ close: [] }>();
+const emit = defineEmits<{
+  close: [];
+  titleUpdated: [payload: { id: string; title: string }];
+}>();
 
 const loading = ref(false);
 const error = ref<string | null>(null);
 const detail = ref<MeetingDetail | null>(null);
 const showFullNotes = ref(false);
 const activeTab = ref<'note' | 'transcript' | 'mynote'>('note');
+
+// Inline title editing. Only Ariso meetings have a server-side rename endpoint
+// (PATCH /meeting-notes/{id}); local recordings render a plain title.
+const editingTitle = ref(false);
+const titleDraft = ref('');
+const savingTitle = ref(false);
+const titleInput = ref<HTMLInputElement | null>(null);
+const canEditTitle = computed(() => !!detail.value && !detail.value.isLocal);
 
 // Transcript is loaded lazily when the Transcript tab is opened (Ariso fetches
 // /meeting-notes/{id}/transcript; local reads transcript.md).
@@ -204,6 +237,8 @@ async function load(item: MeetingListItem | null): Promise<void> {
   error.value = null;
   showFullNotes.value = false;
   activeTab.value = 'note';
+  editingTitle.value = false;
+  savingTitle.value = false;
   transcript.value = null;
   transcriptLoaded.value = false;
   loadingTranscript.value = false;
@@ -240,6 +275,52 @@ watch(
   () => load(props.item),
   { immediate: true }
 );
+
+async function startTitleEdit(): Promise<void> {
+  if (!canEditTitle.value || editingTitle.value) return;
+  titleDraft.value = detail.value?.title ?? '';
+  editingTitle.value = true;
+  await nextTick();
+  titleInput.value?.focus();
+  titleInput.value?.select();
+}
+
+function cancelTitleEdit(): void {
+  editingTitle.value = false;
+  savingTitle.value = false;
+}
+
+// Persist the edited title. Blur and Enter both route here; the savingTitle /
+// editingTitle guards make the second call (Enter then blur) a no-op. A no-op
+// or whitespace-only edit just closes the editor without hitting the API.
+async function commitTitle(): Promise<void> {
+  if (!editingTitle.value || savingTitle.value) return;
+  const d = detail.value;
+  if (!d) {
+    editingTitle.value = false;
+    return;
+  }
+  const next = titleDraft.value.trim();
+  if (!next || next === d.title) {
+    editingTitle.value = false;
+    return;
+  }
+  savingTitle.value = true;
+  const my = reqId;
+  try {
+    const { updateMeetingNotesTitle } = useMeetingApi();
+    await updateMeetingNotesTitle(d.id, next);
+    if (my !== reqId) return; // selection changed mid-save — drop the stale result
+    d.title = next;
+    emit('titleUpdated', { id: d.id, title: next });
+    editingTitle.value = false;
+  } catch (e) {
+    console.error('Failed to update meeting title', e);
+    // Keep the editor open so the user's text survives and they can retry.
+  } finally {
+    if (my === reqId) savingTitle.value = false;
+  }
+}
 
 // Local recordings already carry their transcript on the detail; Ariso loads it
 // lazily into `transcript`. Either way this is what the Transcript tab renders.
@@ -442,6 +523,14 @@ const durationLabel = computed<string | null>(() => {
 .card-head { display: flex; align-items: flex-start; justify-content: space-between; gap: 12px; padding: 22px 24px 12px; }
 .head-titles { min-width: 0; }
 .head-title { margin: 0; font-size: 22px; font-weight: 700; line-height: 1.2; color: #1c1c1c; }
+.head-title--editable { cursor: text; }
+.head-title--input {
+  display: block; width: 100%; height: 1.2em; margin: 0; padding: 0; box-sizing: border-box;
+  position: relative; top: -1px;
+  font-family: inherit; font-size: 22px; font-weight: 700; line-height: 1.2; color: #1c1c1c;
+  border: none; background: transparent; outline: none; appearance: none;
+}
+.head-title--input:disabled { opacity: 0.6; }
 .head-sub { margin: 4px 0 0; font-size: 13px; color: #6f6f6f; }
 .head-actions { display: flex; align-items: center; gap: 8px; flex-shrink: 0; }
 .btn-share {


### PR DESCRIPTION
## What

Lets you rename a meeting by clicking its title in the detail panel and editing it in place.

## How

- **API** — new `updateMeetingNotesTitle(id, title)` in `useMeetingApi`, calling `PATCH /meeting-notes/{id}` with `{ "title": "..." }`.
- **Detail view** — the `<h1>` becomes a clickable, in-place text field:
  - **Enter** / **blur** saves, **Escape** cancels.
  - No-op or whitespace-only edits skip the API call.
  - Stale-guarded with `reqId` so a selection change mid-save is dropped; on API failure the editor stays open so the typed text survives a retry.
  - Editing is gated to server-backed Ariso meetings; local recordings keep a plain title (no rename endpoint).
- **List sync** — emits `titleUpdated`; `LibraryView` updates the sidebar label without a full reload.
- **Styling** — the inline input mirrors the `<h1>` box (no border/background, matched metrics) so the title doesn't shift or jump when entering edit mode.

## Tests

Added `MeetingDetailView.test.ts` (6 cases): editable-for-Ariso, commit (API call + heading update + emit), no-op/whitespace skip, Escape cancel, local-is-plain, and API-failure-keeps-editor-open. All pass; `vite build` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added inline meeting title editing for Ariso meetings. Users can now click a meeting title to edit it directly in the detail view. Changes are saved with Enter, canceled with Escape, and instantly reflected across the application.

* **Tests**
  * Added comprehensive test coverage for the new title editing feature, including validation and error handling scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->