### PR TITLE
feat(desktop): allow runtime backend URL overrides

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -19,11 +19,11 @@ pub(crate) fn http_client() -> reqwest::Client {
 compile_error!("Features `prod-api` and `dev-api` are mutually exclusive");
 
 #[cfg(feature = "prod-api")]
-pub(crate) const API_BASE_URL: &str = "https://api.ari.ariso.ai";
+const DEFAULT_API_BASE_URL: &str = "https://api.ari.ariso.ai";
 #[cfg(feature = "dev-api")]
-pub(crate) const API_BASE_URL: &str = "https://api-dev.ari.ariso.ai";
+const DEFAULT_API_BASE_URL: &str = "https://api-dev.ari.ariso.ai";
 #[cfg(not(any(feature = "prod-api", feature = "dev-api")))]
-pub(crate) const API_BASE_URL: &str = "http://localhost:4000";
+const DEFAULT_API_BASE_URL: &str = "http://localhost:4000";
 
 // Public Pusher client key. dev-api and local both use the dev key, so this
 // gates on prod-api only (unlike WEB_APP_BASE_URL's three-way split).
@@ -35,11 +35,50 @@ pub(crate) const PUSHER_KEY: &str = "39d990870841a6b478cc";
 pub(crate) const PUSHER_CLUSTER: &str = "us2";
 
 #[cfg(feature = "prod-api")]
-pub(crate) const WEB_APP_BASE_URL: &str = "https://web.ari.ariso.ai";
+const DEFAULT_WEB_APP_BASE_URL: &str = "https://web.ari.ariso.ai";
 #[cfg(feature = "dev-api")]
-pub(crate) const WEB_APP_BASE_URL: &str = "https://web-dev.ari.ariso.ai";
+const DEFAULT_WEB_APP_BASE_URL: &str = "https://web-dev.ari.ariso.ai";
 #[cfg(not(any(feature = "prod-api", feature = "dev-api")))]
-pub(crate) const WEB_APP_BASE_URL: &str = "http://localhost:5173";
+const DEFAULT_WEB_APP_BASE_URL: &str = "http://localhost:5173";
+
+/// Resolve the production API origin from the baked binary constant. Production
+/// builds intentionally ignore environment overrides so deployment endpoints
+/// cannot be changed outside the signed app.
+#[cfg(feature = "prod-api")]
+pub(crate) fn api_base_url() -> String {
+    DEFAULT_API_BASE_URL.to_string()
+}
+
+/// Resolve the API origin used by desktop-native HTTP calls in development.
+/// Non-production launchers can point the app at an isolated Agents dev stack.
+#[cfg(not(feature = "prod-api"))]
+pub(crate) fn api_base_url() -> String {
+    std::env::var("ARISO_DESKTOP_API_BASE_URL")
+        .ok()
+        .filter(|url| !url.trim().is_empty())
+        .unwrap_or_else(|| DEFAULT_API_BASE_URL.to_string())
+        .trim_end_matches('/')
+        .to_string()
+}
+
+/// Resolve the production web origin from the baked binary constant. Production
+/// builds intentionally ignore environment overrides to keep deep links fixed.
+#[cfg(feature = "prod-api")]
+pub(crate) fn web_app_base_url() -> String {
+    DEFAULT_WEB_APP_BASE_URL.to_string()
+}
+
+/// Resolve the browser-facing web origin used for deep links in development.
+/// Keeping this separate from the API origin matches the Agents dev.sh Caddy /api routing.
+#[cfg(not(feature = "prod-api"))]
+pub(crate) fn web_app_base_url() -> String {
+    std::env::var("ARISO_DESKTOP_WEB_APP_BASE_URL")
+        .ok()
+        .filter(|url| !url.trim().is_empty())
+        .unwrap_or_else(|| DEFAULT_WEB_APP_BASE_URL.to_string())
+        .trim_end_matches('/')
+        .to_string()
+}
 
 const STORE_PATH: &str = "session.json";
 const SESSION_KEY: &str = "session_token";
@@ -98,7 +137,7 @@ pub async fn is_session_valid(app: &tauri::AppHandle) -> bool {
 
     let client = http_client();
     let response = match client
-        .get(format!("{API_BASE_URL}/auth/session"))
+        .get(format!("{}/auth/session", api_base_url()))
         .header(AUTHORIZATION, format!("Bearer {token}"))
         .header(CONTENT_TYPE, "application/json")
         .send()
@@ -138,7 +177,7 @@ pub async fn google_sign_in(app: tauri::AppHandle) -> Result<SignInResult, Strin
     // Step 1: Get the OAuth redirect URL from the API. The backend expands
     // these service names into Google scopes and owns credential persistence.
     let response = client
-        .post(format!("{API_BASE_URL}/oauth2/prepare-state"))
+        .post(format!("{}/oauth2/prepare-state", api_base_url()))
         .header(CONTENT_TYPE, "application/json")
         .body(
             r#"{"integration":"google-signin","scopes":["calendar-readonly"],"newUserSignupIntent":"personal_unless_domain_autojoin"}"#,
@@ -238,7 +277,7 @@ async fn exchange_token_for_session(
     let client = http_client();
 
     let response = match client
-        .get(format!("{API_BASE_URL}/auth/check"))
+        .get(format!("{}/auth/check", api_base_url()))
         .header(AUTHORIZATION, format!("Bearer {token}"))
         .header(CONTENT_TYPE, "application/json")
         .send()
@@ -305,7 +344,7 @@ pub async fn check_session(app: tauri::AppHandle) -> Result<Option<SessionResult
 
     let client = http_client();
     let response = client
-        .get(format!("{API_BASE_URL}/auth/session"))
+        .get(format!("{}/auth/session", api_base_url()))
         .header(AUTHORIZATION, format!("Bearer {token}"))
         .header(CONTENT_TYPE, "application/json")
         .send()
@@ -337,7 +376,7 @@ pub async fn api_request(
 ) -> Result<ApiResponse, String> {
     let token = get_session_token(&app).unwrap_or_default();
     let client = http_client();
-    let url = format!("{API_BASE_URL}{path}");
+    let url = format!("{}{}", api_base_url(), path);
 
     let mut request = match method.to_uppercase().as_str() {
         "GET" => client.get(&url),
@@ -379,7 +418,7 @@ pub async fn upload_file(
 ) -> Result<ApiResponse, String> {
     let token = get_session_token(&app).unwrap_or_default();
     let client = http_client();
-    let url = format!("{API_BASE_URL}{path}");
+    let url = format!("{}{}", api_base_url(), path);
 
     let file_part = reqwest::multipart::Part::bytes(file_data)
         .file_name(file_name)
@@ -598,7 +637,7 @@ pub fn get_desktop_config() -> DesktopConfig {
     DesktopConfig {
         pusher_key: PUSHER_KEY.to_string(),
         pusher_cluster: PUSHER_CLUSTER.to_string(),
-        web_app_base_url: WEB_APP_BASE_URL.to_string(),
+        web_app_base_url: web_app_base_url(),
     }
 }
 

--- a/src-tauri/src/meeting_notifications.rs
+++ b/src-tauri/src/meeting_notifications.rs
@@ -22,8 +22,8 @@ use tauri_plugin_store::StoreExt;
 use tokio_tungstenite::tungstenite::Message;
 
 use crate::commands::{
-    clear_session_token, get_session_token, http_client, API_BASE_URL, PUSHER_CLUSTER, PUSHER_KEY,
-    WEB_APP_BASE_URL,
+    api_base_url, clear_session_token, get_session_token, http_client, web_app_base_url,
+    PUSHER_CLUSTER, PUSHER_KEY,
 };
 
 const SETTINGS_PATH: &str = "settings.json";
@@ -264,7 +264,7 @@ async fn fetch_me(app: &AppHandle) -> Result<(String, String), SessionError> {
     let token = get_session_token(app).ok_or(SessionError::Auth)?;
     let v: Value = tokio::time::timeout(HTTP_TIMEOUT, async {
         let resp = http_client()
-            .get(format!("{API_BASE_URL}/auth/me"))
+            .get(format!("{}/auth/me", api_base_url()))
             .header(AUTHORIZATION, format!("Bearer {token}"))
             .header(CONTENT_TYPE, "application/json")
             .send()
@@ -313,7 +313,7 @@ async fn pusher_auth(
     let body = json!({ "socketId": socket_id, "channelName": channel });
     let v: Value = tokio::time::timeout(HTTP_TIMEOUT, async {
         let resp = http_client()
-            .post(format!("{API_BASE_URL}/pusher/auth"))
+            .post(format!("{}/pusher/auth", api_base_url()))
             .header(AUTHORIZATION, format!("Bearer {token}"))
             .header(CONTENT_TYPE, "application/json")
             .json(&body)
@@ -355,7 +355,7 @@ async fn fetch_inbox(app: &AppHandle) -> Result<Vec<InboxItem>, SessionError> {
     let token = get_session_token(app).ok_or(SessionError::Auth)?;
     let v: Value = tokio::time::timeout(HTTP_TIMEOUT, async {
         let resp = http_client()
-            .get(format!("{API_BASE_URL}/user-inbox-messages?limit=20"))
+            .get(format!("{}/user-inbox-messages?limit=20", api_base_url()))
             .header(AUTHORIZATION, format!("Bearer {token}"))
             .header(CONTENT_TYPE, "application/json")
             .send()
@@ -470,7 +470,7 @@ fn build_notification(message: Option<&str>) -> (String, String) {
 
 /// The web deep link a meeting-prep notification opens when clicked.
 fn prep_url(prep_id: i64) -> String {
-    format!("{WEB_APP_BASE_URL}/my/meeting-prep-v2/{prep_id}")
+    format!("{}/my/meeting-prep-v2/{prep_id}", web_app_base_url())
 }
 
 /// Initialize native notification support. On a macOS bundle this installs the


### PR DESCRIPTION
## Summary
- keep production API/web URLs hard-coded from build-time constants; production builds ignore `ARISO_DESKTOP_*` environment overrides
- allow non-production builds (`dev-api` and local) to use `ARISO_DESKTOP_API_BASE_URL` and `ARISO_DESKTOP_WEB_APP_BASE_URL` for isolated Agents/dev stacks
- route native auth/session/API calls and meeting-prep deep links through the guarded URL resolvers

## Verification
- `cargo check --manifest-path src-tauri/Cargo.toml --features dev-api`
- `cargo check --manifest-path src-tauri/Cargo.toml --features prod-api`

## Notes
This PR intentionally does not change Google sign-in scopes or onboarding UX. OAuth callback origin remains backend-owned through the selected API stack. Production endpoint selection remains baked into the binary; only development/local builds honor environment overrides.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * API and web app base URLs are now configurable at runtime via environment variables (ARISO_DESKTOP_API_BASE_URL and ARISO_DESKTOP_WEB_APP_BASE_URL), replacing compile-time values.
  * Desktop config now surfaces the runtime web app base URL.

* **Bug Fixes**
  * Notification links, deep links, and API request URLs now use the runtime-configured base URLs and trim trailing slashes for consistent link formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->