### PR TITLE
feat: meeting list & picker UX tweaks

### DIFF
--- a/src/composables/groupMeetingsByDate.test.ts
+++ b/src/composables/groupMeetingsByDate.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { groupMeetingsByDate, todaysMeetings, dateLabel } from './groupMeetingsByDate';
+import { groupMeetingsByDate, groupTodaysMeetings, dateLabel } from './groupMeetingsByDate';
 import type { MeetingListItem } from './useBackend';
 
 // Fixed "now": Wed 2026-06-10 15:00 local.
@@ -49,14 +49,32 @@ describe('groupMeetingsByDate', () => {
   });
 });
 
-describe('todaysMeetings', () => {
-  it('returns only today, soonest-first, dropping other days and NaN', () => {
+describe('groupTodaysMeetings', () => {
+  it('splits today into UPCOMING then EARLIER, each earliest-first', () => {
     const meetings = [
       m('y', '2026-06-09T09:00:00'),
-      m('t2', '2026-06-10T18:00:00'),
-      m('t1', '2026-06-10T08:00:00'),
+      m('up-late', '2026-06-10T18:00:00'),
+      m('up-soon', '2026-06-10T16:30:00'),
+      m('past-late', '2026-06-10T11:00:00'),
+      m('past-early', '2026-06-10T09:00:00'),
       m('bad', 'nope'),
     ];
-    expect(todaysMeetings(meetings, NOW).map((x) => x.id)).toEqual(['t1', 't2']);
+    const sections = groupTodaysMeetings(meetings, NOW);
+    expect(sections.map((s) => s.label)).toEqual(['UPCOMING', 'EARLIER']);
+    expect(sections[0].items.map((x) => x.id)).toEqual(['up-soon', 'up-late']);
+    expect(sections[1].items.map((x) => x.id)).toEqual(['past-early', 'past-late']);
+  });
+
+  it('omits a group when it has no meetings', () => {
+    expect(groupTodaysMeetings([m('p', '2026-06-10T09:00:00')], NOW).map((s) => s.label)).toEqual([
+      'EARLIER',
+    ]);
+    expect(groupTodaysMeetings([m('u', '2026-06-10T18:00:00')], NOW).map((s) => s.label)).toEqual([
+      'UPCOMING',
+    ]);
+  });
+
+  it('returns an empty array when nothing is today', () => {
+    expect(groupTodaysMeetings([m('y', '2026-06-09T09:00:00'), m('bad', 'nope')], NOW)).toEqual([]);
   });
 });

--- a/src/composables/groupMeetingsByDate.ts
+++ b/src/composables/groupMeetingsByDate.ts
@@ -68,13 +68,27 @@ export function groupMeetingsByDate(meetings: MeetingListItem[], now: Date): Mee
   return sections;
 }
 
-/** Today's meetings only, soonest-first; drops other days and invalid dates. */
-export function todaysMeetings(meetings: MeetingListItem[], now: Date): MeetingListItem[] {
+/** Today's meetings split into UPCOMING (still to come) then EARLIER (already
+ *  started), each ordered earliest-first; drops other days and invalid dates. */
+export function groupTodaysMeetings(meetings: MeetingListItem[], now: Date): MeetingSection[] {
+  const nowMs = now.getTime();
   const today = localDateKey(now);
-  return meetings
-    .filter((meeting) => {
-      const d = new Date(meeting.timestamp);
-      return !Number.isNaN(d.getTime()) && localDateKey(d) === today;
-    })
-    .sort((a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime());
+  const upcoming: MeetingListItem[] = [];
+  const earlier: MeetingListItem[] = [];
+  for (const meeting of meetings) {
+    const d = new Date(meeting.timestamp);
+    if (Number.isNaN(d.getTime()) || localDateKey(d) !== today) continue;
+    if (d.getTime() > nowMs) upcoming.push(meeting);
+    else earlier.push(meeting);
+  }
+
+  const byTimeAsc = (a: MeetingListItem, b: MeetingListItem) =>
+    new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime();
+  upcoming.sort(byTimeAsc);
+  earlier.sort(byTimeAsc);
+
+  const sections: MeetingSection[] = [];
+  if (upcoming.length) sections.push({ key: 'upcoming', label: 'UPCOMING', items: upcoming });
+  if (earlier.length) sections.push({ key: 'earlier', label: 'EARLIER', items: earlier });
+  return sections;
 }

--- a/src/views/LibraryView.vue
+++ b/src/views/LibraryView.vue
@@ -97,7 +97,7 @@ import { ref, computed, onMounted, onUnmounted } from 'vue';
 import { invoke } from '@tauri-apps/api/core';
 import { getAllWebviewWindows } from '@tauri-apps/api/webviewWindow';
 import { getActiveBackend, type MeetingListItem } from '../composables/useBackend';
-import { groupMeetingsByDate, todaysMeetings, type MeetingSection } from '../composables/groupMeetingsByDate';
+import { groupMeetingsByDate, groupTodaysMeetings, type MeetingSection } from '../composables/groupMeetingsByDate';
 import MeetingDetailView from './MeetingDetailView.vue';
 
 const meetings = ref<MeetingListItem[]>([]);
@@ -115,8 +115,7 @@ const activeView = ref<'today' | 'meetings'>('meetings');
 
 const displayedSections = computed<MeetingSection[]>(() => {
   if (activeView.value === 'today') {
-    const items = todaysMeetings(meetings.value, now);
-    return items.length ? [{ key: 'today', label: '', items }] : [];
+    return groupTodaysMeetings(meetings.value, now);
   }
   return groupMeetingsByDate(meetings.value, now);
 });
@@ -268,9 +267,9 @@ onUnmounted(() => {
 
 /* Sidebar */
 .sidebar {
-  width: 276px;
+  width: 300px;
   flex-shrink: 0;
-  padding: 40px 18px 16px;
+  padding: 40px 18px 18px;
   box-sizing: border-box;
   display: flex;
   flex-direction: column;
@@ -356,7 +355,7 @@ onUnmounted(() => {
   display: flex;
   align-items: center;
   gap: 8px;
-  padding-top: 12px;
+  padding-top: 24px;
 }
 .nav-pill,
 .nav-circle {
@@ -407,7 +406,7 @@ onUnmounted(() => {
 .detail-wrap {
   flex: 1;
   min-width: 0;
-  padding: 28px 24px 24px 8px;
+  padding: 28px 18px 18px 8px;
   box-sizing: border-box;
   display: flex;
   min-height: 0;

--- a/src/views/MeetingPickerView.vue
+++ b/src/views/MeetingPickerView.vue
@@ -121,8 +121,9 @@ onMounted(async () => {
   height: 100vh;
   display: flex;
   flex-direction: column;
-  background: #0f0f1a;
-  color: #e5e7eb;
+  background: #f7f6f4; /* Backdrop/Primary — matches the Meetings window */
+  color: #1c1c1c;
+  font-family: 'Polymath', -apple-system, system-ui, sans-serif;
   padding: 20px;
   box-sizing: border-box;
 }
@@ -130,6 +131,7 @@ onMounted(async () => {
 .title {
   font-size: 16px;
   font-weight: 600;
+  color: #1c1c1c;
   margin: 0 0 16px;
 }
 
@@ -137,9 +139,10 @@ onMounted(async () => {
   font-size: 11px;
   font-weight: 600;
   text-transform: uppercase;
-  letter-spacing: 0.5px;
-  color: #9ca3af;
-  margin: 0 0 8px;
+  letter-spacing: 1.5px;
+  color: #9a9a96;
+  margin: 0 0 6px;
+  padding: 0 2px;
 }
 
 .link-btn {
@@ -148,13 +151,15 @@ onMounted(async () => {
   padding: 0;
   border: none;
   background: none;
-  color: #818cf8;
+  color: #6f6f6f;
+  font-family: inherit;
   font-size: 12px;
   font-weight: 600;
   cursor: pointer;
 }
 
 .link-btn:hover {
+  color: #1c1c1c;
   text-decoration: underline;
 }
 
@@ -164,15 +169,15 @@ onMounted(async () => {
   align-items: center;
   justify-content: center;
   gap: 10px;
-  color: #9ca3af;
-  font-size: 13px;
+  color: #6f6f6f;
+  font-size: 14px;
 }
 
 .spinner {
   width: 14px;
   height: 14px;
-  border: 2px solid #4b5563;
-  border-top-color: #818cf8;
+  border: 2px solid #d6d6d6;
+  border-top-color: #1c1c1c;
   border-radius: 50%;
   animation: spin 0.8s linear infinite;
 }
@@ -181,8 +186,8 @@ onMounted(async () => {
   width: 18px;
   height: 18px;
   border-radius: 50%;
-  background: #f87171;
-  color: #0f0f1a;
+  background: #d96a5a;
+  color: #f7f6f4;
   font-weight: 700;
   display: inline-flex;
   align-items: center;
@@ -190,33 +195,41 @@ onMounted(async () => {
   font-size: 12px;
 }
 
+/* Scrollable list with the same top/bottom fade as the Meetings window. */
 .meeting-list {
   flex: 1;
+  min-height: 0;
   overflow-y: auto;
   list-style: none;
   margin: 0;
-  padding: 0;
+  padding: 6px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  -webkit-mask-image: linear-gradient(to bottom, transparent 0, #000 24px, #000 calc(100% - 24px), transparent 100%);
+  mask-image: linear-gradient(to bottom, transparent 0, #000 24px, #000 calc(100% - 24px), transparent 100%);
 }
+.meeting-list::-webkit-scrollbar { width: 6px; }
+.meeting-list::-webkit-scrollbar-thumb { background: #d6d6d6; border-radius: 3px; }
 
 .meeting-row {
-  width: 100%;
   display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 12px 14px;
-  border: none;
-  background: #1e1e2e;
-  color: #e5e7eb;
-  border-radius: 8px;
-  margin-bottom: 6px;
-  cursor: pointer;
-  font-size: 13px;
+  flex-direction: column;
+  gap: 3px;
+  width: 100%;
+  padding: 10px 12px;
+  border: 1px solid transparent;
+  border-radius: 12px;
+  background: transparent;
+  color: #1c1c1c;
+  font-family: inherit;
   text-align: left;
-  transition: background 0.15s;
+  cursor: pointer;
+  transition: background 0.12s;
 }
 
 .meeting-row:hover {
-  background: #2a2a3e;
+  background: rgba(0, 0, 0, 0.03);
 }
 
 .meeting-row:disabled,
@@ -226,35 +239,39 @@ onMounted(async () => {
 }
 
 .meeting-title {
+  font-size: 15px;
   font-weight: 500;
+  color: #1c1c1c;
+  line-height: 1.25;
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  margin-right: 10px;
 }
 
 .meeting-time {
-  color: #9ca3af;
-  font-family: monospace;
-  flex-shrink: 0;
+  font-size: 12px;
+  color: #6f6f6f;
 }
 
 .skip-btn {
   margin-top: 14px;
   padding: 10px 14px;
-  border-radius: 8px;
-  border: none;
-  background: #1e1e2e;
-  color: #d1d5db;
+  border-radius: 12px;
+  border: 1px solid #d6d6d6;
+  background: #ffffff;
+  box-shadow: 2px 2px 0 #e7e5e2;
+  color: #1c1c1c;
+  font-family: inherit;
   font-size: 13px;
   font-weight: 600;
   cursor: pointer;
-  transition: background 0.15s;
+  transition: transform 0.1s, box-shadow 0.1s;
 }
 
 .skip-btn:hover {
-  background: #2a2a3e;
+  box-shadow: 1px 1px 0 #e7e5e2;
+  transform: translate(1px, 1px);
 }
 
 @keyframes spin {


### PR DESCRIPTION
## Summary

UX refinements to the meeting list (Today view), the meeting picker window, and sidebar spacing.

- **Today view regrouping**: clicking **Today** now splits today's meetings into an `UPCOMING` section (still to come) followed by an `EARLIER` section (already started), each ordered earliest-first. Replaces the old single unlabeled list (`todaysMeetings` → `groupTodaysMeetings`).
- **Meeting picker reskin**: `MeetingPickerView` now matches the light cream/white "Meetings" window design — `#f7f6f4` backdrop, Polymath font, card-style rows with the shared hover/fade-mask/scrollbar treatment, and the white offset-shadow button style. (CSS only; markup unchanged.)
- **Sidebar layout**: widened the sidebar (276px → 300px) so it contains the Today/Meetings/Todo nav pill; equalized bottom padding with left/right (18px); added breathing room above the nav bar (`padding-top` 12px → 24px).
- **Detail pane**: right/bottom padding aligned to the sidebar's 18px.

## Testing

- `npx vitest run` — 103/103 passing (grouping tests updated to cover the UPCOMING/EARLIER split, group omission, and empty cases).
- `npx vite build` — succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Today's meetings are now organized into "Upcoming" and "Earlier" sections, making it easier to distinguish between upcoming and past meetings.

* **Style**
  * Updated meeting picker interface styling and refined layout spacing in the library view for improved usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->