### PR TITLE
ci: split R2 publish into a separate job

### DIFF
--- a/.github/scripts/release-publish.sh
+++ b/.github/scripts/release-publish.sh
@@ -3,8 +3,9 @@
 # Build the Tauri updater manifest (latest.json) and publish the release
 # artifacts (updater tarball, DMG, manifest) to Cloudflare R2.
 #
-# Invoked by the release job in .github/workflows/desktop.yaml after the
-# bundler has produced its outputs under src-tauri/target/release/bundle/.
+# Invoked by the publish job in .github/workflows/desktop.yaml after the
+# release job has uploaded the bundler outputs (restored under
+# src-tauri/target/release/bundle/).
 #
 # Required environment:
 #   RELEASE_TAG    release tag (e.g. v0.3.1); leading 'v' is stripped for VERSION

--- a/.github/scripts/release-publish.sh
+++ b/.github/scripts/release-publish.sh
@@ -38,6 +38,17 @@ require_env() {
 
 require_env RELEASE_TAG R2_ENDPOINT R2_BUCKET AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
 
+# R2_BUCKET must be the bucket NAME (e.g. ariso-app), not the public
+# pub-<hash>.r2.dev domain that serves it. Bucket names can't contain dots,
+# and the AWS CLI surfaces the mixup as an unhelpful InvalidBucketName error
+# from CreateMultipartUpload.
+if [[ "$R2_BUCKET" == *.* ]]; then
+  echo "R2_BUCKET looks like a domain ('${R2_BUCKET}'), not a bucket name." >&2
+  echo "Set it to the R2 bucket name (no dots), e.g. via" \
+    "'gh variable set R2_BUCKET --env release --body <bucket>'." >&2
+  exit 1
+fi
+
 # Ensure the AWS CLI is available on the self-hosted runner.
 if ! command -v aws >/dev/null 2>&1; then
   echo "AWS CLI not found on runner; install with 'brew install awscli'." >&2

--- a/.github/workflows/desktop.yaml
+++ b/.github/workflows/desktop.yaml
@@ -197,9 +197,6 @@ jobs:
     # The R2 credentials live in the `release` environment alongside the Apple
     # signing secrets (see README → Signing & Notarization).
     environment: release
-    permissions:
-      # Needed to append the download link to the GitHub Release.
-      contents: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v6

--- a/.github/workflows/desktop.yaml
+++ b/.github/workflows/desktop.yaml
@@ -103,7 +103,7 @@ jobs:
     # the required-reviewer protection rule (see README → Signing & Notarization).
     environment: release
     permissions:
-      contents: write
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -173,6 +173,44 @@ jobs:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         run: npm run tauri:build -- -- --features prod-api
+
+      # Hand the bundler outputs to the publish job. Paths share the common
+      # ancestor bundle/, so the artifact preserves the macos/ and dmg/
+      # subdirectories that release-publish.sh expects. The DMG and tarball are
+      # already compressed, so skip recompression.
+      - name: Upload release bundle
+        uses: actions/upload-artifact@v7
+        with:
+          name: release-bundle
+          if-no-files-found: error
+          compression-level: 0
+          retention-days: 1
+          path: |
+            src-tauri/target/release/bundle/macos/*.app.tar.gz
+            src-tauri/target/release/bundle/macos/*.app.tar.gz.sig
+            src-tauri/target/release/bundle/dmg/*.dmg
+
+  publish:
+    name: Generate manifest and publish artifacts to R2
+    needs: release
+    runs-on: [self-hosted, macOS, ARM64]
+    # The R2 credentials live in the `release` environment alongside the Apple
+    # signing secrets (see README → Signing & Notarization).
+    environment: release
+    permissions:
+      # Needed to append the download link to the GitHub Release.
+      contents: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.release.tag_name }}
+
+      - name: Download release bundle
+        uses: actions/download-artifact@v8
+        with:
+          name: release-bundle
+          path: src-tauri/target/release/bundle
 
       - name: Generate manifest and publish artifacts to R2
         env:


### PR DESCRIPTION
## Summary
- Split the **Generate manifest and publish artifacts to R2** step (and the dependent GitHub Release link append) out of the `release` job into a new `publish` job with `needs: release`.
- The bundler outputs (updater tarball, `.sig`, DMG) are handed between jobs via a `release-bundle` workflow artifact (`if-no-files-found: error`, no recompression, 1-day retention), restored under `src-tauri/target/release/bundle` so `release-publish.sh` works unchanged.
- The `release` job no longer touches the GitHub Release, so its `contents` permission drops to `read`; `publish` carries `contents: write` for the link append and re-enters the `release` environment for the R2 credentials.

## Notes
- Because `publish` also declares `environment: release`, a required-reviewer rule on that environment will now prompt for approval twice per release (once per job). If that's unwanted, move the R2 secrets/vars to repo level or a separate unprotected environment.

## Test Plan
- [x] YAML parses cleanly
- [ ] Publish a (pre)release and confirm the `publish` job restores the artifact, uploads to R2, and appends the download link

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Tightened desktop release workflow permissions and split build vs. publish so generated release bundles are uploaded after build and retrieved by a dedicated publish job for publishing.
* **Documentation**
  * Clarified publish-job invocation and restored bundle output location in script header comments.
* **Bug Fixes**
  * Added runtime validation that rejects misconfigured bucket names containing dots and shows an actionable error message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->