### PR TITLE
feat(markdown): render GFM task lists as disabled checkboxes

### DIFF
--- a/src/utils/markdown.test.ts
+++ b/src/utils/markdown.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { renderMarkdown } from './markdown';
+
+describe('renderMarkdown task lists', () => {
+  it('renders `- [ ]` as a disabled unchecked checkbox', () => {
+    const html = renderMarkdown('- [ ] todo item');
+    expect(html).toContain('<li class="task-list-item">');
+    expect(html).toContain('<input type="checkbox" disabled />');
+    expect(html).not.toContain('checked');
+    expect(html).toContain('todo item');
+  });
+
+  it('renders `- []` (no inner space) as a disabled unchecked checkbox', () => {
+    const html = renderMarkdown('- [] todo item');
+    expect(html).toContain('<input type="checkbox" disabled />');
+    expect(html).not.toContain('checked');
+  });
+
+  it('renders `- [x]` as a disabled checked checkbox', () => {
+    const html = renderMarkdown('- [x] done item');
+    expect(html).toContain('<input type="checkbox" disabled checked />');
+    expect(html).toContain('done item');
+  });
+
+  it('renders `- [X]` (uppercase) as a disabled checked checkbox', () => {
+    const html = renderMarkdown('- [X] done item');
+    expect(html).toContain('<input type="checkbox" disabled checked />');
+  });
+
+  it('keeps plain list items unchanged', () => {
+    const html = renderMarkdown('- regular item');
+    expect(html).toContain('<li>regular item</li>');
+    expect(html).not.toContain('checkbox');
+  });
+
+  it('still renders inline markup inside task items', () => {
+    const html = renderMarkdown('- [x] **bold** task');
+    expect(html).toContain('<strong>bold</strong>');
+  });
+});

--- a/src/utils/markdown.ts
+++ b/src/utils/markdown.ts
@@ -110,7 +110,19 @@ export function renderMarkdown(src: string): string {
         html.push('<ul>');
         listType = 'ul';
       }
-      html.push(`<li>${renderInline(ul[1])}</li>`);
+      // GFM task list: `[ ]`/`[]` → unchecked, `[x]`/`[X]` → checked. Both are
+      // rendered as disabled checkboxes (display only, not interactive).
+      const task = ul[1].match(/^\[([ xX]?)\]\s+(.*)$/);
+      if (task) {
+        const checked = task[1] === 'x' || task[1] === 'X';
+        html.push(
+          `<li class="task-list-item"><input type="checkbox" disabled${
+            checked ? ' checked' : ''
+          } />${renderInline(task[2])}</li>`,
+        );
+      } else {
+        html.push(`<li>${renderInline(ul[1])}</li>`);
+      }
       continue;
     }
 

--- a/src/utils/markdown.ts
+++ b/src/utils/markdown.ts
@@ -112,13 +112,13 @@ export function renderMarkdown(src: string): string {
       }
       // GFM task list: `[ ]`/`[]` → unchecked, `[x]`/`[X]` → checked. Both are
       // rendered as disabled checkboxes (display only, not interactive).
-      const task = ul[1].match(/^\[([ xX]?)\]\s+(.*)$/);
+      const task = ul[1].match(/^\[([ xX]?)\](?:\s+(.*))?$/);
       if (task) {
         const checked = task[1] === 'x' || task[1] === 'X';
         html.push(
           `<li class="task-list-item"><input type="checkbox" disabled${
             checked ? ' checked' : ''
-          } />${renderInline(task[2])}</li>`,
+          } />${renderInline(task[2] ?? '')}</li>`,
         );
       } else {
         html.push(`<li>${renderInline(ul[1])}</li>`);

--- a/src/views/MeetingDetailView.vue
+++ b/src/views/MeetingDetailView.vue
@@ -563,6 +563,8 @@ const durationLabel = computed<string | null>(() => {
 .md :deep(p) { margin: 0 0 10px; }
 .md :deep(ul), .md :deep(ol) { margin: 0 0 10px; padding-left: 22px; display: flex; flex-direction: column; gap: 4px; }
 .md :deep(li) { line-height: 1.5; }
+.md :deep(li.task-list-item) { list-style: none; margin-left: -22px; display: flex; align-items: flex-start; gap: 8px; }
+.md :deep(li.task-list-item input[type="checkbox"]) { margin: 4px 0 0; flex: none; }
 .md :deep(strong) { font-weight: 600; color: #1c1c1c; }
 .md :deep(code) { background: #f0eeed; padding: 1px 5px; border-radius: 4px; font-size: 0.9em; }
 .md :deep(a) { color: #6c63c0; text-decoration: underline; }


### PR DESCRIPTION
## What

The meeting notes markdown renderer (`src/utils/markdown.ts`) is a custom, dependency-free renderer that had no task-list support, so a line like `- [ ] task` rendered as the literal text `[ ] task`.

This PR adds GitHub-flavored task-list rendering:

- `- [ ]` / `- []` → **disabled unchecked** checkbox
- `- [x]` / `- [X]` → **disabled checked** checkbox

Both are display-only (`disabled`), not interactive — consistent with how these notes are generated rather than edited inline.

## Changes

- **`src/utils/markdown.ts`** — detect task-list syntax in the unordered-list branch; emit `<input type="checkbox" disabled>` inside `<li class="task-list-item">`. Inline markup (bold/italic/code/links) inside the item still renders. Text remains HTML-escaped before markup, so `v-html` output stays safe.
- **`src/views/MeetingDetailView.vue`** — CSS so task items drop the bullet and align the checkbox with the text.
- **`src/utils/markdown.test.ts`** — tests for `[ ]`, `[]`, `[x]`, `[X]`, plain items (unchanged), and inline markup inside a task item.

## Notes

Follows GFM semantics: checkboxes render only inside list items (`- [x] text`), not for a bare `[x] text`.

## Test plan

- [x] `vitest run src/utils/markdown.test.ts` — 6/6 pass
- [x] `npm run vite:build` — compiles clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for GitHub-flavored task lists (checkboxes) in markdown rendering.
  * Task list items render as disabled checkbox list entries with visual checked state for completed items.
  * Inline markdown formatting (e.g., bold) remains intact inside task items.
  * Styling updated so task items align and display without default list markers.

* **Tests**
  * Added test coverage for various task-list checkbox formats and rendering behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->