### PR TITLE
feat: auto- & manual-trigger recording

### DIFF
--- a/docs/superpowers/specs/2026-06-10-auto-trigger-recording-design.md
+++ b/docs/superpowers/specs/2026-06-10-auto-trigger-recording-design.md
@@ -1,0 +1,236 @@
+# Auto-Trigger Recording — Design
+
+**Date:** 2026-06-10
+**Branch:** `feat/auto-trigger-recording`
+**Status:** Approved (pending spec review)
+
+## Summary
+
+Automatically start a meeting recording when another application (Zoom,
+FaceTime, Google Meet, etc.) begins using the microphone, and automatically end
+it when that application releases the microphone — independent of any calendar
+entry. When a current calendar meeting can be matched, the recording is attached
+to it; otherwise the user is asked to confirm the capture.
+
+The recording itself reuses the existing recorder pipeline (`useRecorder` +
+`RecorderPanel.vue` in the `waveform` window) and finalize/upload flow
+unchanged. The new work is a native microphone-usage monitor and the
+orchestration that connects it to that pipeline.
+
+## Goals
+
+- Start recording within a few seconds of a meeting app taking the mic.
+- Stop recording shortly after the meeting app releases the mic.
+- Attach to a "happening now" calendar meeting when one exists (Ariso backend).
+- Never silently capture ad-hoc mic usage without a calendar match — ask first.
+- Never interfere with a manual recording already in progress.
+- Be a user-controllable setting (default ON), and degrade gracefully on
+  hardware/OS that can't support reliable detection.
+
+## Non-Goals
+
+- Windows/Linux support (the app is macOS-only).
+- Detecting *which* meeting app is in use, or app-specific behavior.
+- Recording purely local mic blips (Siri, voice memos, "test your mic").
+- Changing the recording/encoding/upload pipeline.
+
+## Key Decisions
+
+| Decision | Choice |
+|---|---|
+| Detection mechanism | Per-process CoreAudio (`kAudioProcessPropertyIsRunningInput`), macOS 14.4+ |
+| Self-recording loop | PID-snapshot at trigger; stop only when the *triggering* PIDs release |
+| Opt-in | Settings toggle, **default ON** |
+| Calendar association | Best-effort match to a "current" meeting; else confirm prompt |
+| Confirm-prompt timeout (~60 s, no response) | **Discard & stop** |
+| Local backend (no calendar) | Same confirm prompt as an unmatched Ariso recording |
+| UI surface | Reuse the existing recorder pill + tray menu; fully controllable |
+| OS gating | Monitor active on macOS 14.4+ only; app minimum stays macOS 13 |
+
+## Architecture
+
+### Component overview
+
+```
+┌──────────────────────── Rust process (never suspended) ────────────────────┐
+│                                                                             │
+│  mic_monitor.rs                          commands.rs / tray.rs              │
+│  ┌─────────────────────────┐             ┌──────────────────────────────┐  │
+│  │ CoreAudio poll loop      │  open win   │ open_waveform_window(auto=1) │  │
+│  │  - enumerate proc objs   ├────────────▶│ RecordingState (shared)      │  │
+│  │  - debounce on/off       │  emit stop  │ set_tray_recording           │  │
+│  │  - PID snapshot          │◀────────────┤                              │  │
+│  └─────────────────────────┘             └──────────────────────────────┘  │
+│            │ emits: auto-record://stop                                       │
+└────────────┼────────────────────────────────────────────────────────────────┘
+             ▼
+   waveform webview  ── RecorderPanel.vue (auto=1)
+       - start recording immediately
+       - match calendar meeting (Ariso) OR show confirm overlay
+       - on auto-record://stop → finalize + upload (existing flow)
+```
+
+### New / changed files
+
+- **`src-tauri/src/mic_monitor.rs`** (new) — CoreAudio FFI + monitor task +
+  state machine + the `RecordingState` shared flag and start/stop commands.
+- **`src-tauri/src/main.rs`** — register module, manage `RecordingState`, spawn
+  the monitor on startup (gated on setting + OS version), register new commands.
+- **`src-tauri/src/commands.rs`** — `open_waveform_window` gains an `auto` flag
+  that adds `&auto=1` to the URL; `RecordingState` is set/cleared alongside the
+  tray menu transitions.
+- **`src/views/RecorderPanel.vue`** — read `auto=1`; start immediately; run the
+  match-or-confirm flow; render the confirm overlay; listen for
+  `auto-record://stop`.
+- **`src/composables/useAutoTrigger.ts`** (new) — pure-ish orchestration the
+  panel calls: resolve association (match vs prompt), drive the confirm overlay
+  state machine, and the timeout. Unit-tested in isolation.
+- **`src/views/SettingsView.vue`** + **`src/composables/useRecordingPermissions.ts`**
+  — new "Auto-record meetings" toggle persisted to `settings.json`
+  (`autoRecordEnabled`), and a sync call so toggling it starts/stops the native
+  monitor without a restart.
+
+## Native detection (`mic_monitor.rs`)
+
+### CoreAudio FFI (macOS 14.4+)
+
+Read-only enumeration — no audio tap is created, so no extra TCC capture
+permission should be required (to be verified during implementation):
+
+- `kAudioHardwarePropertyProcessObjectList` → `[AudioObjectID]` of process
+  objects.
+- Per object: `kAudioProcessPropertyPID` (pid) and
+  `kAudioProcessPropertyIsRunningInput` (bool).
+- "External input set" = `{ pid : IsRunningInput == true } \ { our_pid }` where
+  `our_pid = std::process::id()`.
+
+Implemented as raw `extern "C"` against the CoreAudio framework, matching the
+existing raw-FFI style in `audio_capture.rs` (`CGRequestScreenCaptureAccess`).
+Availability is detected at runtime; if the symbols/property are unavailable or
+the OS is < 14.4, the monitor reports unsupported and never runs.
+
+### State machine
+
+States: `Idle` → `Arming` → `Recording` → `Stopping` → `Idle`.
+
+- **Idle:** poll every ~1 s. When the external input set becomes non-empty,
+  capture `armed_at` and move to `Arming`.
+- **Arming:** require the external set to stay non-empty for `START_DEBOUNCE`
+  (**3 s**). If it empties first, return to `Idle` (it was a blip). On success:
+  snapshot `trigger_pids` = current external set, consult `RecordingState`.
+  - If a recording is already active (manual or auto) **or** the setting is
+    disabled → return to `Idle` (do nothing).
+  - Else → open the recorder window with `auto=1`, mark `RecordingState`
+    auto-active, move to `Recording`.
+- **Recording:** the meeting is "alive" while *any* PID in `trigger_pids` still
+  has input running. New PIDs that appear (our own `getUserMedia` capture, a
+  second app) are ignored for the stop decision. When none of `trigger_pids`
+  has input running, capture `released_at`, move to `Stopping`.
+- **Stopping:** require all `trigger_pids` to stay released for `STOP_DEBOUNCE`
+  (**8 s**). If any re-acquires input, return to `Recording`. On success → emit
+  `auto-record://stop`, move to `Idle`. `RecordingState` is cleared by the
+  frontend when finalize completes (or by a window-closed fallback).
+
+### Why the PID snapshot
+
+Our own recorder opens the mic via `getUserMedia`, which would keep the input
+device "in use." By tracking only the *triggering* PIDs for the stop decision,
+our own capture (whatever PID WebKit attributes it to) never keeps the meeting
+artificially "alive." The `RecordingState` guard separately prevents a manual
+recording from self-triggering, regardless of PID attribution.
+
+## Orchestration & shared state
+
+- **`RecordingState`** (`Mutex<Recording>` in native, `app.manage`d):
+  `{ active: bool, source: Manual | Auto }`. Set when a recorder window opens
+  (manual via tray, or auto), cleared when finalize completes. The monitor reads
+  it to suppress triggers while any recording runs.
+- Manual recordings already flow through `open_waveform_window`; that helper
+  sets `RecordingState{active, Manual}` so the monitor stays quiet.
+- A new command `auto_recording_finished` (called by the panel after finalize,
+  success or failure) clears the flag. A window-`Destroyed` handler clears it as
+  a fallback so a crashed/closed window can't wedge the monitor off.
+
+## Match-or-prompt flow (`useAutoTrigger.ts` + `RecorderPanel.vue`)
+
+On mount with `auto=1`:
+
+1. **Start recording immediately** via the existing path (respecting the user's
+   mic/system source toggles) so the meeting's opening is never lost.
+2. **Resolve association** in parallel:
+   - **Ariso:** `listScheduledMeetings(now-2h … now+2h)` → `pickDefaultMeeting`
+     (which itself applies the `start-5min … start+60min` "current" window).
+     - `kind === 'current'` → set `meetingId`, header shows `Recording — <title>`.
+       No prompt.
+     - otherwise → enter **confirm** state.
+   - **Local:** always **confirm** state (no calendar).
+3. **Confirm overlay** (shown over the pill while recording continues):
+   *"Recording started — keep it?"* with **Keep** / **Discard**.
+   - **Keep** → dismiss overlay, continue as a normal recording.
+   - **Discard** → stop recorder, drop audio, close window, mark
+     `auto_recording_finished`.
+   - **Timeout (~60 s, no response)** → same as **Discard**.
+4. **Stop:** `auto-record://stop` (from native) ends the recording and runs the
+   existing finalize/upload. A manual Stop (tray or pill) also works at any time.
+
+Auto-recordings shorter than **MIN_DURATION (15 s)** at stop time are discarded
+rather than uploaded (guards against late mic-on/quick-off races).
+
+## Settings
+
+- New toggle **"Auto-record meetings"** in `SettingsView.vue`, persisted to
+  `settings.json` key `autoRecordEnabled` (default **true** on first read).
+- Toggling calls a `sync_auto_record` command that starts/stops the native
+  monitor immediately (mirrors `sync_meeting_notifications`).
+- On macOS < 14.4 or when the CoreAudio symbols are unavailable, the toggle is
+  rendered disabled with a "Requires macOS 14.4+" caption and the monitor never
+  starts.
+- The feature reuses the existing mic + screen-recording permissions already
+  gated by the recording-source toggles; no new OS permission UI is introduced
+  unless implementation reveals the process-list read needs one (see Risks).
+
+## Edge cases
+
+- **Mute mid-meeting:** Zoom/Meet keep the input stream open while muted, so the
+  triggering PID stays "running input" → recording continues. Correct.
+- **Manual recording active:** monitor suppressed via `RecordingState`.
+- **Back-to-back meetings:** after `Stopping`→`Idle`, a fresh mic-on re-arms
+  normally and produces a separate recording.
+- **App started mid-meeting:** monitor begins in `Idle`; an already-running mic
+  is detected on the first poll and arms normally.
+- **Sign-out / Ariso match fails:** match step errors are swallowed; the flow
+  falls back to the confirm prompt (treated as "no match").
+- **Multiple input apps at once:** `trigger_pids` holds all of them; the meeting
+  is alive until all release.
+- **Window/finalize crash:** `Destroyed` handler clears `RecordingState` so the
+  monitor recovers.
+
+## Testing
+
+- **Pure unit (Vitest):**
+  - `useAutoTrigger`: association resolution (current/none), confirm state
+    machine (keep/discard/timeout via injected clock), min-duration discard.
+  - Reuse `pickDefaultMeeting` tests for the match boundary.
+- **Rust unit:** the state-machine transitions modeled as a pure function over
+  `(state, external_pid_set, recording_active, now)` so debounce/snapshot logic
+  is testable without CoreAudio. FFI enumeration is a thin, separately-kept
+  boundary.
+- **Manual verification (ariso-desktop MCP):** start a FaceTime/Zoom call →
+  confirm recorder opens and arms after ~3 s; end the call → confirm it stops
+  after ~8 s and finalizes; verify manual recording suppresses auto-trigger;
+  verify the confirm overlay keep/discard/timeout paths; verify the toggle
+  starts/stops the monitor live.
+
+## Risks & verification items
+
+1. **PID attribution of our own `getUserMedia` capture** — the snapshot approach
+   is designed to be robust to this, but confirm during implementation that our
+   capture does not retroactively land in `trigger_pids`.
+2. **TCC for reading the process list / `IsRunningInput`** — verify no audio
+   capture authorization is required for a read-only enumeration; if it is,
+   surface it through the existing permission UX.
+3. **CoreAudio symbol availability across 14.4–15.x** — confirm the property
+   constants and behave consistently; keep the runtime-availability guard.
+4. **Poll interval vs. responsiveness/CPU** — 1 s poll is the starting point;
+   switch to a CoreAudio property listener if a poll proves too laggy or costly.
+```

--- a/docs/superpowers/specs/2026-06-10-auto-trigger-recording-design.md
+++ b/docs/superpowers/specs/2026-06-10-auto-trigger-recording-design.md
@@ -23,7 +23,7 @@ Either kind of recording ends on an explicit Stop **or** on a universal
 finalizes the recording. Auto recordings additionally end on mic-off detection.
 
 The recording itself reuses the existing recorder pipeline (`useRecorder` +
-`RecorderPanel.vue` in the `waveform` window) and finalize/upload flow
+`WaveformView.vue` in the `waveform` window) and finalize/upload flow
 unchanged. The new work is a native microphone-usage monitor, the orchestration
 that connects it to that pipeline, and the silence backstop in the pipeline.
 
@@ -79,7 +79,7 @@ that connects it to that pipeline, and the silence backstop in the pipeline.
 │            │ emits: auto-record://stop                                       │
 └────────────┼────────────────────────────────────────────────────────────────┘
              ▼
-   waveform webview  ── RecorderPanel.vue (auto=1)
+   waveform webview  ── WaveformView.vue (auto=1)
        - start recording immediately
        - match calendar meeting (Ariso) OR show confirm overlay
        - on auto-record://stop → finalize + upload (existing flow)
@@ -94,7 +94,7 @@ that connects it to that pipeline, and the silence backstop in the pipeline.
 - **`src-tauri/src/commands.rs`** — `open_waveform_window` gains an `auto` flag
   that adds `&auto=1` to the URL; `RecordingState` is set/cleared alongside the
   tray menu transitions.
-- **`src/views/RecorderPanel.vue`** — read `auto=1`; start immediately; run the
+- **`src/views/WaveformView.vue`** — read `auto=1`; start immediately; run the
   match-or-confirm flow; render the confirm overlay; listen for
   `auto-record://stop`.
 - **`src/composables/useAutoTrigger.ts`** (new) — pure-ish orchestration the
@@ -173,7 +173,7 @@ recording from self-triggering, regardless of PID attribution.
   success or failure) clears the flag. A window-`Destroyed` handler clears it as
   a fallback so a crashed/closed window can't wedge the monitor off.
 
-## Match-or-prompt flow (`useAutoTrigger.ts` + `RecorderPanel.vue`)
+## Match-or-prompt flow (`useAutoTrigger.ts` + `WaveformView.vue`)
 
 On mount with `auto=1`:
 
@@ -232,7 +232,7 @@ pipeline (frontend) because that is where the captured signal is available.
     never counts toward the 15 minutes.
   - When `now − lastSoundAt ≥ SILENCE_TIMEOUT` (**15 min**) and not paused →
     `shouldAutoStop = true`.
-- `RecorderPanel.vue` evaluates the watch on the existing 1-second timer tick;
+- `WaveformView.vue` evaluates the watch on the existing 1-second timer tick;
   on `shouldAutoStop` it runs the **same Stop path** as a manual/tray stop
   (finalize + upload, or discard if under `MIN_DURATION`). For an auto recording
   this is an additional safety net layered on top of mic-off detection —

--- a/docs/superpowers/specs/2026-06-10-auto-trigger-recording-design.md
+++ b/docs/superpowers/specs/2026-06-10-auto-trigger-recording-design.md
@@ -1,4 +1,4 @@
-# Auto-Trigger Recording — Design
+# Auto- & Manual-Trigger Recording — Design
 
 **Date:** 2026-06-10
 **Branch:** `feat/auto-trigger-recording`
@@ -6,21 +6,33 @@
 
 ## Summary
 
-Automatically start a meeting recording when another application (Zoom,
-FaceTime, Google Meet, etc.) begins using the microphone, and automatically end
-it when that application releases the microphone — independent of any calendar
-entry. When a current calendar meeting can be matched, the recording is attached
-to it; otherwise the user is asked to confirm the capture.
+The recorder supports two ways to start a meeting recording, and several ways to
+end one:
+
+- **Auto trigger:** automatically start when another application (Zoom,
+  FaceTime, Google Meet, etc.) begins using the microphone, and automatically
+  end when that application releases it — independent of any calendar entry. When
+  a current calendar meeting can be matched, the recording is attached to it;
+  otherwise the user is asked to confirm the capture.
+- **Manual trigger:** the user starts a recording (tray "Start Recording"),
+  which begins capture and activates the enabled capture sources as needed —
+  today's flow, documented here so both paths share one lifecycle.
+
+Either kind of recording ends on an explicit Stop **or** on a universal
+**silence backstop**: 15 minutes of continuous no-sound activity auto-stops and
+finalizes the recording. Auto recordings additionally end on mic-off detection.
 
 The recording itself reuses the existing recorder pipeline (`useRecorder` +
 `RecorderPanel.vue` in the `waveform` window) and finalize/upload flow
-unchanged. The new work is a native microphone-usage monitor and the
-orchestration that connects it to that pipeline.
+unchanged. The new work is a native microphone-usage monitor, the orchestration
+that connects it to that pipeline, and the silence backstop in the pipeline.
 
 ## Goals
 
 - Start recording within a few seconds of a meeting app taking the mic.
 - Stop recording shortly after the meeting app releases the mic.
+- Let the user start a recording manually at any time (existing flow preserved).
+- Auto-stop **any** recording after 15 minutes of continuous silence.
 - Attach to a "happening now" calendar meeting when one exists (Ariso backend).
 - Never silently capture ad-hoc mic usage without a calendar match — ask first.
 - Never interfere with a manual recording already in progress.
@@ -46,6 +58,9 @@ orchestration that connects it to that pipeline.
 | Local backend (no calendar) | Same confirm prompt as an unmatched Ariso recording |
 | UI surface | Reuse the existing recorder pill + tray menu; fully controllable |
 | OS gating | Monitor active on macOS 14.4+ only; app minimum stays macOS 13 |
+| Manual trigger | Existing tray "Start Recording" flow; activates enabled capture sources |
+| Silence auto-stop | **15 min** continuous silence ends **any** recording (manual or auto) |
+| Silence while paused | Timer **frozen** while paused; resets on resume |
 
 ## Architecture
 
@@ -85,6 +100,13 @@ orchestration that connects it to that pipeline.
 - **`src/composables/useAutoTrigger.ts`** (new) — pure-ish orchestration the
   panel calls: resolve association (match vs prompt), drive the confirm overlay
   state machine, and the timeout. Unit-tested in isolation.
+- **`src/composables/useRecorder.ts`** — compute a per-frame amplitude from the
+  combined captured samples (mic + system, all modes) in the existing
+  `onaudioprocess` handler and track `lastSoundAt`; expose it so the silence
+  backstop can observe real captured audio (not just the mic analyser).
+- **`src/composables/silenceWatch.ts`** (new) — pure state machine over
+  `(lastSoundAt, now, paused)` → `shouldAutoStop`, encapsulating the 15-min
+  threshold and the pause-freeze rule. Unit-tested in isolation.
 - **`src/views/SettingsView.vue`** + **`src/composables/useRecordingPermissions.ts`**
   — new "Auto-record meetings" toggle persisted to `settings.json`
   (`autoRecordEnabled`), and a sync call so toggling it starts/stops the native
@@ -176,6 +198,46 @@ On mount with `auto=1`:
 Auto-recordings shorter than **MIN_DURATION (15 s)** at stop time are discarded
 rather than uploaded (guards against late mic-on/quick-off races).
 
+## Manual trigger
+
+The existing tray **"Start Recording"** flow is unchanged and is the manual
+trigger:
+
+- **Local backend:** opens the recorder window directly (after the model-ready
+  gate).
+- **Ariso backend:** session gate → meeting-picker → recorder window.
+
+"Activates if need" means starting a recording **activates the enabled capture
+sources** (mic and/or system audio per the recording-source toggles), prompting
+for OS permission where required — today's behavior. No new manual-start work is
+introduced beyond making manual recordings participate in the shared
+`RecordingState` (so the auto monitor stays quiet) and the silence backstop
+below.
+
+## Silence auto-stop (universal backstop)
+
+Applies to **every** recording, manual or auto. Implemented in the recorder
+pipeline (frontend) because that is where the captured signal is available.
+
+- In `useRecorder`'s `onaudioprocess` handler, compute a per-frame peak/RMS over
+  the **combined** captured samples (mic + system, whichever sources are
+  active). When the frame's level exceeds `SILENCE_LEVEL`, update `lastSoundAt`.
+  `SILENCE_LEVEL` is a small amplitude floor tuned to ignore ambient noise floor
+  but catch any real speech/system sound (starting point: peak ≥ ~0.01 of full
+  scale; revisited during manual verification).
+- `silenceWatch.ts` (pure) decides `shouldAutoStop` from
+  `(lastSoundAt, now, paused)`:
+  - While **paused**, the timer is **frozen** — elapsed silence does not
+    accumulate, and `lastSoundAt` is effectively reset on resume so a paused gap
+    never counts toward the 15 minutes.
+  - When `now − lastSoundAt ≥ SILENCE_TIMEOUT` (**15 min**) and not paused →
+    `shouldAutoStop = true`.
+- `RecorderPanel.vue` evaluates the watch on the existing 1-second timer tick;
+  on `shouldAutoStop` it runs the **same Stop path** as a manual/tray stop
+  (finalize + upload, or discard if under `MIN_DURATION`). For an auto recording
+  this is an additional safety net layered on top of mic-off detection —
+  whichever fires first wins.
+
 ## Settings
 
 - New toggle **"Auto-record meetings"** in `SettingsView.vue`, persisted to
@@ -204,12 +266,21 @@ rather than uploaded (guards against late mic-on/quick-off races).
   is alive until all release.
 - **Window/finalize crash:** `Destroyed` handler clears `RecordingState` so the
   monitor recovers.
+- **Silence during a real meeting:** continuous speech/system audio keeps
+  `lastSoundAt` fresh, so a normal meeting never trips the 15-min backstop.
+- **Long deliberate pause:** the silence timer is frozen while paused, so a
+  paused recording is never auto-stopped by the backstop.
+- **Forgotten recording after a call ends:** if mic-off detection somehow misses
+  (or it's a manual recording with no app to release the mic), 15 min of silence
+  finalizes it instead of recording indefinitely.
 
 ## Testing
 
 - **Pure unit (Vitest):**
   - `useAutoTrigger`: association resolution (current/none), confirm state
     machine (keep/discard/timeout via injected clock), min-duration discard.
+  - `silenceWatch`: accumulates to `shouldAutoStop` at 15 min via injected
+    clock; resets on sound activity; stays frozen while paused; resumes cleanly.
   - Reuse `pickDefaultMeeting` tests for the match boundary.
 - **Rust unit:** the state-machine transitions modeled as a pure function over
   `(state, external_pid_set, recording_active, now)` so debounce/snapshot logic
@@ -219,7 +290,8 @@ rather than uploaded (guards against late mic-on/quick-off races).
   confirm recorder opens and arms after ~3 s; end the call → confirm it stops
   after ~8 s and finalizes; verify manual recording suppresses auto-trigger;
   verify the confirm overlay keep/discard/timeout paths; verify the toggle
-  starts/stops the monitor live.
+  starts/stops the monitor live; verify a manual recording auto-stops after a
+  (test-shortened) silence window and that ongoing audio keeps it alive.
 
 ## Risks & verification items
 
@@ -233,4 +305,3 @@ rather than uploaded (guards against late mic-on/quick-off races).
    constants and behave consistently; keep the runtime-availability guard.
 4. **Poll interval vs. responsiveness/CPU** — 1 s poll is the starting point;
    switch to a CoreAudio property listener if a poll proves too laggy or costly.
-```

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -406,6 +406,10 @@ pub async fn upload_file(
 #[tauri::command]
 pub async fn set_tray_recording(app: tauri::AppHandle, is_recording: bool, is_paused: bool) -> Result<(), String> {
     crate::tray::set_menu(&app, is_recording, is_paused);
+    if !is_recording {
+        use tauri::Manager;
+        app.state::<crate::recording_state::RecordingState>().clear();
+    }
     Ok(())
 }
 
@@ -431,9 +435,15 @@ pub async fn create_settings_window(app: tauri::AppHandle) -> Result<(), String>
 }
 
 /// Shared helper to open the waveform recording window. Used by the
-/// `start_recording_window` command and by the tray (Local backend path).
-pub(crate) fn open_waveform_window(app: &tauri::AppHandle, meeting_id: Option<i64>) -> Result<(), String> {
-    use tauri::{WebviewUrl, WebviewWindowBuilder};
+/// `start_recording_window` command, the tray (Local backend path), and the
+/// auto mic monitor. `auto` adds `auto=1` to the URL and tags the shared
+/// `RecordingState` as an auto recording.
+pub(crate) fn open_waveform_window(
+    app: &tauri::AppHandle,
+    meeting_id: Option<i64>,
+    auto: bool,
+) -> Result<(), String> {
+    use tauri::{Manager, WebviewUrl, WebviewWindowBuilder};
 
     if let Some(picker) = app.get_webview_window("meeting-picker") {
         let _ = picker.close();
@@ -442,11 +452,14 @@ pub(crate) fn open_waveform_window(app: &tauri::AppHandle, meeting_id: Option<i6
         let _ = existing.set_focus();
         return Ok(());
     }
-    let url = match meeting_id {
+    let mut url = match meeting_id {
         Some(id) => format!("/#/waveform?meetingId={id}"),
         None => "/#/waveform".to_string(),
     };
-    WebviewWindowBuilder::new(app, "waveform", WebviewUrl::App(url.into()))
+    if auto {
+        url.push_str(if url.contains('?') { "&auto=1" } else { "?auto=1" });
+    }
+    let win = WebviewWindowBuilder::new(app, "waveform", WebviewUrl::App(url.into()))
         .title("")
         // Fixed size: room for the expanded pill plus its CSS shadow. The pill
         // itself is anchored to the bottom and grows upward within this window.
@@ -459,6 +472,25 @@ pub(crate) fn open_waveform_window(app: &tauri::AppHandle, meeting_id: Option<i6
         .skip_taskbar(true)
         .build()
         .map_err(|e| e.to_string())?;
+
+    let source = if auto {
+        crate::recording_state::RecordingSource::Auto
+    } else {
+        crate::recording_state::RecordingSource::Manual
+    };
+    app.state::<crate::recording_state::RecordingState>().set(source);
+
+    // If the window is destroyed without a clean stop (crash / force-close),
+    // clear the shared flag so the monitor can recover and re-arm.
+    let app_for_event = app.clone();
+    win.on_window_event(move |event| {
+        if let tauri::WindowEvent::Destroyed = event {
+            app_for_event
+                .state::<crate::recording_state::RecordingState>()
+                .clear();
+        }
+    });
+
     crate::tray::set_menu(app, true, false);
     Ok(())
 }
@@ -471,7 +503,7 @@ pub async fn start_recording_window(
     app: tauri::AppHandle,
     meeting_id: Option<i64>,
 ) -> Result<(), String> {
-    open_waveform_window(&app, meeting_id)
+    open_waveform_window(&app, meeting_id, false)
 }
 
 /// Show/focus the meeting-picker window, building it if absent. Shared by the

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -7,6 +7,7 @@ mod meeting_notifications;
 mod storage;
 mod transcribe;
 mod model_manager;
+mod recording_state;
 mod tray;
 mod update_manager;
 
@@ -62,6 +63,7 @@ fn main() {
             // Native meeting-prep notification orchestrator. Owns the Pusher
             // connection in the Rust process (webviews get suspended when
             // hidden). Self-gates on session + the enabled toggle.
+            app.manage(recording_state::RecordingState::new());
             app.manage(meeting_notifications::NotificationManager::new());
             // Install the macOS notification-click delegate on the main thread.
             meeting_notifications::init_native(app.handle());

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -4,6 +4,7 @@
 mod audio_capture;
 mod commands;
 mod meeting_notifications;
+mod mic_monitor;
 mod storage;
 mod transcribe;
 mod model_manager;

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -42,6 +42,8 @@ fn main() {
             model_manager::download_local_llm,
             meeting_notifications::sync_meeting_notifications,
             meeting_notifications::stop_meeting_notifications,
+            mic_monitor::sync_auto_record,
+            mic_monitor::auto_record_supported,
             audio_capture::start_system_audio_capture,
             audio_capture::stop_system_audio_capture,
             audio_capture::request_screen_capture_permission,
@@ -65,6 +67,13 @@ fn main() {
             // connection in the Rust process (webviews get suspended when
             // hidden). Self-gates on session + the enabled toggle.
             app.manage(recording_state::RecordingState::new());
+            app.manage(mic_monitor::MicMonitorManager::new());
+            // Start the auto-record mic monitor (self-gates on OS support + the
+            // enabled setting).
+            let mic_handle = app.handle().clone();
+            tauri::async_runtime::spawn(async move {
+                mic_monitor::sync(&mic_handle).await;
+            });
             app.manage(meeting_notifications::NotificationManager::new());
             // Install the macOS notification-click delegate on the main thread.
             meeting_notifications::init_native(app.handle());

--- a/src-tauri/src/mic_monitor.rs
+++ b/src-tauri/src/mic_monitor.rs
@@ -4,6 +4,9 @@
 //! sustained mic-off it emits `auto-record://stop`.
 
 use std::collections::HashSet;
+use std::sync::Mutex;
+use std::time::Duration;
+use tauri::{AppHandle, Emitter, Manager};
 
 /// Time (ms) an external app must hold the mic before we start recording.
 const START_DEBOUNCE_MS: u64 = 3_000;
@@ -188,6 +191,102 @@ pub fn is_supported() -> bool {
     {
         false
     }
+}
+
+const POLL_INTERVAL: Duration = Duration::from_secs(1);
+const SETTINGS_PATH: &str = "settings.json";
+const ENABLED_KEY: &str = "autoRecordEnabled";
+
+/// Holds the running monitor task (if any). Mirrors `NotificationManager`.
+#[derive(Default)]
+pub struct MicMonitorManager {
+    handle: Mutex<Option<tauri::async_runtime::JoinHandle<()>>>,
+}
+
+impl MicMonitorManager {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+/// Whether the user has auto-record enabled (defaults to true).
+fn enabled(app: &AppHandle) -> bool {
+    use tauri_plugin_store::StoreExt;
+    match app.store(SETTINGS_PATH) {
+        Ok(store) => !matches!(store.get(ENABLED_KEY), Some(serde_json::Value::Bool(false))),
+        Err(_) => true,
+    }
+}
+
+/// Start the monitor if supported and enabled; otherwise stop it. Safe to call
+/// repeatedly (startup, settings toggle).
+pub async fn sync(app: &AppHandle) {
+    let desired = is_supported() && enabled(app);
+    let mgr = app.state::<MicMonitorManager>();
+    let mut guard = mgr.handle.lock().unwrap();
+    if !desired {
+        if let Some(h) = guard.take() {
+            h.abort();
+        }
+        return;
+    }
+    if guard.is_some() {
+        return;
+    }
+    let app = app.clone();
+    *guard = Some(tauri::async_runtime::spawn(async move {
+        run_loop(app).await;
+    }));
+}
+
+/// Stop and tear down the monitor task.
+pub fn stop(app: &AppHandle) {
+    let mgr = app.state::<MicMonitorManager>();
+    let mut guard = mgr.handle.lock().unwrap();
+    if let Some(h) = guard.take() {
+        h.abort();
+    }
+}
+
+async fn run_loop(app: AppHandle) {
+    let mut machine = Machine::new();
+    let mut elapsed: u64 = 0;
+    loop {
+        let external = external_input_pids();
+        let recording_active = app
+            .state::<crate::recording_state::RecordingState>()
+            .is_active();
+        if let Some(action) = machine.tick(elapsed, &external, recording_active) {
+            match action {
+                Action::Start => {
+                    let app_main = app.clone();
+                    let _ = app.run_on_main_thread(move || {
+                        if let Err(e) =
+                            crate::commands::open_waveform_window(&app_main, None, true)
+                        {
+                            eprintln!("mic-monitor: failed to open recorder window: {e}");
+                        }
+                    });
+                }
+                Action::Stop => {
+                    let _ = app.emit("auto-record://stop", ());
+                }
+            }
+        }
+        tokio::time::sleep(POLL_INTERVAL).await;
+        elapsed = elapsed.saturating_add(POLL_INTERVAL.as_millis() as u64);
+    }
+}
+
+#[tauri::command]
+pub async fn sync_auto_record(app: AppHandle) -> Result<(), String> {
+    sync(&app).await;
+    Ok(())
+}
+
+#[tauri::command]
+pub fn auto_record_supported() -> bool {
+    is_supported()
 }
 
 #[cfg(target_os = "macos")]

--- a/src-tauri/src/mic_monitor.rs
+++ b/src-tauri/src/mic_monitor.rs
@@ -1,0 +1,166 @@
+//! Auto-trigger microphone monitor. Watches per-process audio input via
+//! CoreAudio (macOS 14.4+), excludes our own PID, and runs a debounced state
+//! machine. On a sustained external mic-on it opens the recorder window; on a
+//! sustained mic-off it emits `auto-record://stop`.
+
+use std::collections::HashSet;
+
+/// Time (ms) an external app must hold the mic before we start recording.
+const START_DEBOUNCE_MS: u64 = 3_000;
+/// Time (ms) the triggering apps must all stay released before we stop.
+const STOP_DEBOUNCE_MS: u64 = 8_000;
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum Action {
+    Start,
+    Stop,
+}
+
+#[derive(Debug, Default)]
+enum Phase {
+    #[default]
+    Idle,
+    Arming {
+        since: u64,
+    },
+    Recording {
+        trigger: HashSet<i32>,
+    },
+    Stopping {
+        trigger: HashSet<i32>,
+        since: u64,
+    },
+}
+
+#[derive(Default)]
+pub struct Machine {
+    phase: Phase,
+}
+
+impl Machine {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Advance one tick. `now` is a monotonic millisecond counter. `external`
+    /// is the set of PIDs (excluding our own) currently running audio input.
+    /// `recording_active` is whether any recording (manual or auto) is in
+    /// progress. Returns an `Action` when a transition demands one.
+    pub fn tick(
+        &mut self,
+        now: u64,
+        external: &HashSet<i32>,
+        recording_active: bool,
+    ) -> Option<Action> {
+        match &self.phase {
+            Phase::Idle => {
+                if !external.is_empty() && !recording_active {
+                    self.phase = Phase::Arming { since: now };
+                }
+                None
+            }
+            Phase::Arming { since } => {
+                if external.is_empty() {
+                    self.phase = Phase::Idle;
+                    None
+                } else if now.saturating_sub(*since) >= START_DEBOUNCE_MS {
+                    if recording_active {
+                        self.phase = Phase::Idle;
+                        None
+                    } else {
+                        // Snapshot the triggering PIDs; only these decide when
+                        // the meeting is over, so our own later capture (a new
+                        // PID) never keeps it artificially alive.
+                        self.phase = Phase::Recording {
+                            trigger: external.clone(),
+                        };
+                        Some(Action::Start)
+                    }
+                } else {
+                    None
+                }
+            }
+            Phase::Recording { trigger } => {
+                let alive = trigger.iter().any(|p| external.contains(p));
+                if !alive {
+                    self.phase = Phase::Stopping {
+                        trigger: trigger.clone(),
+                        since: now,
+                    };
+                }
+                None
+            }
+            Phase::Stopping { trigger, since } => {
+                let alive = trigger.iter().any(|p| external.contains(p));
+                if alive {
+                    self.phase = Phase::Recording {
+                        trigger: trigger.clone(),
+                    };
+                    None
+                } else if now.saturating_sub(*since) >= STOP_DEBOUNCE_MS {
+                    self.phase = Phase::Idle;
+                    Some(Action::Stop)
+                } else {
+                    None
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn pids(list: &[i32]) -> HashSet<i32> {
+        list.iter().copied().collect()
+    }
+
+    #[test]
+    fn brief_blip_does_not_start() {
+        let mut m = Machine::new();
+        assert_eq!(m.tick(0, &pids(&[42]), false), None); // -> Arming
+        // Mic released before the 3s debounce elapses.
+        assert_eq!(m.tick(1_000, &pids(&[]), false), None); // -> Idle
+        assert_eq!(m.tick(5_000, &pids(&[]), false), None);
+    }
+
+    #[test]
+    fn sustained_mic_starts_after_debounce() {
+        let mut m = Machine::new();
+        assert_eq!(m.tick(0, &pids(&[42]), false), None); // Arming
+        assert_eq!(m.tick(2_000, &pids(&[42]), false), None); // still arming
+        assert_eq!(m.tick(3_000, &pids(&[42]), false), Some(Action::Start));
+    }
+
+    #[test]
+    fn active_recording_suppresses_start() {
+        let mut m = Machine::new();
+        // recording_active true keeps us out of Arming entirely.
+        assert_eq!(m.tick(0, &pids(&[42]), true), None);
+        assert_eq!(m.tick(3_000, &pids(&[42]), true), None);
+    }
+
+    #[test]
+    fn stops_after_trigger_pids_release() {
+        let mut m = Machine::new();
+        m.tick(0, &pids(&[42]), false);
+        assert_eq!(m.tick(3_000, &pids(&[42]), false), Some(Action::Start));
+        // Our own capture appears as a new PID — must be ignored.
+        assert_eq!(m.tick(4_000, &pids(&[42, 99]), false), None);
+        // Trigger app releases; only PID 99 (ours) remains.
+        assert_eq!(m.tick(5_000, &pids(&[99]), false), None); // -> Stopping
+        assert_eq!(m.tick(13_000, &pids(&[99]), false), Some(Action::Stop));
+    }
+
+    #[test]
+    fn reacquire_during_stopping_cancels_stop() {
+        let mut m = Machine::new();
+        m.tick(0, &pids(&[42]), false);
+        m.tick(3_000, &pids(&[42]), false); // Start
+        m.tick(4_000, &pids(&[]), false); // Stopping
+        // Trigger app comes back before the 8s stop debounce.
+        assert_eq!(m.tick(6_000, &pids(&[42]), false), None); // -> Recording
+        assert_eq!(m.tick(20_000, &pids(&[42]), false), None); // stays recording
+    }
+}

--- a/src-tauri/src/mic_monitor.rs
+++ b/src-tauri/src/mic_monitor.rs
@@ -164,3 +164,167 @@ mod tests {
         assert_eq!(m.tick(20_000, &pids(&[42]), false), None); // stays recording
     }
 }
+
+/// PIDs (excluding our own) currently running audio input, via CoreAudio.
+/// Returns an empty set off macOS or when the API is unavailable.
+fn external_input_pids() -> HashSet<i32> {
+    #[cfg(target_os = "macos")]
+    {
+        coreaudio::external_input_pids(std::process::id() as i32)
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        HashSet::new()
+    }
+}
+
+/// Whether the per-process input API (macOS 14.4+) is available at runtime.
+pub fn is_supported() -> bool {
+    #[cfg(target_os = "macos")]
+    {
+        coreaudio::is_supported()
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        false
+    }
+}
+
+#[cfg(target_os = "macos")]
+mod coreaudio {
+    use std::collections::HashSet;
+    use std::ffi::c_void;
+
+    type OSStatus = i32;
+    type AudioObjectID = u32;
+
+    const SYSTEM_OBJECT: AudioObjectID = 1; // kAudioObjectSystemObject
+    const SCOPE_GLOBAL: u32 = fourcc(b"glob"); // kAudioObjectPropertyScopeGlobal
+    const ELEMENT_MAIN: u32 = 0; // kAudioObjectPropertyElementMain
+    const PROCESS_OBJECT_LIST: u32 = fourcc(b"prs#"); // kAudioHardwarePropertyProcessObjectList
+    const PROCESS_PID: u32 = fourcc(b"ppid"); // kAudioProcessPropertyPID
+    const IS_RUNNING_INPUT: u32 = fourcc(b"piri"); // kAudioProcessPropertyIsRunningInput (14.4+)
+
+    const fn fourcc(s: &[u8; 4]) -> u32 {
+        ((s[0] as u32) << 24) | ((s[1] as u32) << 16) | ((s[2] as u32) << 8) | (s[3] as u32)
+    }
+
+    #[repr(C)]
+    struct AudioObjectPropertyAddress {
+        selector: u32,
+        scope: u32,
+        element: u32,
+    }
+
+    #[link(name = "CoreAudio", kind = "framework")]
+    unsafe extern "C" {
+        fn AudioObjectGetPropertyDataSize(
+            object: AudioObjectID,
+            address: *const AudioObjectPropertyAddress,
+            qualifier_size: u32,
+            qualifier: *const c_void,
+            out_size: *mut u32,
+        ) -> OSStatus;
+
+        fn AudioObjectGetPropertyData(
+            object: AudioObjectID,
+            address: *const AudioObjectPropertyAddress,
+            qualifier_size: u32,
+            qualifier: *const c_void,
+            io_size: *mut u32,
+            out_data: *mut c_void,
+        ) -> OSStatus;
+    }
+
+    fn global_address(selector: u32) -> AudioObjectPropertyAddress {
+        AudioObjectPropertyAddress {
+            selector,
+            scope: SCOPE_GLOBAL,
+            element: ELEMENT_MAIN,
+        }
+    }
+
+    fn process_object_list() -> Option<Vec<AudioObjectID>> {
+        let addr = global_address(PROCESS_OBJECT_LIST);
+        let mut size: u32 = 0;
+        let status = unsafe {
+            AudioObjectGetPropertyDataSize(SYSTEM_OBJECT, &addr, 0, std::ptr::null(), &mut size)
+        };
+        if status != 0 {
+            return None;
+        }
+        let count = size as usize / std::mem::size_of::<AudioObjectID>();
+        let mut ids: Vec<AudioObjectID> = vec![0; count];
+        if count == 0 {
+            return Some(ids);
+        }
+        let status = unsafe {
+            AudioObjectGetPropertyData(
+                SYSTEM_OBJECT,
+                &addr,
+                0,
+                std::ptr::null(),
+                &mut size,
+                ids.as_mut_ptr() as *mut c_void,
+            )
+        };
+        if status != 0 {
+            return None;
+        }
+        Some(ids)
+    }
+
+    fn read_u32(object: AudioObjectID, selector: u32) -> Option<u32> {
+        let addr = global_address(selector);
+        let mut size: u32 = std::mem::size_of::<u32>() as u32;
+        let mut value: u32 = 0;
+        let status = unsafe {
+            AudioObjectGetPropertyData(
+                object,
+                &addr,
+                0,
+                std::ptr::null(),
+                &mut size,
+                &mut value as *mut u32 as *mut c_void,
+            )
+        };
+        if status != 0 {
+            None
+        } else {
+            Some(value)
+        }
+    }
+
+    pub fn external_input_pids(our_pid: i32) -> HashSet<i32> {
+        let mut set = HashSet::new();
+        let Some(objects) = process_object_list() else {
+            return set;
+        };
+        for obj in objects {
+            if read_u32(obj, IS_RUNNING_INPUT).unwrap_or(0) == 0 {
+                continue;
+            }
+            if let Some(pid) = read_u32(obj, PROCESS_PID).map(|v| v as i32) {
+                if pid > 0 && pid != our_pid {
+                    set.insert(pid);
+                }
+            }
+        }
+        set
+    }
+
+    /// Probe availability: the process-object-list selector is 14.0+, and the
+    /// IsRunningInput property is 14.4+. If either read fails the API is
+    /// unavailable on this OS and the monitor must stay off.
+    pub fn is_supported() -> bool {
+        let Some(objects) = process_object_list() else {
+            return false;
+        };
+        match objects.first() {
+            Some(&obj) => read_u32(obj, IS_RUNNING_INPUT).is_some(),
+            // No audio processes to probe right now — the list call succeeded,
+            // which already requires 14.0+; treat as supported.
+            None => true,
+        }
+    }
+}

--- a/src-tauri/src/recording_state.rs
+++ b/src-tauri/src/recording_state.rs
@@ -1,0 +1,57 @@
+//! Shared "is a recording in progress" flag, set when a recorder window opens
+//! (manual via tray or auto via the mic monitor) and cleared when it stops or
+//! is destroyed. The mic monitor reads it to suppress auto-triggers — and to
+//! avoid self-triggering off a manual recording — regardless of which PID
+//! macOS attributes our own capture to.
+
+use std::sync::Mutex;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RecordingSource {
+    Manual,
+    Auto,
+}
+
+#[derive(Default)]
+pub struct RecordingState {
+    inner: Mutex<Option<RecordingSource>>,
+}
+
+impl RecordingState {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn set(&self, source: RecordingSource) {
+        *self.inner.lock().unwrap() = Some(source);
+    }
+
+    pub fn clear(&self) {
+        *self.inner.lock().unwrap() = None;
+    }
+
+    pub fn is_active(&self) -> bool {
+        self.inner.lock().unwrap().is_some()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn starts_inactive() {
+        assert!(!RecordingState::new().is_active());
+    }
+
+    #[test]
+    fn set_marks_active_clear_resets() {
+        let s = RecordingState::new();
+        s.set(RecordingSource::Manual);
+        assert!(s.is_active());
+        s.set(RecordingSource::Auto);
+        assert!(s.is_active());
+        s.clear();
+        assert!(!s.is_active());
+    }
+}

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -51,7 +51,7 @@ pub fn create_tray(app: &AppHandle) -> tauri::Result<()> {
                                     let _ = app_main.emit("tray://show-model-prompt", ());
                                     return;
                                 }
-                                let _ = crate::commands::open_waveform_window(&app_main, None);
+                                let _ = crate::commands::open_waveform_window(&app_main, None, false);
                             });
                             return;
                         }

--- a/src/composables/silenceWatch.test.ts
+++ b/src/composables/silenceWatch.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { shouldAutoStop, SILENCE_TIMEOUT_MS } from './silenceWatch';
+
+describe('shouldAutoStop', () => {
+  it('is false before the timeout elapses', () => {
+    expect(shouldAutoStop(0, SILENCE_TIMEOUT_MS - 1, false)).toBe(false);
+  });
+
+  it('is true at or past the timeout', () => {
+    expect(shouldAutoStop(0, SILENCE_TIMEOUT_MS, false)).toBe(true);
+    expect(shouldAutoStop(0, SILENCE_TIMEOUT_MS + 5_000, false)).toBe(true);
+  });
+
+  it('is frozen (false) while paused, even past the timeout', () => {
+    expect(shouldAutoStop(0, SILENCE_TIMEOUT_MS + 60_000, true)).toBe(false);
+  });
+
+  it('honors a custom timeout', () => {
+    expect(shouldAutoStop(1_000, 2_000, false, 2_000)).toBe(false);
+    expect(shouldAutoStop(1_000, 3_000, false, 2_000)).toBe(true);
+  });
+});

--- a/src/composables/silenceWatch.ts
+++ b/src/composables/silenceWatch.ts
@@ -1,0 +1,21 @@
+/** Universal silence backstop: 15 minutes of no captured sound ends any
+ *  recording (manual or auto). Pure so it can be unit-tested with explicit
+ *  timestamps. */
+export const SILENCE_TIMEOUT_MS = 15 * 60_000;
+
+/**
+ * Whether a recording should auto-stop due to silence.
+ *
+ * Frozen while paused — a deliberately paused recording is never auto-stopped,
+ * and (because the caller resets `lastSoundAt` on resume) a paused gap never
+ * counts toward the timeout.
+ */
+export function shouldAutoStop(
+  lastSoundAt: number,
+  now: number,
+  paused: boolean,
+  timeoutMs: number = SILENCE_TIMEOUT_MS,
+): boolean {
+  if (paused) return false;
+  return now - lastSoundAt >= timeoutMs;
+}

--- a/src/composables/useAutoRecord.test.ts
+++ b/src/composables/useAutoRecord.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const storeGet = vi.fn();
+const storeSet = vi.fn(() => Promise.resolve());
+const emit = vi.fn(() => Promise.resolve());
+const invoke = vi.fn();
+
+vi.mock('@tauri-apps/plugin-store', () => ({
+  load: () => Promise.resolve({ get: storeGet, set: storeSet }),
+}));
+vi.mock('@tauri-apps/api/event', () => ({ emit: (...a: unknown[]) => emit(...a) }));
+vi.mock('@tauri-apps/api/core', () => ({ invoke: (...a: unknown[]) => invoke(...a) }));
+
+import {
+  isAutoRecordEnabled,
+  setAutoRecordEnabled,
+  isAutoRecordSupported,
+  AUTO_RECORD_SYNC_EVENT,
+} from './useAutoRecord';
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('useAutoRecord', () => {
+  it('defaults to enabled when unset', async () => {
+    storeGet.mockResolvedValue(undefined);
+    expect(await isAutoRecordEnabled()).toBe(true);
+  });
+
+  it('is disabled only when explicitly false', async () => {
+    storeGet.mockResolvedValue(false);
+    expect(await isAutoRecordEnabled()).toBe(false);
+  });
+
+  it('persists and broadcasts a sync on set', async () => {
+    await setAutoRecordEnabled(false);
+    expect(storeSet).toHaveBeenCalledWith('autoRecordEnabled', false);
+    expect(emit).toHaveBeenCalledWith(AUTO_RECORD_SYNC_EVENT);
+  });
+
+  it('reports support via the native command, false on error', async () => {
+    invoke.mockResolvedValueOnce(true);
+    expect(await isAutoRecordSupported()).toBe(true);
+    invoke.mockRejectedValueOnce(new Error('nope'));
+    expect(await isAutoRecordSupported()).toBe(false);
+  });
+});

--- a/src/composables/useAutoRecord.ts
+++ b/src/composables/useAutoRecord.ts
@@ -1,0 +1,34 @@
+import { invoke } from '@tauri-apps/api/core';
+import { load } from '@tauri-apps/plugin-store';
+import { emit } from '@tauri-apps/api/event';
+
+// The mic monitor lives natively in Rust (src-tauri/src/mic_monitor.rs). This
+// module owns only the settings toggle + support probe, and broadcasts a sync
+// so the native monitor re-evaluates (start/stop) without an app restart.
+
+const SETTINGS_PATH = 'settings.json';
+const ENABLED_KEY = 'autoRecordEnabled';
+export const AUTO_RECORD_SYNC_EVENT = 'auto-record-sync';
+
+/** Whether auto-record is enabled (defaults to true). */
+export async function isAutoRecordEnabled(): Promise<boolean> {
+  const store = await load(SETTINGS_PATH, { autoSave: true });
+  const value = await store.get<boolean>(ENABLED_KEY);
+  return value !== false;
+}
+
+/** Persist the enabled flag and broadcast a sync so the monitor reacts. */
+export async function setAutoRecordEnabled(enabled: boolean): Promise<void> {
+  const store = await load(SETTINGS_PATH, { autoSave: true });
+  await store.set(ENABLED_KEY, enabled);
+  await emit(AUTO_RECORD_SYNC_EVENT);
+}
+
+/** Whether the OS supports per-process mic detection (macOS 14.4+). */
+export async function isAutoRecordSupported(): Promise<boolean> {
+  try {
+    return await invoke<boolean>('auto_record_supported');
+  } catch {
+    return false;
+  }
+}

--- a/src/composables/useAutoTrigger.test.ts
+++ b/src/composables/useAutoTrigger.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { resolveAssociation } from './useAutoTrigger';
+import type { ScheduledMeeting } from './useMeetingApi';
+
+const now = new Date('2026-06-10T10:00:00Z');
+
+function meeting(id: number, startAt: string): ScheduledMeeting {
+  return { id, title: `M${id}`, start_at: startAt };
+}
+
+describe('resolveAssociation', () => {
+  it('local backend always falls back to confirm', () => {
+    const current = [meeting(1, '2026-06-10T09:58:00Z')];
+    expect(resolveAssociation('local', current, now)).toEqual({ kind: 'confirm' });
+  });
+
+  it('ariso with a current meeting matches it', () => {
+    const meetings = [meeting(7, '2026-06-10T09:58:00Z')]; // within -5/+60min
+    expect(resolveAssociation('ariso', meetings, now)).toEqual({
+      kind: 'matched',
+      meetingId: 7,
+    });
+  });
+
+  it('ariso with only a future meeting falls back to confirm', () => {
+    const meetings = [meeting(8, '2026-06-10T12:00:00Z')];
+    expect(resolveAssociation('ariso', meetings, now)).toEqual({ kind: 'confirm' });
+  });
+
+  it('ariso with no meetings falls back to confirm', () => {
+    expect(resolveAssociation('ariso', [], now)).toEqual({ kind: 'confirm' });
+  });
+});

--- a/src/composables/useAutoTrigger.ts
+++ b/src/composables/useAutoTrigger.ts
@@ -1,0 +1,27 @@
+import type { BackendId } from './useBackend';
+import type { ScheduledMeeting } from './useMeetingApi';
+import { pickDefaultMeeting } from './pickDefaultMeeting';
+
+export interface Association {
+  /** 'matched' → attach to a current calendar meeting; 'confirm' → ask the user. */
+  kind: 'matched' | 'confirm';
+  meetingId?: number;
+}
+
+/**
+ * Decide how an auto-triggered recording associates. Only the Ariso backend has
+ * a calendar; a meeting "happening now" (per `pickDefaultMeeting`) is matched,
+ * otherwise — and always for Local — we fall back to a user confirmation.
+ */
+export function resolveAssociation(
+  backendId: BackendId,
+  meetings: ScheduledMeeting[],
+  now: Date,
+): Association {
+  if (backendId !== 'ariso') return { kind: 'confirm' };
+  const picked = pickDefaultMeeting(meetings, now);
+  if (picked.kind === 'current' && picked.featured) {
+    return { kind: 'matched', meetingId: picked.featured.id };
+  }
+  return { kind: 'confirm' };
+}

--- a/src/composables/useRecorder.ts
+++ b/src/composables/useRecorder.ts
@@ -10,6 +10,10 @@ const hasTauri =
   typeof window !== 'undefined' &&
   ('__TAURI__' in window || '__TAURI_INTERNALS__' in window);
 
+// Peak (absolute Int16) below which a frame counts as "no sound activity".
+// ~0.01 of full scale (32768) — above the noise floor, below real speech.
+const SILENCE_LEVEL = 300;
+
 export function useRecorder() {
   const isRecording: Ref<boolean> = ref(false);
   const isPaused: Ref<boolean> = ref(false);
@@ -17,6 +21,9 @@ export function useRecorder() {
   const durationSeconds: Ref<number> = ref(0);
   const startedAt: Ref<string | null> = ref(null);
   const systemAudioSupported: Ref<boolean> = ref(hasTauri);
+  // Wall-clock of the last frame that carried real sound, for the silence
+  // backstop. Seeded on start and reset on resume so paused gaps don't count.
+  const lastSoundAt: Ref<number> = ref(Date.now());
 
   let audioContext: AudioContext | null = null;
   let micStream: MediaStream | null = null;
@@ -156,6 +163,7 @@ export function useRecorder() {
       processor.onaudioprocess = (e: AudioProcessingEvent) => {
         if (!isRecording.value || isPaused.value || !mp3Encoder) return;
         const frame = e.inputBuffer.length;
+        let drainPeakRef: Int16Array = new Int16Array(0);
 
         // Mic channel (silent zero when mic is disabled)
         const micInt16 = new Int16Array(frame);
@@ -175,6 +183,7 @@ export function useRecorder() {
           if (sysRaw) {
             sysInt16.set(sysRaw.slice(0, micInt16.length));
           }
+          drainPeakRef = sysInt16;
           mp3buf = mp3Encoder.encodeBuffer(micInt16, sysInt16);
         } else if (useSystemAudio) {
           // System-audio-only: mono encode from the ring buffer, and feed the
@@ -185,6 +194,7 @@ export function useRecorder() {
           if (sysRaw) {
             sysInt16.set(sysRaw.slice(0, frame));
           }
+          drainPeakRef = sysInt16;
           mp3buf = mp3Encoder.encodeBuffer(sysInt16);
           const out = e.outputBuffer.getChannelData(0);
           for (let i = 0; i < frame; i++) out[i] = sysInt16[i] / 0x8000;
@@ -195,6 +205,24 @@ export function useRecorder() {
 
         if (mp3buf.length > 0) {
           mp3Chunks.push(new Int8Array(mp3buf));
+        }
+
+        // Silence backstop: note the time if this frame carried real sound on
+        // any active source (mic and/or system).
+        let peak = 0;
+        for (let i = 0; i < micInt16.length; i++) {
+          const a = Math.abs(micInt16[i]);
+          if (a > peak) peak = a;
+        }
+        if (useSystemAudio) {
+          const sys = drainPeakRef;
+          for (let i = 0; i < sys.length; i++) {
+            const a = Math.abs(sys[i]);
+            if (a > peak) peak = a;
+          }
+        }
+        if (peak >= SILENCE_LEVEL) {
+          lastSoundAt.value = Date.now();
         }
       };
 
@@ -215,6 +243,7 @@ export function useRecorder() {
       isRecording.value = true;
       isPaused.value = false;
       startedAt.value = new Date().toISOString();
+      lastSoundAt.value = Date.now();
 
       timerInterval = setInterval(() => {
         if (!isPaused.value) {
@@ -235,6 +264,8 @@ export function useRecorder() {
 
   function resumeRecording(): void {
     if (!isRecording.value || !isPaused.value) return;
+    // Reset so the paused interval never counts as silence.
+    lastSoundAt.value = Date.now();
     isPaused.value = false;
   }
 
@@ -341,6 +372,7 @@ export function useRecorder() {
     error,
     durationSeconds,
     startedAt,
+    lastSoundAt,
     systemAudioSupported,
     getAnalyser,
     startRecording,

--- a/src/views/BootstrapView.vue
+++ b/src/views/BootstrapView.vue
@@ -3,11 +3,13 @@ import { onMounted, onUnmounted } from 'vue';
 import { listen, type UnlistenFn } from '@tauri-apps/api/event';
 import { invoke } from '@tauri-apps/api/core';
 import { SYNC_EVENT } from '../composables/useMeetingNotifications';
+import { AUTO_RECORD_SYNC_EVENT } from '../composables/useAutoRecord';
 
 // The notification orchestrator lives natively in Rust; this window just asks
 // it to re-evaluate (session + enabled toggle) on launch and whenever a sync
 // is broadcast (sign-in/out, settings toggle).
 let unlisten: UnlistenFn | null = null;
+let unlistenAuto: UnlistenFn | null = null;
 let disposed = false;
 
 onMounted(async () => {
@@ -24,12 +26,24 @@ onMounted(async () => {
   }
   unlisten = off;
   void invoke('sync_meeting_notifications');
+
+  const offAuto = await listen(AUTO_RECORD_SYNC_EVENT, () => {
+    void invoke('sync_auto_record');
+  });
+  if (disposed) {
+    offAuto();
+  } else {
+    unlistenAuto = offAuto;
+    void invoke('sync_auto_record');
+  }
 });
 
 onUnmounted(() => {
   disposed = true;
   unlisten?.();
   unlisten = null;
+  unlistenAuto?.();
+  unlistenAuto = null;
 });
 </script>
 

--- a/src/views/SettingsView.vue
+++ b/src/views/SettingsView.vue
@@ -137,6 +137,25 @@
         <p v-else-if="systemAudioStatus === 'denied'" class="notif-status notif-status--err">
           Permission not granted
         </p>
+
+        <div class="setting-row" style="margin-top: 16px">
+          <span class="setting-label">Auto-record meetings</span>
+          <label class="toggle">
+            <input
+              type="checkbox"
+              class="toggle-input"
+              :checked="autoRecordEnabled"
+              :disabled="!autoRecordSupported"
+              @change="onToggleAutoRecord"
+            />
+            <span class="toggle-track">
+              <span class="toggle-thumb"></span>
+            </span>
+          </label>
+        </div>
+        <p v-if="!autoRecordSupported" class="notif-status notif-status--err">
+          Requires macOS 14.4+
+        </p>
       </div>
     </section>
 
@@ -236,6 +255,11 @@ import {
   openNotificationSettings,
   emitNotificationsSync,
 } from '../composables/useMeetingNotifications';
+import {
+  isAutoRecordEnabled,
+  setAutoRecordEnabled,
+  isAutoRecordSupported,
+} from '../composables/useAutoRecord';
 
 const isSignedIn = ref(false);
 const isSigningIn = ref(false);
@@ -244,6 +268,8 @@ const displayName = ref('');
 const email = ref('');
 const micEnabled = ref(true);
 const systemAudioEnabled = ref(true);
+const autoRecordEnabled = ref(true);
+const autoRecordSupported = ref(true);
 const micStatus = ref<PermissionStatus>('');
 const systemAudioStatus = ref<PermissionStatus>('');
 const micToggling = ref(false);
@@ -474,6 +500,17 @@ async function onToggleMic(e: Event) {
   }
 }
 
+async function onToggleAutoRecord(e: Event) {
+  const checked = (e.target as HTMLInputElement).checked;
+  const previous = autoRecordEnabled.value;
+  autoRecordEnabled.value = checked;
+  try {
+    await setAutoRecordEnabled(checked);
+  } catch {
+    autoRecordEnabled.value = previous;
+  }
+}
+
 async function onToggleSystemAudio(e: Event) {
   if (recordingToggleBusy.value) return;
   systemAudioToggling.value = true;
@@ -521,6 +558,8 @@ onMounted(async () => {
     const enabled = await loadRecordingEnabled();
     micEnabled.value = enabled.mic;
     systemAudioEnabled.value = enabled.systemAudio;
+    autoRecordSupported.value = await isAutoRecordSupported();
+    autoRecordEnabled.value = await isAutoRecordEnabled();
     // Reflect the current Screen Recording status without prompting. (Mic status
     // is intentionally left blank on load — there's no silent mic preflight as
     // clean as CGPreflightScreenCaptureAccess, and getUserMedia would prompt.)

--- a/src/views/WaveformView.test.ts
+++ b/src/views/WaveformView.test.ts
@@ -23,6 +23,7 @@ vi.mock('../composables/useRecorder', () => ({
     isRecording: { value: true },
     isPaused: { value: false },
     durationSeconds: { value: 5 },
+    lastSoundAt: { value: 0 },
     startedAt: { value: '2026-06-09T10:00:00Z' },
     getAnalyser,
     startRecording: (...a: unknown[]) => startRecording(...a),
@@ -111,6 +112,7 @@ describe('WaveformView vertical pill', () => {
 
   it('stops, finalizes, shows ✓, and auto-closes on success', async () => {
     vi.useFakeTimers();
+    vi.setSystemTime(0); // keep Date.now() at epoch so silence backstop (lastSoundAt=0) never trips
     stopRecording.mockResolvedValue(new Blob([new Uint8Array([1, 2, 3])], { type: 'audio/mpeg' }));
     finalizeRecording.mockResolvedValue({ backend: 'local' });
     const wrapper = mount(WaveformView);
@@ -133,5 +135,19 @@ describe('WaveformView vertical pill', () => {
     await flushPromises();
     expect(wrapper.find('.status-icon.err').exists()).toBe(true);
     expect(closeWin).not.toHaveBeenCalled();
+  });
+
+  it('auto-stops after the silence timeout elapses', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(16 * 60_000); // now well past lastSoundAt (0) + 15min
+    finalizeRecording.mockResolvedValue({ backend: 'local' });
+    const wrapper = mount(WaveformView);
+    await flushPromises();
+    stopRecording.mockResolvedValue(new Blob(['x'], { type: 'audio/mpeg' }));
+    await vi.advanceTimersByTimeAsync(1_100);
+    await flushPromises();
+    expect(stopRecording).toHaveBeenCalled();
+    vi.useRealTimers();
+    wrapper.unmount();
   });
 });

--- a/src/views/WaveformView.test.ts
+++ b/src/views/WaveformView.test.ts
@@ -17,7 +17,8 @@ vi.mock('@tauri-apps/api/event', () => ({ listen: vi.fn(() => Promise.resolve(()
 vi.mock('@tauri-apps/api/webviewWindow', () => ({
   getCurrentWebviewWindow: () => ({ close: closeWin }),
 }));
-vi.mock('vue-router', () => ({ useRoute: () => ({ query: {} }) }));
+let routeQuery: Record<string, string> = {};
+vi.mock('vue-router', () => ({ useRoute: () => ({ query: routeQuery }) }));
 vi.mock('../composables/useRecorder', () => ({
   useRecorder: () => ({
     isRecording: { value: true },
@@ -47,10 +48,20 @@ vi.mock('../composables/useRecordingPermissions', () => ({
   loadRecordingEnabled: () => loadRecordingEnabled(),
 }));
 
+const listScheduledMeetings = vi.fn(() => Promise.resolve([]));
+vi.mock('../composables/useMeetingApi', () => ({
+  useMeetingApi: () => ({ listScheduledMeetings: (...a: unknown[]) => listScheduledMeetings(...a) }),
+}));
+
+vi.mock('../composables/useAutoTrigger', () => ({
+  resolveAssociation: vi.fn(() => ({ kind: 'confirm' })),
+}));
+
 import WaveformView from './WaveformView.vue';
 
 beforeEach(() => {
   vi.clearAllMocks();
+  routeQuery = {};
   loadRecordingEnabled.mockResolvedValue({ mic: true, systemAudio: false });
 });
 afterEach(() => vi.restoreAllMocks());
@@ -148,6 +159,17 @@ describe('WaveformView vertical pill', () => {
     await flushPromises();
     expect(stopRecording).toHaveBeenCalled();
     vi.useRealTimers();
+    wrapper.unmount();
+  });
+
+  it('auto mode with no calendar match shows the confirm overlay', async () => {
+    routeQuery = { auto: '1' };
+    listScheduledMeetings.mockResolvedValue([]);
+    const wrapper = mount(WaveformView);
+    await flushPromises();
+    expect(wrapper.find('.confirm').exists()).toBe(true);
+    expect(wrapper.find('.keep-btn').exists()).toBe(true);
+    routeQuery = {};
     wrapper.unmount();
   });
 });

--- a/src/views/WaveformView.test.ts
+++ b/src/views/WaveformView.test.ts
@@ -13,7 +13,13 @@ const closeWin = vi.fn(() => Promise.resolve());
 const invoke = vi.fn(() => Promise.resolve());
 
 vi.mock('@tauri-apps/api/core', () => ({ invoke: (...a: unknown[]) => invoke(...a) }));
-vi.mock('@tauri-apps/api/event', () => ({ listen: vi.fn(() => Promise.resolve(() => {})) }));
+const eventHandlers: Record<string, (e: unknown) => void> = {};
+vi.mock('@tauri-apps/api/event', () => ({
+  listen: vi.fn((name: string, cb: (e: unknown) => void) => {
+    eventHandlers[name] = cb;
+    return Promise.resolve(() => {});
+  }),
+}));
 vi.mock('@tauri-apps/api/webviewWindow', () => ({
   getCurrentWebviewWindow: () => ({ close: closeWin }),
 }));
@@ -57,6 +63,7 @@ import WaveformView from './WaveformView.vue';
 
 beforeEach(() => {
   vi.clearAllMocks();
+  for (const k in eventHandlers) delete eventHandlers[k];
   routeQuery = {};
   loadRecordingEnabled.mockResolvedValue({ mic: true, systemAudio: false });
 });
@@ -165,6 +172,24 @@ describe('WaveformView vertical pill', () => {
     await flushPromises();
     expect(wrapper.find('.confirm').exists()).toBe(true);
     expect(wrapper.find('.keep-btn').exists()).toBe(true);
+    routeQuery = {};
+    wrapper.unmount();
+  });
+
+  it('discards (does not upload) when stopped while the confirm overlay is unanswered', async () => {
+    routeQuery = { auto: '1' };
+    listScheduledMeetings.mockResolvedValue([]);
+    const wrapper = mount(WaveformView);
+    await flushPromises();
+    // Confirm overlay should be showing (local backend, no match).
+    expect(wrapper.find('.confirm').exists()).toBe(true);
+    stopRecording.mockResolvedValue(new Blob(['x'], { type: 'audio/mpeg' }));
+    // A native mic-off stop arrives before the user answers.
+    await eventHandlers['auto-record://stop']?.({});
+    await flushPromises();
+    // Must NOT have uploaded; must have stopped + closed.
+    expect(finalizeRecording).not.toHaveBeenCalled();
+    expect(stopRecording).toHaveBeenCalled();
     routeQuery = {};
     wrapper.unmount();
   });

--- a/src/views/WaveformView.test.ts
+++ b/src/views/WaveformView.test.ts
@@ -53,10 +53,6 @@ vi.mock('../composables/useMeetingApi', () => ({
   useMeetingApi: () => ({ listScheduledMeetings: (...a: unknown[]) => listScheduledMeetings(...a) }),
 }));
 
-vi.mock('../composables/useAutoTrigger', () => ({
-  resolveAssociation: vi.fn(() => ({ kind: 'confirm' })),
-}));
-
 import WaveformView from './WaveformView.vue';
 
 beforeEach(() => {

--- a/src/views/WaveformView.vue
+++ b/src/views/WaveformView.vue
@@ -83,6 +83,7 @@ import { getActiveBackend, type Backend } from '../composables/useBackend';
 import { loadRecordingEnabled } from '../composables/useRecordingPermissions';
 import { deriveRecordingMode } from './recordingSettings';
 import { bucketLevels } from './waveformBars';
+import { shouldAutoStop } from '../composables/silenceWatch';
 
 const SUCCESS_CLOSE_MS = 1500;
 
@@ -136,6 +137,7 @@ let unlistenPause: UnlistenFn | null = null;
 let unlistenResume: UnlistenFn | null = null;
 let unlistenStop: UnlistenFn | null = null;
 let closeTimer: ReturnType<typeof setTimeout> | null = null;
+let silenceTimer: ReturnType<typeof setInterval> | null = null;
 
 // Reset the tray to idle and close the recording window. Best-effort: a
 // failure of either step must not throw out of the abort/rollback path.
@@ -248,9 +250,24 @@ onMounted(async () => {
   unlistenStop = await listen('tray://stop-recording', handleStop);
 
   await startRecording();
+
+  // Universal silence backstop: end any recording after 15 min of no sound.
+  silenceTimer = setInterval(() => {
+    if (isUploading.value || uploadResult.value || !recorder.isRecording.value) return;
+    if (
+      shouldAutoStop(
+        recorder.lastSoundAt.value,
+        Date.now(),
+        recorder.isPaused.value,
+      )
+    ) {
+      void handleStop();
+    }
+  }, 1_000);
 });
 
 onUnmounted(() => {
+  if (silenceTimer) clearInterval(silenceTimer);
   if (closeTimer) clearTimeout(closeTimer);
   unlistenPause?.();
   unlistenResume?.();

--- a/src/views/WaveformView.vue
+++ b/src/views/WaveformView.vue
@@ -243,6 +243,10 @@ async function discardRecording() {
     clearTimeout(confirmTimer);
     confirmTimer = null;
   }
+  if (closeTimer) {
+    clearTimeout(closeTimer);
+    closeTimer = null;
+  }
   confirmVisible.value = false;
   if (silenceTimer) {
     clearInterval(silenceTimer);

--- a/src/views/WaveformView.vue
+++ b/src/views/WaveformView.vue
@@ -58,6 +58,19 @@
           </button>
         </div>
 
+        <div v-if="confirmVisible" class="confirm">
+          <button
+            class="ctrl-btn keep-btn"
+            aria-label="Keep recording"
+            @click.stop.prevent="keepRecording"
+          >✓</button>
+          <button
+            class="ctrl-btn discard-btn"
+            aria-label="Discard recording"
+            @click.stop.prevent="discardRecording"
+          >✕</button>
+        </div>
+
         <!-- Tauri only drags when the mousedown target itself carries the
              attribute, so every leaf in the handle needs it. -->
         <div class="drag-handle" data-tauri-drag-region @click.stop>
@@ -84,6 +97,8 @@ import { loadRecordingEnabled } from '../composables/useRecordingPermissions';
 import { deriveRecordingMode } from './recordingSettings';
 import { bucketLevels } from './waveformBars';
 import { shouldAutoStop } from '../composables/silenceWatch';
+import { resolveAssociation } from '../composables/useAutoTrigger';
+import { useMeetingApi } from '../composables/useMeetingApi';
 
 const SUCCESS_CLOSE_MS = 1500;
 
@@ -101,10 +116,18 @@ const bars = computed(() => bucketLevels(waveform.levels.value.slice(0, 20), 5))
 
 const route = useRoute();
 const meetingIdQuery = route.query.meetingId;
-const meetingId: number | null =
+const effectiveMeetingId = ref<number | null>(
   typeof meetingIdQuery === 'string' && /^\d+$/.test(meetingIdQuery)
     ? Number(meetingIdQuery)
-    : null;
+    : null,
+);
+const isAuto = route.query.auto === '1';
+const confirmVisible = ref(false);
+let confirmTimer: ReturnType<typeof setTimeout> | null = null;
+const CONFIRM_TIMEOUT_MS = 60_000;
+// Auto recordings shorter than this are discarded, not uploaded (guards against
+// late mic-on / quick-off races). Manual recordings are never length-gated.
+const MIN_AUTO_DURATION_S = 15;
 
 const formattedDuration = computed(() => {
   const s = recorder.durationSeconds.value;
@@ -136,6 +159,7 @@ async function showMeetings() {
 let unlistenPause: UnlistenFn | null = null;
 let unlistenResume: UnlistenFn | null = null;
 let unlistenStop: UnlistenFn | null = null;
+let unlistenAutoStop: UnlistenFn | null = null;
 let closeTimer: ReturnType<typeof setTimeout> | null = null;
 let silenceTimer: ReturnType<typeof setInterval> | null = null;
 
@@ -176,7 +200,69 @@ async function startRecording() {
   await invoke('set_tray_recording', { isRecording: true, isPaused: false });
 }
 
+// Auto-trigger: resolve calendar association, falling back to a confirm prompt.
+async function resolveAuto() {
+  try {
+    if (backend.value?.id === 'ariso') {
+      const now = new Date();
+      const start = new Date(now.getTime() - 2 * 60 * 60 * 1000);
+      const end = new Date(now.getTime() + 2 * 60 * 60 * 1000);
+      const meetings = await useMeetingApi().listScheduledMeetings(start, end);
+      const assoc = resolveAssociation('ariso', meetings, now);
+      if (assoc.kind === 'matched') {
+        effectiveMeetingId.value = assoc.meetingId ?? null;
+        return;
+      }
+    }
+  } catch (e) {
+    console.error('Auto-trigger match failed; asking for confirmation', e);
+  }
+  showConfirm();
+}
+
+function showConfirm() {
+  confirmVisible.value = true;
+  // No response within the window → discard (per spec).
+  confirmTimer = setTimeout(() => {
+    confirmTimer = null;
+    void discardRecording();
+  }, CONFIRM_TIMEOUT_MS);
+}
+
+function keepRecording() {
+  if (confirmTimer) {
+    clearTimeout(confirmTimer);
+    confirmTimer = null;
+  }
+  confirmVisible.value = false;
+}
+
+// Discard the in-progress capture without uploading, then close.
+async function discardRecording() {
+  if (confirmTimer) {
+    clearTimeout(confirmTimer);
+    confirmTimer = null;
+  }
+  confirmVisible.value = false;
+  if (silenceTimer) {
+    clearInterval(silenceTimer);
+    silenceTimer = null;
+  }
+  waveform.stop();
+  try {
+    await recorder.stopRecording();
+  } catch {
+    /* best-effort */
+  }
+  await invoke('set_tray_recording', { isRecording: false, isPaused: false });
+  await closeWindow();
+}
+
 async function handleStop() {
+  if (isAuto && recorder.durationSeconds.value < MIN_AUTO_DURATION_S) {
+    await discardRecording();
+    return;
+  }
   collapse();
   isUploading.value = true;
   waveform.stop();
@@ -199,7 +285,7 @@ async function handleStop() {
           startAt,
           endAt,
           durationSeconds: recorder.durationSeconds.value,
-          meetingId: meetingId ?? undefined,
+          meetingId: effectiveMeetingId.value ?? undefined,
         }),
         timeout,
       ]);
@@ -264,6 +350,11 @@ onMounted(async () => {
       void handleStop();
     }
   }, 1_000);
+
+  unlistenAutoStop = await listen('auto-record://stop', handleStop);
+  if (isAuto) {
+    void resolveAuto();
+  }
 });
 
 onUnmounted(() => {
@@ -272,6 +363,8 @@ onUnmounted(() => {
   unlistenPause?.();
   unlistenResume?.();
   unlistenStop?.();
+  unlistenAutoStop?.();
+  if (confirmTimer) clearTimeout(confirmTimer);
 });
 </script>
 
@@ -426,6 +519,17 @@ html, body {
   border-radius: 50%;
   background: #6b7280;
 }
+
+.confirm {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  margin-top: 7px;
+  flex-shrink: 0;
+}
+.keep-btn { color: #34d399; font-size: 16px; font-weight: 700; }
+.discard-btn { color: #f87171; font-size: 14px; font-weight: 700; }
 
 .status-icon {
   margin-top: 8px;

--- a/src/views/WaveformView.vue
+++ b/src/views/WaveformView.vue
@@ -123,6 +123,7 @@ const effectiveMeetingId = ref<number | null>(
 );
 const isAuto = route.query.auto === '1';
 const confirmVisible = ref(false);
+const isStopping = ref(false);
 let confirmTimer: ReturnType<typeof setTimeout> | null = null;
 const CONFIRM_TIMEOUT_MS = 60_000;
 // Auto recordings shorter than this are discarded, not uploaded (guards against
@@ -239,6 +240,8 @@ function keepRecording() {
 
 // Discard the in-progress capture without uploading, then close.
 async function discardRecording() {
+  if (isStopping.value) return;
+  isStopping.value = true;
   if (confirmTimer) {
     clearTimeout(confirmTimer);
     confirmTimer = null;
@@ -263,9 +266,26 @@ async function discardRecording() {
 }
 
 async function handleStop() {
+  if (isStopping.value) return;
+  // An unanswered confirm overlay means the user never opted in — a stop of any
+  // kind (native mic-off, silence backstop, tray) must discard, not upload.
+  if (confirmVisible.value) {
+    await discardRecording();
+    return;
+  }
   if (isAuto && recorder.durationSeconds.value < MIN_AUTO_DURATION_S) {
     await discardRecording();
     return;
+  }
+  isStopping.value = true;
+  // Tear down the auto-trigger/backstop timers so they can't fire post-stop.
+  if (confirmTimer) {
+    clearTimeout(confirmTimer);
+    confirmTimer = null;
+  }
+  if (silenceTimer) {
+    clearInterval(silenceTimer);
+    silenceTimer = null;
   }
   collapse();
   isUploading.value = true;


### PR DESCRIPTION
## Summary

Adds automatic meeting recording driven by microphone activity, plus a universal silence backstop, on top of the existing manual recorder.

- **Auto trigger (macOS 14.4+):** a native CoreAudio monitor (`mic_monitor.rs`) watches per-process mic input, excludes our own PID, and snapshots the *triggering* PIDs so our own capture never keeps a meeting artificially alive. Sustained mic-on (3s debounce) opens the recorder window with `?auto=1`; sustained mic-off (8s debounce) emits `auto-record://stop`.
- **Suppression:** a shared native `RecordingState` (set on window open, cleared on stop/`Destroyed`) prevents auto-triggering while any recording — manual or auto — is in progress.
- **Match-or-confirm:** Ariso backend matches a "happening now" calendar meeting (`resolveAssociation` + existing `pickDefaultMeeting`) and attaches to it; otherwise (and always on Local) a Keep/Discard confirm overlay shows, defaulting to **discard** after 60s. Recording starts immediately so nothing is lost; auto recordings under 15s are discarded.
- **Universal silence backstop:** 15 min of no captured sound (peak below threshold) auto-stops *any* recording; frozen while paused. Driven by real captured audio (`lastSoundAt` in `useRecorder`) + a pure `shouldAutoStop` helper.
- **Settings:** "Auto-record meetings" toggle (default ON, key `autoRecordEnabled`) syncs the native monitor live via `BootstrapView`; disabled with a "Requires macOS 14.4+" caption on older OS. App minimum stays macOS 13.

`handleStop` was made idempotent and now honors the confirm gate (a stop while the overlay is unanswered discards rather than uploads) — fixing three cross-cutting issues caught in final integration review.

Design spec: `docs/superpowers/specs/2026-06-10-auto-trigger-recording-design.md`

## Test Plan

Automated (passing):
- [x] `npm test` — all new suites green (`silenceWatch`, `useAutoTrigger`, `useAutoRecord`, `WaveformView` incl. silence + confirm-gate tests). The 5 `LibraryView.test.ts` failures are pre-existing and untouched by this branch.
- [x] `cd src-tauri && cargo build` — clean (incl. `mic_monitor` state-machine unit tests).

Live manual verification (pending — needs real hardware/apps):
- [ ] Start a Zoom/FaceTime call → recorder pill appears within ~3s; end call → stops within ~8s and finalizes.
- [ ] Ariso current meeting attaches (no overlay); no match / Local shows Keep/Discard; Discard and 60s timeout both drop & close.
- [ ] Manual recording active → no second auto recording triggers.
- [ ] Silence backstop ends a recording after 15 min of silence (test with a shortened constant); ongoing audio keeps it alive; pause freezes it.
- [ ] Settings toggle starts/stops the monitor without restart; disabled on macOS < 14.4.
- [ ] Verify (review notes) our own `getUserMedia` capture never lands in `trigger_pids`, and the read-only CoreAudio enumeration needs no extra TCC permission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Auto-trigger recording when external microphone use is detected (suppressed during manual recordings).
  * Frontend confirmation overlay for unmatched auto-records (Keep/Discard/timeout); very short auto-recordings are discarded.
  * Recorder now tracks latest sound timestamp to improve silence handling.

* **Configuration**
  * “Auto-record meetings” toggle in Settings (defaults ON) with OS gating; changes take effect immediately.

* **Reliability**
  * Monitor recovery when recorder window is closed/crashes so auto-monitor can re-arm.

* **Tests**
  * Unit and integration tests added for auto-stop, association logic, and sync behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->