### PR TITLE
feat(meeting-list): relative time + "Now" for the next upcoming meeting

### DIFF
--- a/src/composables/groupMeetingsByDate.test.ts
+++ b/src/composables/groupMeetingsByDate.test.ts
@@ -1,12 +1,18 @@
 import { describe, it, expect } from 'vitest';
-import { groupMeetingsByDate, groupTodaysMeetings, dateLabel } from './groupMeetingsByDate';
+import {
+  groupMeetingsByDate,
+  groupTodaysMeetings,
+  dateLabel,
+  upcomingRelLabel,
+  isMeetingInProgress,
+} from './groupMeetingsByDate';
 import type { MeetingListItem } from './useBackend';
 
 // Fixed "now": Wed 2026-06-10 15:00 local.
 const NOW = new Date(2026, 5, 10, 15, 0, 0);
 
-function m(id: string, iso: string): MeetingListItem {
-  return { id, title: `M${id}`, timestamp: iso };
+function m(id: string, iso: string, end?: string): MeetingListItem {
+  return { id, title: `M${id}`, timestamp: iso, ...(end ? { endTimestamp: end } : {}) };
 }
 
 describe('dateLabel', () => {
@@ -47,6 +53,14 @@ describe('groupMeetingsByDate', () => {
     expect(labels).toContain('UNDATED');
     expect(labels.indexOf('UNDATED')).toBeGreaterThan(labels.indexOf('TODAY'));
   });
+
+  it('treats an in-progress meeting (not yet ended) as UPCOMING, not history', () => {
+    const sections = groupMeetingsByDate(
+      [m('live', '2026-06-10T14:30:00', '2026-06-10T15:30:00'), m('past', '2026-06-10T09:00:00')],
+      NOW
+    );
+    expect(sections.find((s) => s.label === 'UPCOMING')?.items.map((x) => x.id)).toEqual(['live']);
+  });
 });
 
 describe('groupTodaysMeetings', () => {
@@ -76,5 +90,45 @@ describe('groupTodaysMeetings', () => {
 
   it('returns an empty array when nothing is today', () => {
     expect(groupTodaysMeetings([m('y', '2026-06-09T09:00:00'), m('bad', 'nope')], NOW)).toEqual([]);
+  });
+
+  it('keeps an in-progress meeting in UPCOMING, ahead of later ones', () => {
+    const meetings = [
+      m('live', '2026-06-10T14:30:00', '2026-06-10T15:30:00'), // started, not ended → in progress
+      m('soon', '2026-06-10T16:00:00'),
+      m('done', '2026-06-10T09:00:00', '2026-06-10T10:00:00'), // ended → earlier
+    ];
+    const sections = groupTodaysMeetings(meetings, NOW);
+    expect(sections.map((s) => s.label)).toEqual(['UPCOMING', 'EARLIER']);
+    expect(sections[0].items.map((x) => x.id)).toEqual(['live', 'soon']);
+    expect(sections[1].items.map((x) => x.id)).toEqual(['done']);
+  });
+});
+
+describe('isMeetingInProgress', () => {
+  it('is true only between start and end', () => {
+    expect(isMeetingInProgress(m('a', '2026-06-10T14:30:00', '2026-06-10T15:30:00'), NOW)).toBe(true);
+    expect(isMeetingInProgress(m('b', '2026-06-10T15:30:00', '2026-06-10T16:30:00'), NOW)).toBe(false);
+    expect(isMeetingInProgress(m('c', '2026-06-10T13:00:00', '2026-06-10T14:00:00'), NOW)).toBe(false);
+  });
+
+  it('is false without an end timestamp', () => {
+    expect(isMeetingInProgress(m('d', '2026-06-10T14:30:00'), NOW)).toBe(false);
+  });
+});
+
+describe('upcomingRelLabel', () => {
+  it('formats the time until start, scaling minutes → hours → days', () => {
+    expect(upcomingRelLabel(m('a', '2026-06-10T15:20:00'), NOW)).toBe('in 20min');
+    expect(upcomingRelLabel(m('b', '2026-06-10T17:00:00'), NOW)).toBe('in 2h');
+    expect(upcomingRelLabel(m('c', '2026-06-12T15:00:00'), NOW)).toBe('in 2d');
+  });
+
+  it('says "Now" for a meeting in progress', () => {
+    expect(upcomingRelLabel(m('live', '2026-06-10T14:30:00', '2026-06-10T15:30:00'), NOW)).toBe('Now');
+  });
+
+  it('returns an empty string for an invalid start', () => {
+    expect(upcomingRelLabel(m('bad', 'nope'), NOW)).toBe('');
   });
 });

--- a/src/composables/groupMeetingsByDate.ts
+++ b/src/composables/groupMeetingsByDate.ts
@@ -11,6 +11,41 @@ function localDateKey(d: Date): string {
   return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
 }
 
+/** ms at which a meeting is considered over: its end timestamp when known,
+ *  otherwise its start (unknown-duration meetings are "over" once they begin). */
+function meetingEndMs(m: MeetingListItem): number {
+  if (m.endTimestamp) {
+    const end = new Date(m.endTimestamp).getTime();
+    if (!Number.isNaN(end)) return end;
+  }
+  return new Date(m.timestamp).getTime();
+}
+
+/** True while a meeting is happening: start <= now < end. Needs a real end. */
+export function isMeetingInProgress(m: MeetingListItem, now: Date): boolean {
+  if (!m.endTimestamp) return false;
+  const start = new Date(m.timestamp).getTime();
+  const end = new Date(m.endTimestamp).getTime();
+  if (Number.isNaN(start) || Number.isNaN(end)) return false;
+  const t = now.getTime();
+  return start <= t && t < end;
+}
+
+/** Relative label for an upcoming meeting: "Now" while in progress, otherwise
+ *  the time until it starts ("in 20min" / "in 2h" / "in 3d"). Empty for an
+ *  unparseable start or a meeting that is already over. */
+export function upcomingRelLabel(m: MeetingListItem, now: Date): string {
+  const start = new Date(m.timestamp).getTime();
+  if (Number.isNaN(start)) return '';
+  const t = now.getTime();
+  if (start <= t) return isMeetingInProgress(m, now) ? 'Now' : '';
+  const mins = Math.round((start - t) / 60_000);
+  if (mins < 60) return `in ${Math.max(1, mins)}min`;
+  const hours = Math.round(mins / 60);
+  if (hours < 24) return `in ${hours}h`;
+  return `in ${Math.round(hours / 24)}d`;
+}
+
 export function dateLabel(key: string, now: Date): string {
   const yesterday = new Date(now);
   yesterday.setDate(yesterday.getDate() - 1);
@@ -34,8 +69,8 @@ export function groupMeetingsByDate(meetings: MeetingListItem[], now: Date): Mee
   const history: MeetingListItem[] = [];
   const upcoming: MeetingListItem[] = [];
   for (const meeting of meetings) {
-    const ts = new Date(meeting.timestamp).getTime();
-    if (!Number.isNaN(ts) && ts > nowMs) upcoming.push(meeting);
+    // "Upcoming" = not yet over: future meetings and ones in progress right now.
+    if (meetingEndMs(meeting) > nowMs) upcoming.push(meeting);
     else history.push(meeting);
   }
 
@@ -78,7 +113,8 @@ export function groupTodaysMeetings(meetings: MeetingListItem[], now: Date): Mee
   for (const meeting of meetings) {
     const d = new Date(meeting.timestamp);
     if (Number.isNaN(d.getTime()) || localDateKey(d) !== today) continue;
-    if (d.getTime() > nowMs) upcoming.push(meeting);
+    // In-progress meetings (started but not ended) count as upcoming.
+    if (meetingEndMs(meeting) > nowMs) upcoming.push(meeting);
     else earlier.push(meeting);
   }
 

--- a/src/composables/useBackend.ts
+++ b/src/composables/useBackend.ts
@@ -25,6 +25,8 @@ export interface MeetingListItem {
   title: string;
   /** ISO timestamp: local `createdAt` or ariso `start_at`. View formats it. */
   timestamp: string;
+  /** ISO end timestamp (ariso `end_at`); drives "Now" / start–end display. */
+  endTimestamp?: string;
   /** Local recordings only. */
   durationSeconds?: number;
   /** Local recordings only. */
@@ -190,6 +192,7 @@ export class ArisoBackend implements Backend {
       id: String(m.id),
       title: m.title || 'Untitled meeting',
       timestamp: m.start_at,
+      endTimestamp: m.end_at,
     }));
   }
 

--- a/src/composables/useMeetingApi.ts
+++ b/src/composables/useMeetingApi.ts
@@ -30,6 +30,7 @@ interface ScheduledMeeting {
   id: number;
   title: string | null;
   start_at: string;
+  end_at?: string;
 }
 
 interface MeetingNotesParticipant {

--- a/src/views/LibraryView.vue
+++ b/src/views/LibraryView.vue
@@ -51,8 +51,11 @@
             :aria-pressed="selectedItem?.id === m.id"
             @click="selectMeeting(m)"
           >
-            <span class="mi-title">{{ m.title }}</span>
-            <span class="mi-sub">{{ itemSub(m) }}</span>
+            <span class="mi-head">
+              <span class="mi-title">{{ m.title }}</span>
+              <span v-if="relLabel(m)" class="mi-rel" :class="{ 'mi-rel--now': isNextNow(m) }">{{ relLabel(m) }}</span>
+            </span>
+            <span class="mi-sub" :class="{ 'mi-sub--now': isNextNow(m) }">{{ subFor(m) }}</span>
           </button>
         </template>
         <p v-if="displayedSections.length === 0" class="hint">No meetings today.</p>
@@ -97,7 +100,13 @@ import { ref, computed, onMounted, onUnmounted } from 'vue';
 import { invoke } from '@tauri-apps/api/core';
 import { getAllWebviewWindows } from '@tauri-apps/api/webviewWindow';
 import { getActiveBackend, type MeetingListItem } from '../composables/useBackend';
-import { groupMeetingsByDate, groupTodaysMeetings, type MeetingSection } from '../composables/groupMeetingsByDate';
+import {
+  groupMeetingsByDate,
+  groupTodaysMeetings,
+  upcomingRelLabel,
+  isMeetingInProgress,
+  type MeetingSection,
+} from '../composables/groupMeetingsByDate';
 import MeetingDetailView from './MeetingDetailView.vue';
 
 const meetings = ref<MeetingListItem[]>([]);
@@ -107,18 +116,51 @@ const recording = ref(false);
 const leftPanelVisible = ref(true);
 const selectedItem = ref<MeetingListItem | null>(null);
 
-const now = new Date();
-const dayNum = now.getDate();
-const monthName = now.toLocaleString(undefined, { month: 'long' }).toUpperCase();
+// A ticking "now" so relative labels ("in 20min" → "Now") and the upcoming/past
+// split stay fresh while the window sits open.
+const now = ref(new Date());
+const dayNum = computed(() => now.value.getDate());
+const monthName = computed(() => now.value.toLocaleString(undefined, { month: 'long' }).toUpperCase());
 
 const activeView = ref<'today' | 'meetings'>('meetings');
 
 const displayedSections = computed<MeetingSection[]>(() => {
   if (activeView.value === 'today') {
-    return groupTodaysMeetings(meetings.value, now);
+    return groupTodaysMeetings(meetings.value, now.value);
   }
-  return groupMeetingsByDate(meetings.value, now);
+  return groupMeetingsByDate(meetings.value, now.value);
 });
+
+// Only the next upcoming meeting (soonest, or the one in progress) carries a
+// relative-time chip; it's the first item of the trailing UPCOMING section.
+const nextUpcomingId = computed<string | null>(() => {
+  const up = displayedSections.value.find((s) => s.key === 'upcoming');
+  return up?.items[0]?.id ?? null;
+});
+
+function relLabel(m: MeetingListItem): string {
+  return m.id === nextUpcomingId.value ? upcomingRelLabel(m, now.value) : '';
+}
+
+function isNextNow(m: MeetingListItem): boolean {
+  return m.id === nextUpcomingId.value && isMeetingInProgress(m, now.value);
+}
+
+function fmtClock(iso: string): string {
+  const d = new Date(iso);
+  return Number.isNaN(d.getTime())
+    ? iso
+    : d.toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' });
+}
+
+// The in-progress next meeting shows its start–end range (rendered green);
+// every other row keeps the normal start-time subtitle.
+function subFor(m: MeetingListItem): string {
+  if (isNextNow(m) && m.endTimestamp) {
+    return `${fmtClock(m.timestamp)} – ${fmtClock(m.endTimestamp)}`;
+  }
+  return itemSub(m);
+}
 
 function itemSub(m: MeetingListItem): string {
   const d = new Date(m.timestamp);
@@ -208,17 +250,24 @@ async function startRecording(): Promise<void> {
 }
 
 function onWindowFocus(): void {
+  now.value = new Date();
   void loadMeetings();
   void refreshRecordingState();
 }
 
+let clockTimer: number | undefined;
+
 onMounted(() => {
   void loadMeetings();
   void refreshRecordingState();
+  clockTimer = window.setInterval(() => {
+    now.value = new Date();
+  }, 30_000);
   window.addEventListener('focus', onWindowFocus);
 });
 
 onUnmounted(() => {
+  if (clockTimer !== undefined) clearInterval(clockTimer);
   window.removeEventListener('focus', onWindowFocus);
 });
 </script>
@@ -346,8 +395,21 @@ onUnmounted(() => {
   border-color: #1c1c1c;
   box-shadow: 3px 3px 0 #e7e5e2;
 }
-.mi-title { font-size: 15px; font-weight: 500; color: #1c1c1c; line-height: 1.25; }
+.mi-head { display: flex; align-items: baseline; justify-content: space-between; gap: 8px; }
+.mi-title {
+  font-size: 15px;
+  font-weight: 500;
+  color: #1c1c1c;
+  line-height: 1.25;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.mi-rel { flex-shrink: 0; font-size: 11px; font-weight: 600; letter-spacing: 0.3px; color: #6f6f6f; }
+.mi-rel--now { color: #2e8b4f; }
 .mi-sub { font-size: 12px; color: #6f6f6f; }
+.mi-sub--now { color: #2e8b4f; font-weight: 500; }
 
 /* Bottom nav */
 .bottom-nav {


### PR DESCRIPTION

<img width="902" height="601" alt="Screenshot 2026-06-10 at 22 40 41" src="https://github.com/user-attachments/assets/99c60abf-df75-48eb-83f2-14d99bc14fc8" />


## Summary

The next upcoming meeting in the list now tells you how soon it is, and surfaces when one is happening right now.

- **Relative time chip** on the next upcoming meeting (first item of the `UPCOMING` section, in both the Today and Meetings views): `in 20min` / `in 2h` / `in 3d`.
- **"Now" state**: while that meeting is in progress, the chip reads **Now** and its subtitle shows the **start–end range in green** (`2:00 – 3:00 PM`).
- **End-based upcoming/past split**: an in-progress meeting (started but not ended) now stays in `UPCOMING` as the soonest item instead of dropping into `EARLIER`/history — that's what lets it be the "next" meeting labeled "Now".
- **Live updates**: `now` ticks every 30s and refreshes on window focus, so `in 20min` counts down and flips to `Now` without a reload.

## Data

`end_at` is threaded through `ScheduledMeeting` → `MeetingListItem.endTimestamp`. "Now" only appears for meetings that actually carry an `end_at`; without one we can't tell it's still in progress, so the row degrades to the plain start-time display.

## Testing

- `npx vitest run` — 110/110 passing (new coverage for `upcomingRelLabel`, `isMeetingInProgress`, and the end-based in-progress grouping).
- `npx vite build` — succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for meeting end times
  * In-progress meetings now display with a "Now" indicator
  * Meeting listings now show relative time labels (e.g., "in 5 min", "in 2 hours")
  * Updated meeting status display to better distinguish in-progress versus upcoming meetings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->