### PR TITLE
feat(transcript): adopt the new transcript response

### DIFF
--- a/src/composables/useBackend.ts
+++ b/src/composables/useBackend.ts
@@ -1,5 +1,5 @@
 import { local, auth, getBackendSetting, type RecordingSummary } from '../tauri';
-import { useMeetingApi, type ScheduledMeeting } from './useMeetingApi';
+import { useMeetingApi, type ScheduledMeeting, type TranscriptChunk } from './useMeetingApi';
 
 export type BackendId = 'ariso' | 'local';
 
@@ -95,8 +95,9 @@ export interface Backend {
   listMeetings(): Promise<MeetingListItem[]>;
   /** Load the detail for a single row (from the list item the user clicked). */
   getMeetingDetail(item: MeetingListItem): Promise<MeetingDetail>;
-  /** Lazily load the meeting's transcript text (null when none). */
-  getMeetingTranscript(item: MeetingListItem): Promise<string | null>;
+  /** Lazily load the meeting's transcript (null when none). Ariso meetings
+   *  resolve to structured chunks; local recordings resolve to markdown text. */
+  getMeetingTranscript(item: MeetingListItem): Promise<string | TranscriptChunk[] | null>;
   /** Lazily load the requester's individual note (null when none). */
   getIndividualNote(item: MeetingListItem): Promise<{ content: string; title: string | null } | null>;
 }
@@ -225,7 +226,7 @@ export class ArisoBackend implements Backend {
     };
   }
 
-  async getMeetingTranscript(item: MeetingListItem): Promise<string | null> {
+  async getMeetingTranscript(item: MeetingListItem): Promise<TranscriptChunk[] | null> {
     const { getMeetingTranscript } = useMeetingApi();
     return getMeetingTranscript(item.id);
   }

--- a/src/composables/useMeetingApi.ts
+++ b/src/composables/useMeetingApi.ts
@@ -7,6 +7,15 @@ interface TranscriptSegment {
   end: number;
 }
 
+// A single line of a stored transcript: the speaker-attributed `content`
+// (e.g. "Speaker 1: …"), its zero-based `chunk_index`, and `start_ms` offset
+// from the start of the recording.
+interface TranscriptChunk {
+  chunk_index: number;
+  start_ms: number;
+  content: string;
+}
+
 interface Meeting {
   id: number;
   title: string | null;
@@ -59,6 +68,22 @@ interface MeetingNotes {
 
 interface ScheduledMeetingsResponse {
   meetings: ScheduledMeeting[];
+}
+
+// Normalize a raw `transcript` payload into ordered chunks, tolerating missing
+// or mistyped fields. Returns null when there are no usable chunks so callers
+// can treat it the same as an absent transcript.
+function parseTranscriptChunks(raw: unknown): TranscriptChunk[] | null {
+  if (!Array.isArray(raw)) return null;
+  const chunks = raw
+    .filter((c): c is Record<string, unknown> => !!c && typeof c === 'object')
+    .map((c) => ({
+      chunk_index: typeof c.chunk_index === 'number' ? c.chunk_index : 0,
+      start_ms: typeof c.start_ms === 'number' ? c.start_ms : 0,
+      content: typeof c.content === 'string' ? c.content.trim() : '',
+    }))
+    .filter((c) => c.content.length > 0);
+  return chunks.length ? chunks : null;
 }
 
 function assertOk(res: { status: number; data: unknown }, expected: number, action: string): void {
@@ -164,17 +189,19 @@ export function useMeetingApi() {
     assertOk(res, 200, 'update meeting title');
   }
 
-  // Fetch a meeting's stored transcript. Resolves to null on 404 (no transcript
-  // stored yet) so callers can treat "absent" distinctly from a real error.
+  // Fetch a meeting's stored transcript as an ordered list of chunks. Resolves
+  // to null on 404 (no transcript stored yet) so callers can treat "absent"
+  // distinctly from a real error, and also when the payload holds no usable
+  // chunks.
   async function getMeetingTranscript(
     meetingId: number | string
-  ): Promise<string | null> {
+  ): Promise<TranscriptChunk[] | null> {
     const encodedMeetingId = encodeURIComponent(String(meetingId));
     const res = await api.request('GET', `/meeting-notes/${encodedMeetingId}/transcript`);
     if (res.status === 404) return null;
     assertOk(res, 200, 'get transcript');
-    const data = res.data as { transcript?: string } | null;
-    return typeof data?.transcript === 'string' ? data.transcript : null;
+    const data = res.data as { transcript?: unknown } | null;
+    return parseTranscriptChunks(data?.transcript);
   }
 
   // Fetch the requester's individual note. Resolves to null on 404 or when no
@@ -345,4 +372,4 @@ export function useMeetingApi() {
   };
 }
 
-export type { Meeting, PaginatedResponse, ScheduledMeeting, MeetingNotes };
+export type { Meeting, PaginatedResponse, ScheduledMeeting, MeetingNotes, TranscriptChunk };

--- a/src/views/MeetingDetailView.test.ts
+++ b/src/views/MeetingDetailView.test.ts
@@ -4,10 +4,15 @@ import { mount, flushPromises } from '@vue/test-utils';
 import type { MeetingDetail, MeetingListItem } from '../composables/useBackend';
 
 const getMeetingDetail = vi.fn();
+const getMeetingTranscript = vi.fn();
 const updateMeetingNotesTitle = vi.fn();
 
 vi.mock('../composables/useBackend', () => ({
-  getActiveBackend: () => Promise.resolve({ getMeetingDetail: (i: MeetingListItem) => getMeetingDetail(i) }),
+  getActiveBackend: () =>
+    Promise.resolve({
+      getMeetingDetail: (i: MeetingListItem) => getMeetingDetail(i),
+      getMeetingTranscript: (i: MeetingListItem) => getMeetingTranscript(i),
+    }),
 }));
 vi.mock('../composables/useMeetingApi', () => ({
   useMeetingApi: () => ({ updateMeetingNotesTitle: (...a: unknown[]) => updateMeetingNotesTitle(...a) }),
@@ -39,6 +44,7 @@ async function mountWith(d: MeetingDetail) {
 beforeEach(() => {
   vi.clearAllMocks();
   updateMeetingNotesTitle.mockResolvedValue(undefined);
+  getMeetingTranscript.mockResolvedValue(null);
 });
 
 describe('MeetingDetailView inline title editing', () => {
@@ -97,6 +103,31 @@ describe('MeetingDetailView inline title editing', () => {
     expect(wrapper.find('.head-title--editable').exists()).toBe(false);
     await wrapper.find('.head-title').trigger('click');
     expect(wrapper.find('input.head-title--input').exists()).toBe(false);
+  });
+
+  it('renders structured transcript chunks with timestamps for an Ariso meeting', async () => {
+    getMeetingTranscript.mockResolvedValue([
+      { chunk_index: 0, start_ms: 0, content: 'Speaker 1: Five is five bars. Should be' },
+      { chunk_index: 1, start_ms: 3120, content: 'Speaker 1: should be three. Anyway' },
+    ]);
+    const wrapper = await mountWith(detail({ hasTranscript: true }));
+    // Transcript is the only available tab, so it loads on mount.
+    await flushPromises();
+
+    const lines = wrapper.findAll('.transcript-line');
+    expect(lines).toHaveLength(2);
+    expect(lines[0].find('.transcript-ts').text()).toBe('0:00');
+    expect(lines[0].find('.transcript-content').text()).toBe('Speaker 1: Five is five bars. Should be');
+    expect(lines[1].find('.transcript-ts').text()).toBe('0:03');
+    expect(lines[1].find('.transcript-content').text()).toBe('Speaker 1: should be three. Anyway');
+  });
+
+  it('shows the empty state when an Ariso meeting has no transcript chunks', async () => {
+    getMeetingTranscript.mockResolvedValue(null);
+    const wrapper = await mountWith(detail({ hasTranscript: true }));
+    await flushPromises();
+    expect(wrapper.find('.transcript-line').exists()).toBe(false);
+    expect(wrapper.find('.content-empty').text()).toBe('No transcript available.');
   });
 
   it('keeps the editor open and does not emit when the API fails', async () => {

--- a/src/views/MeetingDetailView.vue
+++ b/src/views/MeetingDetailView.vue
@@ -166,7 +166,13 @@
 
         <template v-else-if="activeTab === 'transcript'">
           <div v-if="loadingTranscript" class="card-state"><span class="spinner" /><span>Loading transcript…</span></div>
-          <div v-else-if="transcriptText" class="md" v-html="renderMarkdown(transcriptText)" />
+          <div v-else-if="transcriptMarkdown" class="md" v-html="renderMarkdown(transcriptMarkdown)" />
+          <ol v-else-if="transcriptChunks" class="transcript">
+            <li v-for="c in transcriptChunks" :key="c.chunk_index" class="transcript-line">
+              <span class="transcript-ts">{{ formatTimestamp(c.start_ms) }}</span>
+              <span class="transcript-content">{{ c.content }}</span>
+            </li>
+          </ol>
           <div v-else class="content-empty">No transcript available.</div>
         </template>
 
@@ -186,7 +192,7 @@
 <script setup lang="ts">
 import { ref, computed, watch, nextTick } from 'vue';
 import { renderMarkdown } from '../utils/markdown';
-import { useMeetingApi } from '../composables/useMeetingApi';
+import { useMeetingApi, type TranscriptChunk } from '../composables/useMeetingApi';
 import {
   getActiveBackend,
   type MeetingListItem,
@@ -216,8 +222,8 @@ const titleInput = ref<HTMLInputElement | null>(null);
 const canEditTitle = computed(() => !!detail.value && !detail.value.isLocal);
 
 // Transcript is loaded lazily when the Transcript tab is opened (Ariso fetches
-// /meeting-notes/{id}/transcript; local reads transcript.md).
-const transcript = ref<string | null>(null);
+// /meeting-notes/{id}/transcript as chunks; local reads transcript.md markdown).
+const transcript = ref<string | TranscriptChunk[] | null>(null);
 const transcriptLoaded = ref(false);
 const loadingTranscript = ref(false);
 
@@ -322,11 +328,26 @@ async function commitTitle(): Promise<void> {
   }
 }
 
-// Local recordings already carry their transcript on the detail; Ariso loads it
-// lazily into `transcript`. Either way this is what the Transcript tab renders.
-const transcriptText = computed<string | null>(() =>
-  detail.value?.isLocal ? detail.value?.transcript ?? null : transcript.value
+// Local recordings carry their transcript as markdown on the detail; Ariso
+// loads structured chunks lazily into `transcript`. The Transcript tab renders
+// whichever is present.
+const transcriptMarkdown = computed<string | null>(() =>
+  detail.value?.isLocal ? detail.value?.transcript ?? null : null
 );
+const transcriptChunks = computed<TranscriptChunk[] | null>(() => {
+  if (detail.value?.isLocal) return null;
+  return Array.isArray(transcript.value) ? transcript.value : null;
+});
+
+// Render a chunk's `start_ms` offset as M:SS (or H:MM:SS past an hour).
+function formatTimestamp(ms: number): string {
+  const total = Math.max(0, Math.floor(ms / 1000));
+  const h = Math.floor(total / 3600);
+  const m = Math.floor((total % 3600) / 60);
+  const s = total % 60;
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return h > 0 ? `${h}:${pad(m)}:${pad(s)}` : `${m}:${pad(s)}`;
+}
 
 function coachingPresent(c?: MeetingCoaching | null): boolean {
   return !!(c && (c.strengths?.length || c.improvements?.length || c.patterns));
@@ -642,6 +663,12 @@ const durationLabel = computed<string | null>(() => {
 .bullet { flex-shrink: 0; margin-top: 1px; }
 .bullet--green { color: #22c55e; }
 .bullet--amber { color: #f59e0b; }
+
+/* Structured transcript (Ariso chunks) */
+.transcript { margin: 0; padding: 0; list-style: none; display: flex; flex-direction: column; gap: 12px; }
+.transcript-line { display: flex; gap: 12px; align-items: baseline; font-size: 14px; line-height: 1.6; }
+.transcript-ts { flex-shrink: 0; min-width: 48px; font-variant-numeric: tabular-nums; font-size: 12px; color: #9a9a9a; padding-top: 1px; }
+.transcript-content { color: #535353; }
 
 /* Rendered markdown */
 .md { color: #535353; font-size: 14px; line-height: 1.6; }


### PR DESCRIPTION
This only applies to ariso backend.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Meeting transcripts now display with formatted timestamps for improved readability and navigation
  * Enhanced transcript viewing experience with better structured display format
  * Empty-state message displays when transcripts are unavailable

* **Tests**
  * Added comprehensive test coverage for transcript rendering with timestamps and formatting
  * Added tests for empty-state transcript display scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->