### PR TITLE
Add next-meeting tray countdown

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ src-tauri/ariso-stt/.swiftpm/
 .superpowers/
 docs/superpowers/plans/
 .DS_Store
+.env

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -61,6 +61,7 @@ name = "ariso-desktop"
 version = "0.3.3"
 dependencies = [
  "block2",
+ "chrono",
  "futures-util",
  "objc2",
  "objc2-foundation",
@@ -498,8 +499,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
+ "js-sys",
  "num-traits",
  "serde",
+ "wasm-bindgen",
  "windows-link 0.2.1",
 ]
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -16,6 +16,7 @@ tokio = { version = "1", features = ["full"] }
 tokio-tungstenite = { version = "0.24", features = ["rustls-tls-native-roots"] }
 futures-util = "0.3"
 url = "2"
+chrono = "0.4"
 tauri-plugin-mcp = { git = "https://github.com/P3GLEG/tauri-plugin-mcp", optional = true }
 screencapturekit = { version = "1.5", features = ["macos_13_0"] }
 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -447,16 +447,16 @@ pub async fn upload_file(
 
 #[tauri::command]
 pub async fn set_tray_recording(app: tauri::AppHandle, is_recording: bool, is_paused: bool) -> Result<(), String> {
-    crate::tray::set_menu(&app, is_recording, is_paused);
     let state = app.state::<crate::recording_state::RecordingState>();
     if is_recording {
-        // The recorder window reports this right after capture starts; the
-        // pill visibility watcher waits for it before hiding the window.
+        // Mark capture before redrawing the tray so the title refresh sees the
+        // active recording and clears the countdown text in the menu bar.
         state.mark_capture_active();
     } else {
         state.clear();
         let _ = app.emit("recording://state", false);
     }
+    crate::tray::set_menu(&app, is_recording, is_paused);
     Ok(())
 }
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -11,6 +11,7 @@ mod transcribe;
 mod model_manager;
 mod recording_state;
 mod tray;
+mod tray_meeting;
 mod update_manager;
 
 fn main() {

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -46,6 +46,7 @@ fn main() {
             model_manager::download_local_llm,
             meeting_notifications::sync_meeting_notifications,
             meeting_notifications::stop_meeting_notifications,
+            tray_meeting::sync_tray_meeting,
             mic_monitor::sync_auto_record,
             mic_monitor::auto_record_supported,
             audio_capture::start_system_audio_capture,
@@ -62,7 +63,18 @@ fn main() {
         .setup(|app| {
             use tauri::{Manager, WebviewWindowBuilder, WebviewUrl};
 
+            // Managed state must exist before the tray is created: tray menu
+            // rebuilds and the title refresher read RecordingState and
+            // FeaturedMeetingState.
+            app.manage(recording_state::RecordingState::new());
+            app.manage(tray_meeting::TrayMeetingManager::new());
+            app.manage(tray_meeting::FeaturedMeetingState::new());
+
             tray::create_tray(app.handle())?;
+
+            // Native next-meeting tray orchestrator. Self-gates on Ariso
+            // backend + session; re-synced from BootstrapView on SYNC_EVENT.
+            tray_meeting::sync(app.handle());
 
             let initial_state = update_manager::load_state(&app.handle());
             app.manage(update_manager::Manager::new(initial_state));
@@ -70,7 +82,6 @@ fn main() {
             // Native meeting-prep notification orchestrator. Owns the Pusher
             // connection in the Rust process (webviews get suspended when
             // hidden). Self-gates on session + the enabled toggle.
-            app.manage(recording_state::RecordingState::new());
             app.manage(mic_monitor::MicMonitorManager::new());
             // Start the auto-record mic monitor (self-gates on OS support + the
             // enabled setting).

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -19,6 +19,8 @@ pub fn set_menu(app: &AppHandle, is_recording: bool, is_paused: bool) {
             .0
             .lock()
             .unwrap_or_else(|poisoned| {
+                // If a previous tray update panicked while holding this lock,
+                // keep the last meeting instead of crashing the whole tray.
                 eprintln!("tray: FeaturedMeetingState mutex poisoned; recovering");
                 poisoned.into_inner()
             })
@@ -45,6 +47,8 @@ pub fn refresh_tray_title(app: &AppHandle) {
         .0
         .lock()
         .unwrap_or_else(|poisoned| {
+            // If the shared meeting state was poisoned, use the stored value
+            // anyway so the tray can clear or redraw instead of panicking.
             eprintln!("tray: FeaturedMeetingState mutex poisoned; recovering");
             poisoned.into_inner()
         })
@@ -121,6 +125,8 @@ pub fn create_tray(app: &AppHandle) -> tauri::Result<()> {
                             .0
                             .lock()
                             .unwrap_or_else(|poisoned| {
+                                // A poisoned lock still contains the selected
+                                // meeting; recover it so one-click record works.
                                 eprintln!(
                                     "tray: FeaturedMeetingState mutex poisoned; recovering"
                                 );
@@ -265,6 +271,8 @@ pub fn build_idle_menu(
         .build()
 }
 
+/// Build the smaller tray menu shown while a recording is running. It exposes
+/// only controls that are safe during capture, so users cannot quit mid-upload.
 pub fn build_recording_menu(app: &AppHandle, is_paused: bool) -> tauri::Result<tauri::menu::Menu<tauri::Wry>> {
     let pause_or_resume = if is_paused {
         MenuItemBuilder::with_id("resume_recording", "Resume Recording").build(app)?

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -44,14 +44,16 @@ pub fn refresh_tray_title(app: &AppHandle) {
         .unwrap()
         .clone();
     let title = match featured {
-        Some(f) if !recording => Some(crate::tray_meeting::format_title_bar(
+        Some(f) if !recording => crate::tray_meeting::format_title_bar(
             f.title.as_deref(),
             f.start_at,
             chrono::Utc::now(),
-        )),
-        _ => None,
+        ),
+        // macOS keeps the previous status-item title when passed `None`; use
+        // an explicit empty string for signed-out, Local, and recording states.
+        _ => String::new(),
     };
-    let _ = tray.set_title(title);
+    let _ = tray.set_title(Some(title));
 }
 
 pub fn create_tray(app: &AppHandle) -> tauri::Result<()> {

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -14,15 +14,48 @@ pub fn set_menu(app: &AppHandle, is_recording: bool, is_paused: bool) {
     let menu = if is_recording {
         build_recording_menu(app, is_paused)
     } else {
-        build_idle_menu(app)
+        let featured = app
+            .state::<crate::tray_meeting::FeaturedMeetingState>()
+            .0
+            .lock()
+            .unwrap()
+            .clone();
+        build_idle_menu(app, featured.as_ref())
     };
     if let Ok(menu) = menu {
         let _ = tray.set_menu(Some(menu));
     }
+    refresh_tray_title(app);
+}
+
+/// Render or clear the menu-bar text next to the tray icon. Shows the
+/// featured meeting's countdown only when idle; recording (or no upcoming
+/// meeting / Local backend / signed out) clears it. macOS-only effect —
+/// `set_title` is a no-op elsewhere.
+pub fn refresh_tray_title(app: &AppHandle) {
+    let Some(tray) = app.tray_by_id("main") else { return };
+    let recording = app
+        .state::<crate::recording_state::RecordingState>()
+        .is_active();
+    let featured = app
+        .state::<crate::tray_meeting::FeaturedMeetingState>()
+        .0
+        .lock()
+        .unwrap()
+        .clone();
+    let title = match featured {
+        Some(f) if !recording => Some(crate::tray_meeting::format_title_bar(
+            f.title.as_deref(),
+            f.start_at,
+            chrono::Utc::now(),
+        )),
+        _ => None,
+    };
+    let _ = tray.set_title(title);
 }
 
 pub fn create_tray(app: &AppHandle) -> tauri::Result<()> {
-    let menu = build_idle_menu(app)?;
+    let menu = build_idle_menu(app, None)?;
 
     TrayIconBuilder::with_id("main")
         .icon(Image::from_bytes(TRAY_ICON_BYTES)?)
@@ -69,6 +102,37 @@ pub fn create_tray(app: &AppHandle) -> tauri::Result<()> {
                                 return;
                             }
                             let _ = crate::commands::open_meeting_picker_window(&app_main);
+                        });
+                    });
+                }
+                "record_featured" => {
+                    let app_async = app.clone();
+                    tauri::async_runtime::spawn(async move {
+                        let meeting_id = app_async
+                            .state::<crate::tray_meeting::FeaturedMeetingState>()
+                            .0
+                            .lock()
+                            .unwrap()
+                            .as_ref()
+                            .map(|f| f.id);
+                        let Some(meeting_id) = meeting_id else { return };
+
+                        let valid = crate::commands::is_session_valid(&app_async).await;
+                        let app_main = app_async.clone();
+                        let _ = app_async.run_on_main_thread(move || {
+                            if !valid {
+                                if let Some(win) = app_main.get_webview_window("settings") {
+                                    let _ = win.show();
+                                    let _ = win.set_focus();
+                                }
+                                let _ = app_main.emit("tray://show-sign-in-prompt", ());
+                                return;
+                            }
+                            let _ = crate::commands::open_waveform_window(
+                                &app_main,
+                                Some(meeting_id),
+                                false,
+                            );
                         });
                     });
                 }
@@ -145,14 +209,39 @@ pub fn create_tray(app: &AppHandle) -> tauri::Result<()> {
     Ok(())
 }
 
-pub fn build_idle_menu(app: &AppHandle) -> tauri::Result<tauri::menu::Menu<tauri::Wry>> {
+pub fn build_idle_menu(
+    app: &AppHandle,
+    featured: Option<&crate::tray_meeting::FeaturedMeeting>,
+) -> tauri::Result<tauri::menu::Menu<tauri::Wry>> {
+    let mut builder = MenuBuilder::new(app);
+
+    // Featured next meeting: a clickable full-title row that records that
+    // meeting, over a disabled (gray) time row. muda has no per-item font
+    // control, so a disabled item is the closest native "subtitle".
+    if let Some(f) = featured {
+        let title = f
+            .title
+            .clone()
+            .filter(|t| !t.trim().is_empty())
+            .unwrap_or_else(|| "Untitled meeting".to_string());
+        let record_featured = MenuItemBuilder::with_id("record_featured", title).build(app)?;
+        let time_label = crate::tray_meeting::format_time_range(
+            f.start_at.with_timezone(&chrono::Local),
+            f.end_at.map(|e| e.with_timezone(&chrono::Local)),
+        );
+        let time_row = MenuItemBuilder::with_id("featured_time", time_label)
+            .enabled(false)
+            .build(app)?;
+        builder = builder.item(&record_featured).item(&time_row).separator();
+    }
+
     let start = MenuItemBuilder::with_id("start_recording", "Start Recording").build(app)?;
     let settings = MenuItemBuilder::with_id("settings", "Settings...").build(app)?;
     let library = MenuItemBuilder::with_id("library", "Meetings...").build(app)?;
     let check_updates = MenuItemBuilder::with_id("check_updates", "Check for Updates…").build(app)?;
     let quit = MenuItemBuilder::with_id("quit", "Quit Ariso").build(app)?;
 
-    MenuBuilder::new(app)
+    builder
         .item(&start)
         .separator()
         .item(&settings)

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -18,7 +18,10 @@ pub fn set_menu(app: &AppHandle, is_recording: bool, is_paused: bool) {
             .state::<crate::tray_meeting::FeaturedMeetingState>()
             .0
             .lock()
-            .unwrap()
+            .unwrap_or_else(|poisoned| {
+                eprintln!("tray: FeaturedMeetingState mutex poisoned; recovering");
+                poisoned.into_inner()
+            })
             .clone();
         build_idle_menu(app, featured.as_ref())
     };
@@ -41,7 +44,10 @@ pub fn refresh_tray_title(app: &AppHandle) {
         .state::<crate::tray_meeting::FeaturedMeetingState>()
         .0
         .lock()
-        .unwrap()
+        .unwrap_or_else(|poisoned| {
+            eprintln!("tray: FeaturedMeetingState mutex poisoned; recovering");
+            poisoned.into_inner()
+        })
         .clone();
     let title = match featured {
         Some(f) if !recording => crate::tray_meeting::format_title_bar(
@@ -114,7 +120,12 @@ pub fn create_tray(app: &AppHandle) -> tauri::Result<()> {
                             .state::<crate::tray_meeting::FeaturedMeetingState>()
                             .0
                             .lock()
-                            .unwrap()
+                            .unwrap_or_else(|poisoned| {
+                                eprintln!(
+                                    "tray: FeaturedMeetingState mutex poisoned; recovering"
+                                );
+                                poisoned.into_inner()
+                            })
                             .as_ref()
                             .map(|f| f.id);
                         let Some(meeting_id) = meeting_id else { return };

--- a/src-tauri/src/tray_meeting.rs
+++ b/src-tauri/src/tray_meeting.rs
@@ -1,0 +1,52 @@
+//! Next-meeting tray orchestrator (native).
+//!
+//! Fetches today's scheduled meetings from the Ariso API, features the next
+//! strictly-upcoming one in the menu-bar tray (countdown title + menu rows),
+//! and promotes the following meeting once it starts. Lives in the Rust
+//! process for the same reason as `meeting_notifications`: macOS suspends
+//! hidden webviews, so a webview timer would freeze in the background.
+
+use std::sync::Mutex;
+
+use chrono::{DateTime, Utc};
+
+/// A meeting from `GET /meetings` (list payload carries no end time).
+#[derive(Clone, Debug, PartialEq)]
+pub struct ScheduledMeeting {
+    pub id: i64,
+    pub title: Option<String>,
+    pub start_at: DateTime<Utc>,
+}
+
+/// The meeting currently surfaced in the tray. `end_at` is resolved
+/// separately via `GET /meeting-notes/:id` and may be absent.
+#[derive(Clone, Debug, PartialEq)]
+pub struct FeaturedMeeting {
+    pub id: i64,
+    pub title: Option<String>,
+    pub start_at: DateTime<Utc>,
+    pub end_at: Option<DateTime<Utc>>,
+}
+
+/// Holds the handle to the running orchestrator task (if any).
+#[derive(Default)]
+pub struct TrayMeetingManager {
+    handle: Mutex<Option<tauri::async_runtime::JoinHandle<()>>>,
+}
+
+impl TrayMeetingManager {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+/// The currently featured meeting, readable by the tray menu builder and the
+/// `record_featured` menu-event arm (both need it from `'static` contexts).
+#[derive(Default)]
+pub struct FeaturedMeetingState(pub Mutex<Option<FeaturedMeeting>>);
+
+impl FeaturedMeetingState {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}

--- a/src-tauri/src/tray_meeting.rs
+++ b/src-tauri/src/tray_meeting.rs
@@ -70,6 +70,19 @@ pub(crate) fn truncate_title(title: Option<&str>) -> String {
     out
 }
 
+/// Relative countdown to a future start time: `in 12min`, or `in <1min`
+/// under a minute. Callers only pass strictly-upcoming meetings; a stale
+/// (already-started) one reads `in <1min` until the next tick drops it.
+pub(crate) fn format_countdown(start: DateTime<Utc>, now: DateTime<Utc>) -> String {
+    // num_minutes truncates toward zero == floor for positive durations.
+    let mins = (start - now).num_minutes();
+    if mins >= 1 {
+        format!("in {mins}min")
+    } else {
+        "in <1min".to_string()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -99,5 +112,42 @@ mod tests {
     #[test]
     fn truncate_title_counts_unicode_scalars_not_bytes() {
         assert_eq!(truncate_title(Some("héllo wörld plus")), "héllo wörl…");
+    }
+
+    /// Parse an RFC 3339 timestamp into UTC for test fixtures.
+    fn t(s: &str) -> DateTime<Utc> {
+        DateTime::parse_from_rfc3339(s).unwrap().with_timezone(&Utc)
+    }
+
+    #[test]
+    fn countdown_whole_minutes() {
+        assert_eq!(
+            format_countdown(t("2026-06-11T10:12:00Z"), t("2026-06-11T10:00:00Z")),
+            "in 12min"
+        );
+    }
+
+    #[test]
+    fn countdown_floors_partial_minutes() {
+        assert_eq!(
+            format_countdown(t("2026-06-11T10:12:30Z"), t("2026-06-11T10:00:00Z")),
+            "in 12min"
+        );
+    }
+
+    #[test]
+    fn countdown_exactly_one_minute() {
+        assert_eq!(
+            format_countdown(t("2026-06-11T10:01:00Z"), t("2026-06-11T10:00:00Z")),
+            "in 1min"
+        );
+    }
+
+    #[test]
+    fn countdown_under_a_minute() {
+        assert_eq!(
+            format_countdown(t("2026-06-11T10:00:59Z"), t("2026-06-11T10:00:00Z")),
+            "in <1min"
+        );
     }
 }

--- a/src-tauri/src/tray_meeting.rs
+++ b/src-tauri/src/tray_meeting.rs
@@ -116,6 +116,20 @@ where
     }
 }
 
+/// The soonest meeting with `start_at` strictly after `now`. Computes the min
+/// explicitly so it is order-independent (mirrors the TS `pickDefaultMeeting`
+/// `next` arm; the "current meeting" arm is intentionally absent — only
+/// strictly-upcoming meetings are featured in the tray).
+pub(crate) fn pick_next_upcoming(
+    meetings: &[ScheduledMeeting],
+    now: DateTime<Utc>,
+) -> Option<&ScheduledMeeting> {
+    meetings
+        .iter()
+        .filter(|m| m.start_at > now)
+        .min_by_key(|m| m.start_at)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -228,5 +242,36 @@ mod tests {
     #[test]
     fn time_range_start_only() {
         assert_eq!(format_time_range(at(10, 0), None), "10:00 AM");
+    }
+
+    fn meeting(id: i64, start: &str) -> ScheduledMeeting {
+        ScheduledMeeting { id, title: None, start_at: t(start) }
+    }
+
+    #[test]
+    fn pick_empty_list_is_none() {
+        assert!(pick_next_upcoming(&[], t("2026-06-11T10:00:00Z")).is_none());
+    }
+
+    #[test]
+    fn pick_all_past_is_none() {
+        let ms = [meeting(1, "2026-06-11T08:00:00Z"), meeting(2, "2026-06-11T09:00:00Z")];
+        assert!(pick_next_upcoming(&ms, t("2026-06-11T10:00:00Z")).is_none());
+    }
+
+    #[test]
+    fn pick_soonest_strictly_future_order_independent() {
+        let ms = [
+            meeting(1, "2026-06-11T15:00:00Z"),
+            meeting(2, "2026-06-11T11:00:00Z"),
+            meeting(3, "2026-06-11T08:00:00Z"),
+        ];
+        assert_eq!(pick_next_upcoming(&ms, t("2026-06-11T10:00:00Z")).unwrap().id, 2);
+    }
+
+    #[test]
+    fn pick_excludes_meeting_starting_exactly_now() {
+        let ms = [meeting(1, "2026-06-11T10:00:00Z"), meeting(2, "2026-06-11T11:00:00Z")];
+        assert_eq!(pick_next_upcoming(&ms, t("2026-06-11T10:00:00Z")).unwrap().id, 2);
     }
 }

--- a/src-tauri/src/tray_meeting.rs
+++ b/src-tauri/src/tray_meeting.rs
@@ -133,6 +133,9 @@ fn refresh_tray(app: &AppHandle, rebuild_menu: bool) {
 /// redraw + promote-on-start) and re-fetch every 5min. Exits only on an auth
 /// rejection; transient errors keep the last known state and retry.
 async fn run_loop(app: AppHandle) {
+    // Keep the latest meeting list in memory so normal one-minute ticks do not
+    // hit the API every time. End times are cached separately because they need
+    // a per-meeting detail request.
     let mut meetings: Vec<ScheduledMeeting> = Vec::new();
     let mut end_cache: HashMap<i64, Option<DateTime<Utc>>> = HashMap::new();
     let mut ticks_until_fetch = 0u32;
@@ -397,6 +400,8 @@ fn parse_id(v: Option<&Value>) -> Option<i64> {
 }
 
 fn parse_datetime(v: Option<&Value>) -> Option<DateTime<Utc>> {
+    // Server times arrive as strings with offsets. Normalise them to UTC so
+    // comparisons and countdown maths use one clock.
     v.and_then(Value::as_str)
         .and_then(|s| DateTime::parse_from_rfc3339(s).ok())
         .map(|dt| dt.with_timezone(&Utc))

--- a/src-tauri/src/tray_meeting.rs
+++ b/src-tauri/src/tray_meeting.rs
@@ -50,3 +50,54 @@ impl FeaturedMeetingState {
         Self::default()
     }
 }
+
+/// Max characters of the meeting title shown in the menu-bar (tray) title.
+const TITLE_MAX_CHARS: usize = 10;
+
+/// Truncate a meeting title for the tray title bar. `None`/blank titles
+/// become "Untitled meeting"; titles longer than 10 Unicode scalar values
+/// are cut to 10 + `…`.
+pub(crate) fn truncate_title(title: Option<&str>) -> String {
+    let Some(s) = title.filter(|s| !s.trim().is_empty()) else {
+        return "Untitled meeting".to_string();
+    };
+    let chars: Vec<char> = s.chars().collect();
+    if chars.len() <= TITLE_MAX_CHARS {
+        return s.to_string();
+    }
+    let mut out: String = chars[..TITLE_MAX_CHARS].iter().collect();
+    out.push('…');
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn truncate_title_none_is_untitled() {
+        assert_eq!(truncate_title(None), "Untitled meeting");
+    }
+
+    #[test]
+    fn truncate_title_blank_is_untitled() {
+        assert_eq!(truncate_title(Some("")), "Untitled meeting");
+        assert_eq!(truncate_title(Some("   ")), "Untitled meeting");
+    }
+
+    #[test]
+    fn truncate_title_short_unchanged() {
+        assert_eq!(truncate_title(Some("Standup")), "Standup");
+        assert_eq!(truncate_title(Some("Exactly10!")), "Exactly10!");
+    }
+
+    #[test]
+    fn truncate_title_long_truncated_to_10_plus_ellipsis() {
+        assert_eq!(truncate_title(Some("Weekly Engineering Sync")), "Weekly Eng…");
+    }
+
+    #[test]
+    fn truncate_title_counts_unicode_scalars_not_bytes() {
+        assert_eq!(truncate_title(Some("héllo wörld plus")), "héllo wörl…");
+    }
+}

--- a/src-tauri/src/tray_meeting.rs
+++ b/src-tauri/src/tray_meeting.rs
@@ -6,10 +6,16 @@
 //! process for the same reason as `meeting_notifications`: macOS suspends
 //! hidden webviews, so a webview timer would freeze in the background.
 
+use std::collections::HashMap;
 use std::sync::Mutex;
+use std::time::Duration;
 
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, Local, SecondsFormat, Utc};
+use reqwest::header::{AUTHORIZATION, CONTENT_TYPE};
 use serde_json::Value;
+use tauri::{AppHandle, Manager};
+
+use crate::commands::{api_base_url, clear_session_token, get_session_token, http_client};
 
 /// A meeting from `GET /meetings` (list payload carries no end time).
 #[derive(Clone, Debug, PartialEq)]
@@ -50,6 +56,231 @@ impl FeaturedMeetingState {
     pub fn new() -> Self {
         Self::default()
     }
+}
+
+/// Per-HTTP-request cap covering `.send()` and body decode (the shared
+/// `http_client` has no request timeout — same convention as
+/// `meeting_notifications`).
+const HTTP_TIMEOUT: Duration = Duration::from_secs(15);
+
+/// Countdown redraw cadence.
+const TICK: Duration = Duration::from_secs(60);
+
+/// Full server re-fetch happens every N ticks (5 minutes).
+const FETCH_EVERY_TICKS: u32 = 5;
+
+/// `Auth` means the server rejected the stored session (401/403) — the
+/// orchestrator tears down instead of retrying (mirrors meeting_notifications).
+enum FetchError {
+    Auth,
+    Other(String),
+}
+
+/// Start the orchestrator iff the active backend is Ariso and a session token
+/// is present; otherwise stop it. Safe to call repeatedly (sign-in/out,
+/// backend change). The Local backend has no scheduled meetings, so it gets
+/// no tray title and the unchanged idle menu.
+pub fn sync(app: &AppHandle) {
+    let desired =
+        crate::commands::active_backend(app) == "ariso" && get_session_token(app).is_some();
+    if !desired {
+        stop(app);
+        return;
+    }
+    let mgr = app.state::<TrayMeetingManager>();
+    let mut guard = mgr.handle.lock().unwrap();
+    if guard.is_some() {
+        return;
+    }
+    let app = app.clone();
+    *guard = Some(tauri::async_runtime::spawn(async move {
+        run_loop(app).await;
+    }));
+}
+
+/// Stop the orchestrator, clear the featured meeting, and redraw the tray
+/// (title cleared, idle menu without meeting rows).
+pub fn stop(app: &AppHandle) {
+    let mgr = app.state::<TrayMeetingManager>();
+    let mut guard = mgr.handle.lock().unwrap();
+    if let Some(handle) = guard.take() {
+        handle.abort();
+    }
+    drop(guard);
+    *app.state::<FeaturedMeetingState>().0.lock().unwrap() = None;
+    refresh_tray(app, true);
+}
+
+/// Redraw the tray on the main thread (muda menus are main-thread on macOS).
+/// While recording, the recording menu owns the tray — only the title is
+/// refreshed (which clears it). `rebuild_menu` skips a full idle-menu rebuild
+/// on countdown-only ticks so an open tray menu isn't yanked shut.
+fn refresh_tray(app: &AppHandle, rebuild_menu: bool) {
+    let app = app.clone();
+    let _ = app.clone().run_on_main_thread(move || {
+        let recording = app
+            .state::<crate::recording_state::RecordingState>()
+            .is_active();
+        if rebuild_menu && !recording {
+            crate::tray::set_menu(&app, false, false);
+        } else {
+            crate::tray::refresh_tray_title(&app);
+        }
+    });
+}
+
+/// Fetch → pick → resolve end_at → render, then tick every 60s (countdown
+/// redraw + promote-on-start) and re-fetch every 5min. Exits only on an auth
+/// rejection; transient errors keep the last known state and retry.
+async fn run_loop(app: AppHandle) {
+    let mut meetings: Vec<ScheduledMeeting> = Vec::new();
+    let mut end_cache: HashMap<i64, Option<DateTime<Utc>>> = HashMap::new();
+    let mut ticks_until_fetch = 0u32;
+    let mut interval = tokio::time::interval(TICK);
+    interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+
+    loop {
+        interval.tick().await;
+
+        if ticks_until_fetch == 0 {
+            ticks_until_fetch = FETCH_EVERY_TICKS;
+            match fetch_today_meetings(&app).await {
+                Ok(list) => meetings = list,
+                Err(FetchError::Auth) => break,
+                Err(FetchError::Other(e)) => {
+                    eprintln!("tray-meeting: list fetch failed: {e}");
+                }
+            }
+        }
+        ticks_until_fetch -= 1;
+
+        let now = Utc::now();
+        let featured = match pick_next_upcoming(&meetings, now) {
+            Some(m) => {
+                let end_at = match end_cache.get(&m.id) {
+                    Some(cached) => *cached,
+                    None => {
+                        let end = match fetch_end_at(&app, m.id).await {
+                            Ok(end) => end,
+                            Err(FetchError::Auth) => break,
+                            Err(FetchError::Other(e)) => {
+                                eprintln!(
+                                    "tray-meeting: end_at fetch failed (start-only display): {e}"
+                                );
+                                None
+                            }
+                        };
+                        end_cache.insert(m.id, end);
+                        end
+                    }
+                };
+                Some(FeaturedMeeting {
+                    id: m.id,
+                    title: m.title.clone(),
+                    start_at: m.start_at,
+                    end_at,
+                })
+            }
+            None => None,
+        };
+
+        let menu_changed = {
+            let state = app.state::<FeaturedMeetingState>();
+            let mut guard = state.0.lock().unwrap();
+            let changed = *guard != featured;
+            *guard = featured;
+            changed
+        };
+        refresh_tray(&app, menu_changed);
+    }
+
+    eprintln!("tray-meeting: session invalid; clearing token and stopping orchestrator");
+    let _ = clear_session_token(&app);
+    {
+        let mgr = app.state::<TrayMeetingManager>();
+        *mgr.handle.lock().unwrap() = None;
+    }
+    *app.state::<FeaturedMeetingState>().0.lock().unwrap() = None;
+    refresh_tray(&app, true);
+}
+
+/// GET /meetings?startDate&endDate (local-day bounds) → parsed list.
+async fn fetch_today_meetings(app: &AppHandle) -> Result<Vec<ScheduledMeeting>, FetchError> {
+    let token = get_session_token(app).ok_or(FetchError::Auth)?;
+    let (start, end) = day_bounds(Local::now());
+    let v: Value = tokio::time::timeout(HTTP_TIMEOUT, async {
+        let resp = http_client()
+            .get(format!("{}/meetings", api_base_url()))
+            .query(&[
+                ("startDate", start.to_rfc3339_opts(SecondsFormat::Millis, true)),
+                ("endDate", end.to_rfc3339_opts(SecondsFormat::Millis, true)),
+            ])
+            .header(AUTHORIZATION, format!("Bearer {token}"))
+            .header(CONTENT_TYPE, "application/json")
+            .send()
+            .await
+            .map_err(|e| FetchError::Other(e.to_string()))?;
+        let status = resp.status();
+        if status == reqwest::StatusCode::UNAUTHORIZED || status == reqwest::StatusCode::FORBIDDEN
+        {
+            return Err(FetchError::Auth);
+        }
+        if !status.is_success() {
+            return Err(FetchError::Other(format!(
+                "/meetings returned {}",
+                status.as_u16()
+            )));
+        }
+        resp.json::<Value>()
+            .await
+            .map_err(|e| FetchError::Other(e.to_string()))
+    })
+    .await
+    .map_err(|_| FetchError::Other("/meetings timed out".into()))??;
+    Ok(parse_meetings(&v))
+}
+
+/// GET /meeting-notes/:id → optional end_at.
+async fn fetch_end_at(
+    app: &AppHandle,
+    meeting_id: i64,
+) -> Result<Option<DateTime<Utc>>, FetchError> {
+    let token = get_session_token(app).ok_or(FetchError::Auth)?;
+    let v: Value = tokio::time::timeout(HTTP_TIMEOUT, async {
+        let resp = http_client()
+            .get(format!("{}/meeting-notes/{meeting_id}", api_base_url()))
+            .header(AUTHORIZATION, format!("Bearer {token}"))
+            .header(CONTENT_TYPE, "application/json")
+            .send()
+            .await
+            .map_err(|e| FetchError::Other(e.to_string()))?;
+        let status = resp.status();
+        if status == reqwest::StatusCode::UNAUTHORIZED || status == reqwest::StatusCode::FORBIDDEN
+        {
+            return Err(FetchError::Auth);
+        }
+        if !status.is_success() {
+            return Err(FetchError::Other(format!(
+                "/meeting-notes/{meeting_id} returned {}",
+                status.as_u16()
+            )));
+        }
+        resp.json::<Value>()
+            .await
+            .map_err(|e| FetchError::Other(e.to_string()))
+    })
+    .await
+    .map_err(|_| FetchError::Other(format!("/meeting-notes/{meeting_id} timed out")))??;
+    Ok(parse_end_at(&v))
+}
+
+/// Re-evaluate the orchestrator's desired state. Invoked by the bootstrap
+/// window on launch and on every SYNC_EVENT broadcast (sign-in/out, backend
+/// change) — same pattern as `sync_meeting_notifications`.
+#[tauri::command]
+pub async fn sync_tray_meeting(app: AppHandle) -> Result<(), String> {
+    sync(&app);
+    Ok(())
 }
 
 /// Max characters of the meeting title shown in the menu-bar (tray) title.

--- a/src-tauri/src/tray_meeting.rs
+++ b/src-tauri/src/tray_meeting.rs
@@ -66,20 +66,22 @@ const HTTP_TIMEOUT: Duration = Duration::from_secs(15);
 /// Countdown redraw cadence.
 const TICK: Duration = Duration::from_secs(60);
 
-/// Full server re-fetch happens every N ticks (5 minutes).
+/// Full server re-fetch happens every N ticks (5 minutes). Explicit sync calls
+/// restart the loop, so user-visible meeting-list refreshes can still pull now.
 const FETCH_EVERY_TICKS: u32 = 5;
 
 /// `Auth` means the server rejected the stored session (401/403) — the
 /// orchestrator tears down instead of retrying (mirrors meeting_notifications).
+#[derive(Debug)]
 enum FetchError {
     Auth,
     Other(String),
 }
 
-/// Start the orchestrator iff the active backend is Ariso and a session token
-/// is present; otherwise stop it. Safe to call repeatedly (sign-in/out,
-/// backend change). The Local backend has no scheduled meetings, so it gets
-/// no tray title and the unchanged idle menu.
+/// Start or refresh the orchestrator iff the active backend is Ariso and a
+/// session token is present; otherwise stop it. A repeated sync aborts the old
+/// loop and starts a fresh one so a visible meeting-list reload gets tray data
+/// immediately instead of waiting for the 5-minute poll.
 pub fn sync(app: &AppHandle) {
     let desired =
         crate::commands::active_backend(app) == "ariso" && get_session_token(app).is_some();
@@ -89,8 +91,8 @@ pub fn sync(app: &AppHandle) {
     }
     let mgr = app.state::<TrayMeetingManager>();
     let mut guard = mgr.handle.lock().unwrap();
-    if guard.is_some() {
-        return;
+    if let Some(handle) = guard.take() {
+        handle.abort();
     }
     let app = app.clone();
     *guard = Some(tauri::async_runtime::spawn(async move {
@@ -116,15 +118,15 @@ pub fn stop(app: &AppHandle) {
 /// refreshed (which clears it). `rebuild_menu` skips a full idle-menu rebuild
 /// on countdown-only ticks so an open tray menu isn't yanked shut.
 fn refresh_tray(app: &AppHandle, rebuild_menu: bool) {
-    let app = app.clone();
-    let _ = app.clone().run_on_main_thread(move || {
-        let recording = app
+    let app_for_menu = app.clone();
+    let _ = app.run_on_main_thread(move || {
+        let recording = app_for_menu
             .state::<crate::recording_state::RecordingState>()
             .is_active();
         if rebuild_menu && !recording {
-            crate::tray::set_menu(&app, false, false);
+            crate::tray::set_menu(&app_for_menu, false, false);
         } else {
-            crate::tray::refresh_tray_title(&app);
+            crate::tray::refresh_tray_title(&app_for_menu);
         }
     });
 }
@@ -163,18 +165,14 @@ async fn run_loop(app: AppHandle) {
                 let end_at = match end_cache.get(&m.id) {
                     Some(cached) => *cached,
                     None => {
-                        let end = match fetch_end_at(&app, m.id).await {
+                        match cache_end_lookup(&mut end_cache, m.id, fetch_end_at(&app, m.id).await)
+                        {
                             Ok(end) => end,
                             Err(FetchError::Auth) => break,
-                            Err(FetchError::Other(e)) => {
-                                eprintln!(
-                                    "tray-meeting: end_at fetch failed (start-only display): {e}"
-                                );
-                                None
-                            }
-                        };
-                        end_cache.insert(m.id, end);
-                        end
+                            Err(FetchError::Other(_)) => unreachable!(
+                                "cache_end_lookup converts transient end_at failures into a retryable None"
+                            ),
+                        }
                     }
                 };
                 Some(FeaturedMeeting {
@@ -207,6 +205,27 @@ async fn run_loop(app: AppHandle) {
     refresh_tray(&app, true);
 }
 
+/// Store successful end-time lookups only. A timeout or 5xx should show a
+/// start-only row for this tick, but leave the cache empty so the next tick can
+/// try the detail endpoint again.
+fn cache_end_lookup(
+    end_cache: &mut HashMap<i64, Option<DateTime<Utc>>>,
+    meeting_id: i64,
+    result: Result<Option<DateTime<Utc>>, FetchError>,
+) -> Result<Option<DateTime<Utc>>, FetchError> {
+    match result {
+        Ok(end) => {
+            end_cache.insert(meeting_id, end);
+            Ok(end)
+        }
+        Err(FetchError::Auth) => Err(FetchError::Auth),
+        Err(FetchError::Other(e)) => {
+            eprintln!("tray-meeting: end_at fetch failed (start-only display): {e}");
+            Ok(None)
+        }
+    }
+}
+
 /// GET /meetings?startDate&endDate (local-day bounds) → parsed list.
 async fn fetch_today_meetings(app: &AppHandle) -> Result<Vec<ScheduledMeeting>, FetchError> {
     let token = get_session_token(app).ok_or(FetchError::Auth)?;
@@ -215,7 +234,10 @@ async fn fetch_today_meetings(app: &AppHandle) -> Result<Vec<ScheduledMeeting>, 
         let resp = http_client()
             .get(format!("{}/meetings", api_base_url()))
             .query(&[
-                ("startDate", start.to_rfc3339_opts(SecondsFormat::Millis, true)),
+                (
+                    "startDate",
+                    start.to_rfc3339_opts(SecondsFormat::Millis, true),
+                ),
                 ("endDate", end.to_rfc3339_opts(SecondsFormat::Millis, true)),
             ])
             .header(AUTHORIZATION, format!("Bearer {token}"))
@@ -224,8 +246,7 @@ async fn fetch_today_meetings(app: &AppHandle) -> Result<Vec<ScheduledMeeting>, 
             .await
             .map_err(|e| FetchError::Other(e.to_string()))?;
         let status = resp.status();
-        if status == reqwest::StatusCode::UNAUTHORIZED || status == reqwest::StatusCode::FORBIDDEN
-        {
+        if status == reqwest::StatusCode::UNAUTHORIZED || status == reqwest::StatusCode::FORBIDDEN {
             return Err(FetchError::Auth);
         }
         if !status.is_success() {
@@ -258,8 +279,7 @@ async fn fetch_end_at(
             .await
             .map_err(|e| FetchError::Other(e.to_string()))?;
         let status = resp.status();
-        if status == reqwest::StatusCode::UNAUTHORIZED || status == reqwest::StatusCode::FORBIDDEN
-        {
+        if status == reqwest::StatusCode::UNAUTHORIZED || status == reqwest::StatusCode::FORBIDDEN {
             return Err(FetchError::Auth);
         }
         if !status.is_success() {
@@ -305,13 +325,21 @@ pub(crate) fn truncate_title(title: Option<&str>) -> String {
     out
 }
 
-/// Relative countdown to a future start time: `in 12min`, or `in <1min`
-/// under a minute. Callers only pass strictly-upcoming meetings; a stale
-/// (already-started) one reads `in <1min` until the next tick drops it.
+/// Relative countdown to a future start time: `in 12min`, `in 1h39min`, or
+/// `in <1min` under a minute. Callers only pass strictly-upcoming meetings; a
+/// stale (already-started) one reads `in <1min` until the next tick drops it.
 pub(crate) fn format_countdown(start: DateTime<Utc>, now: DateTime<Utc>) -> String {
     // num_minutes truncates toward zero == floor for positive durations.
     let mins = (start - now).num_minutes();
-    if mins >= 1 {
+    if mins >= 60 {
+        let hours = mins / 60;
+        let minutes = mins % 60;
+        if minutes == 0 {
+            format!("in {hours}h")
+        } else {
+            format!("in {hours}h{minutes}min")
+        }
+    } else if mins >= 1 {
         format!("in {mins}min")
     } else {
         "in <1min".to_string()
@@ -453,7 +481,10 @@ mod tests {
 
     #[test]
     fn truncate_title_long_truncated_to_10_plus_ellipsis() {
-        assert_eq!(truncate_title(Some("Weekly Engineering Sync")), "Weekly Eng…");
+        assert_eq!(
+            truncate_title(Some("Weekly Engineering Sync")),
+            "Weekly Eng…"
+        );
     }
 
     #[test]
@@ -499,6 +530,43 @@ mod tests {
     }
 
     #[test]
+    fn countdown_over_an_hour_includes_hours_and_minutes() {
+        assert_eq!(
+            format_countdown(t("2026-06-11T11:39:00Z"), t("2026-06-11T10:00:00Z")),
+            "in 1h39min"
+        );
+    }
+
+    #[test]
+    fn countdown_exact_hours_omit_zero_minutes() {
+        assert_eq!(
+            format_countdown(t("2026-06-11T12:00:00Z"), t("2026-06-11T10:00:00Z")),
+            "in 2h"
+        );
+    }
+
+    #[test]
+    fn transient_end_lookup_failure_does_not_fill_cache() {
+        let mut cache = HashMap::new();
+        let end = cache_end_lookup(&mut cache, 7, Err(FetchError::Other("timeout".into())))
+            .expect("transient end_at failures fall back to start-only display");
+
+        assert_eq!(end, None);
+        assert!(!cache.contains_key(&7));
+    }
+
+    #[test]
+    fn successful_end_lookup_fills_cache() {
+        let mut cache = HashMap::new();
+        let end_at = Some(t("2026-06-11T10:30:00Z"));
+        let end = cache_end_lookup(&mut cache, 7, Ok(end_at))
+            .expect("successful end_at lookups are cacheable");
+
+        assert_eq!(end, end_at);
+        assert_eq!(cache.get(&7), Some(&end_at));
+    }
+
+    #[test]
     fn title_bar_composes_truncated_title_and_countdown() {
         assert_eq!(
             format_title_bar(
@@ -531,12 +599,18 @@ mod tests {
 
     #[test]
     fn time_range_same_meridiem_shares_suffix() {
-        assert_eq!(format_time_range(at(10, 0), Some(at(10, 30))), "10:00 – 10:30 AM");
+        assert_eq!(
+            format_time_range(at(10, 0), Some(at(10, 30))),
+            "10:00 – 10:30 AM"
+        );
     }
 
     #[test]
     fn time_range_cross_meridiem_shows_both() {
-        assert_eq!(format_time_range(at(11, 30), Some(at(12, 15))), "11:30 AM – 12:15 PM");
+        assert_eq!(
+            format_time_range(at(11, 30), Some(at(12, 15))),
+            "11:30 AM – 12:15 PM"
+        );
     }
 
     #[test]
@@ -545,7 +619,11 @@ mod tests {
     }
 
     fn meeting(id: i64, start: &str) -> ScheduledMeeting {
-        ScheduledMeeting { id, title: None, start_at: t(start) }
+        ScheduledMeeting {
+            id,
+            title: None,
+            start_at: t(start),
+        }
     }
 
     #[test]
@@ -555,7 +633,10 @@ mod tests {
 
     #[test]
     fn pick_all_past_is_none() {
-        let ms = [meeting(1, "2026-06-11T08:00:00Z"), meeting(2, "2026-06-11T09:00:00Z")];
+        let ms = [
+            meeting(1, "2026-06-11T08:00:00Z"),
+            meeting(2, "2026-06-11T09:00:00Z"),
+        ];
         assert!(pick_next_upcoming(&ms, t("2026-06-11T10:00:00Z")).is_none());
     }
 
@@ -566,13 +647,26 @@ mod tests {
             meeting(2, "2026-06-11T11:00:00Z"),
             meeting(3, "2026-06-11T08:00:00Z"),
         ];
-        assert_eq!(pick_next_upcoming(&ms, t("2026-06-11T10:00:00Z")).unwrap().id, 2);
+        assert_eq!(
+            pick_next_upcoming(&ms, t("2026-06-11T10:00:00Z"))
+                .unwrap()
+                .id,
+            2
+        );
     }
 
     #[test]
     fn pick_excludes_meeting_starting_exactly_now() {
-        let ms = [meeting(1, "2026-06-11T10:00:00Z"), meeting(2, "2026-06-11T11:00:00Z")];
-        assert_eq!(pick_next_upcoming(&ms, t("2026-06-11T10:00:00Z")).unwrap().id, 2);
+        let ms = [
+            meeting(1, "2026-06-11T10:00:00Z"),
+            meeting(2, "2026-06-11T11:00:00Z"),
+        ];
+        assert_eq!(
+            pick_next_upcoming(&ms, t("2026-06-11T10:00:00Z"))
+                .unwrap()
+                .id,
+            2
+        );
     }
 
     #[test]
@@ -608,7 +702,10 @@ mod tests {
         let v = serde_json::json!({ "id": 7, "end_at": "2026-06-11T14:30:00Z" });
         assert_eq!(parse_end_at(&v), Some(t("2026-06-11T14:30:00Z")));
         assert_eq!(parse_end_at(&serde_json::json!({ "id": 7 })), None);
-        assert_eq!(parse_end_at(&serde_json::json!({ "end_at": "garbage" })), None);
+        assert_eq!(
+            parse_end_at(&serde_json::json!({ "end_at": "garbage" })),
+            None
+        );
     }
 
     #[test]

--- a/src-tauri/src/tray_meeting.rs
+++ b/src-tauri/src/tray_meeting.rs
@@ -9,6 +9,7 @@
 use std::sync::Mutex;
 
 use chrono::{DateTime, Utc};
+use serde_json::Value;
 
 /// A meeting from `GET /meetings` (list payload carries no end time).
 #[derive(Clone, Debug, PartialEq)]
@@ -128,6 +129,46 @@ pub(crate) fn pick_next_upcoming(
         .iter()
         .filter(|m| m.start_at > now)
         .min_by_key(|m| m.start_at)
+}
+
+/// Parse the `GET /meetings` payload `{ "meetings": [{ id, title, start_at }] }`.
+/// Entries with a missing/unparseable id or start_at are skipped.
+pub(crate) fn parse_meetings(v: &Value) -> Vec<ScheduledMeeting> {
+    let items = v
+        .get("meetings")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    items
+        .iter()
+        .filter_map(|it| {
+            Some(ScheduledMeeting {
+                id: parse_id(it.get("id"))?,
+                title: it.get("title").and_then(Value::as_str).map(String::from),
+                start_at: parse_datetime(it.get("start_at"))?,
+            })
+        })
+        .collect()
+}
+
+/// Read the optional `end_at` from a `GET /meeting-notes/:id` payload.
+pub(crate) fn parse_end_at(v: &Value) -> Option<DateTime<Utc>> {
+    parse_datetime(v.get("end_at"))
+}
+
+/// id may arrive as a JSON number or a numeric string.
+fn parse_id(v: Option<&Value>) -> Option<i64> {
+    match v {
+        Some(Value::Number(n)) => n.as_i64(),
+        Some(Value::String(s)) => s.parse().ok(),
+        _ => None,
+    }
+}
+
+fn parse_datetime(v: Option<&Value>) -> Option<DateTime<Utc>> {
+    v.and_then(Value::as_str)
+        .and_then(|s| DateTime::parse_from_rfc3339(s).ok())
+        .map(|dt| dt.with_timezone(&Utc))
 }
 
 #[cfg(test)]
@@ -273,5 +314,41 @@ mod tests {
     fn pick_excludes_meeting_starting_exactly_now() {
         let ms = [meeting(1, "2026-06-11T10:00:00Z"), meeting(2, "2026-06-11T11:00:00Z")];
         assert_eq!(pick_next_upcoming(&ms, t("2026-06-11T10:00:00Z")).unwrap().id, 2);
+    }
+
+    #[test]
+    fn parse_meetings_reads_payload_and_skips_bad_entries() {
+        let v = serde_json::json!({ "meetings": [
+            { "id": 7, "title": "Standup", "start_at": "2026-06-11T14:00:00.000Z" },
+            { "id": "8", "title": null, "start_at": "2026-06-11T15:00:00Z" },
+            { "id": 9, "title": "Bad date", "start_at": "not-a-date" },
+            { "title": "No id", "start_at": "2026-06-11T16:00:00Z" }
+        ]});
+        let ms = parse_meetings(&v);
+        assert_eq!(ms.len(), 2);
+        assert_eq!(
+            ms[0],
+            ScheduledMeeting {
+                id: 7,
+                title: Some("Standup".to_string()),
+                start_at: t("2026-06-11T14:00:00Z"),
+            }
+        );
+        assert_eq!(ms[1].id, 8);
+        assert_eq!(ms[1].title, None);
+    }
+
+    #[test]
+    fn parse_meetings_tolerates_missing_array() {
+        assert!(parse_meetings(&serde_json::json!({})).is_empty());
+        assert!(parse_meetings(&serde_json::Value::Null).is_empty());
+    }
+
+    #[test]
+    fn parse_end_at_reads_optional_field() {
+        let v = serde_json::json!({ "id": 7, "end_at": "2026-06-11T14:30:00Z" });
+        assert_eq!(parse_end_at(&v), Some(t("2026-06-11T14:30:00Z")));
+        assert_eq!(parse_end_at(&serde_json::json!({ "id": 7 })), None);
+        assert_eq!(parse_end_at(&serde_json::json!({ "end_at": "garbage" })), None);
     }
 }

--- a/src-tauri/src/tray_meeting.rs
+++ b/src-tauri/src/tray_meeting.rs
@@ -171,6 +171,29 @@ fn parse_datetime(v: Option<&Value>) -> Option<DateTime<Utc>> {
         .map(|dt| dt.with_timezone(&Utc))
 }
 
+/// The fetch window for "today": [00:00:00.000, 23:59:59.999] in `now`'s
+/// timezone, returned in UTC for the API query. Generic over the timezone so
+/// tests can pin a `FixedOffset` (production passes `chrono::Local::now()`).
+fn day_bounds<Tz: chrono::TimeZone>(now: DateTime<Tz>) -> (DateTime<Utc>, DateTime<Utc>) {
+    let tz = now.timezone();
+    let date = now.date_naive();
+    let start_naive = date.and_hms_opt(0, 0, 0).expect("midnight is valid");
+    let end_naive = date
+        .and_hms_milli_opt(23, 59, 59, 999)
+        .expect("end of day is valid");
+    // earliest/latest resolve DST folds; fall back to `now` on the
+    // pathological edge where the local wall-clock instant doesn't exist.
+    let start = tz
+        .from_local_datetime(&start_naive)
+        .earliest()
+        .unwrap_or_else(|| now.clone());
+    let end = tz
+        .from_local_datetime(&end_naive)
+        .latest()
+        .unwrap_or_else(|| now.clone());
+    (start.with_timezone(&Utc), end.with_timezone(&Utc))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -350,5 +373,14 @@ mod tests {
         assert_eq!(parse_end_at(&v), Some(t("2026-06-11T14:30:00Z")));
         assert_eq!(parse_end_at(&serde_json::json!({ "id": 7 })), None);
         assert_eq!(parse_end_at(&serde_json::json!({ "end_at": "garbage" })), None);
+    }
+
+    #[test]
+    fn day_bounds_cover_the_local_day_in_utc() {
+        // 13:45 local in UTC-4 → local day is [04:00:00Z, next-day 03:59:59.999Z].
+        let now = tz().with_ymd_and_hms(2026, 6, 11, 13, 45, 0).unwrap();
+        let (start, end) = day_bounds(now);
+        assert_eq!(start, t("2026-06-11T04:00:00Z"));
+        assert_eq!(end, t("2026-06-12T03:59:59.999Z"));
     }
 }

--- a/src-tauri/src/tray_meeting.rs
+++ b/src-tauri/src/tray_meeting.rs
@@ -83,6 +83,15 @@ pub(crate) fn format_countdown(start: DateTime<Utc>, now: DateTime<Utc>) -> Stri
     }
 }
 
+/// The full menu-bar string next to the tray icon, e.g. `Weekly Eng… in 12min`.
+pub(crate) fn format_title_bar(
+    title: Option<&str>,
+    start: DateTime<Utc>,
+    now: DateTime<Utc>,
+) -> String {
+    format!("{} {}", truncate_title(title), format_countdown(start, now))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -148,6 +157,26 @@ mod tests {
         assert_eq!(
             format_countdown(t("2026-06-11T10:00:59Z"), t("2026-06-11T10:00:00Z")),
             "in <1min"
+        );
+    }
+
+    #[test]
+    fn title_bar_composes_truncated_title_and_countdown() {
+        assert_eq!(
+            format_title_bar(
+                Some("Weekly Engineering Sync"),
+                t("2026-06-11T10:12:00Z"),
+                t("2026-06-11T10:00:00Z")
+            ),
+            "Weekly Eng… in 12min"
+        );
+    }
+
+    #[test]
+    fn title_bar_untitled_meeting() {
+        assert_eq!(
+            format_title_bar(None, t("2026-06-11T10:00:30Z"), t("2026-06-11T10:00:00Z")),
+            "Untitled meeting in <1min"
         );
     }
 }

--- a/src-tauri/src/tray_meeting.rs
+++ b/src-tauri/src/tray_meeting.rs
@@ -92,6 +92,30 @@ pub(crate) fn format_title_bar(
     format!("{} {}", truncate_title(title), format_countdown(start, now))
 }
 
+/// Gray time row under the menu title row: `10:00 – 10:30 AM` (or `10:00 AM`
+/// when the end time is unknown). Takes already-localized datetimes; the
+/// caller converts with `.with_timezone(&chrono::Local)`. Generic over the
+/// timezone so tests can pin a `FixedOffset`.
+pub(crate) fn format_time_range<Tz: chrono::TimeZone>(
+    start: DateTime<Tz>,
+    end: Option<DateTime<Tz>>,
+) -> String
+where
+    Tz::Offset: std::fmt::Display,
+{
+    match end {
+        Some(end) if start.format("%p").to_string() == end.format("%p").to_string() => {
+            format!("{} – {}", start.format("%-I:%M"), end.format("%-I:%M %p"))
+        }
+        Some(end) => format!(
+            "{} – {}",
+            start.format("%-I:%M %p"),
+            end.format("%-I:%M %p")
+        ),
+        None => start.format("%-I:%M %p").to_string(),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -178,5 +202,31 @@ mod tests {
             format_title_bar(None, t("2026-06-11T10:00:30Z"), t("2026-06-11T10:00:00Z")),
             "Untitled meeting in <1min"
         );
+    }
+
+    use chrono::{FixedOffset, TimeZone};
+
+    /// Fixed UTC-4 zone so these tests don't depend on the machine timezone.
+    fn tz() -> FixedOffset {
+        FixedOffset::west_opt(4 * 3600).unwrap()
+    }
+
+    fn at(h: u32, m: u32) -> DateTime<FixedOffset> {
+        tz().with_ymd_and_hms(2026, 6, 11, h, m, 0).unwrap()
+    }
+
+    #[test]
+    fn time_range_same_meridiem_shares_suffix() {
+        assert_eq!(format_time_range(at(10, 0), Some(at(10, 30))), "10:00 – 10:30 AM");
+    }
+
+    #[test]
+    fn time_range_cross_meridiem_shows_both() {
+        assert_eq!(format_time_range(at(11, 30), Some(at(12, 15))), "11:30 AM – 12:15 PM");
+    }
+
+    #[test]
+    fn time_range_start_only() {
+        assert_eq!(format_time_range(at(10, 0), None), "10:00 AM");
     }
 }

--- a/src/views/BootstrapView.vue
+++ b/src/views/BootstrapView.vue
@@ -18,6 +18,7 @@ onMounted(async () => {
   // future sign-in/out and settings-toggle broadcasts from being seen.
   const off = await listen(SYNC_EVENT, () => {
     void invoke('sync_meeting_notifications');
+    void invoke('sync_tray_meeting');
   });
   // onUnmounted can fire before this await resolves; if it did, detach now
   // so the listener doesn't outlive the component.
@@ -27,6 +28,7 @@ onMounted(async () => {
   }
   unlisten = off;
   void invoke('sync_meeting_notifications');
+  void invoke('sync_tray_meeting');
 
   const offAuto = await listen(AUTO_RECORD_SYNC_EVENT, () => {
     void invoke('sync_auto_record');

--- a/src/views/LibraryView.test.ts
+++ b/src/views/LibraryView.test.ts
@@ -8,6 +8,7 @@ const openRecordingFile = vi.fn();
 const readRecordingAudio = vi.fn();
 const invoke = vi.fn(() => Promise.resolve());
 const getAllWebviewWindows = vi.fn(() => Promise.resolve([] as { label: string }[]));
+const emitNotificationsSync = vi.fn(() => Promise.resolve());
 
 vi.mock('@tauri-apps/api/core', () => ({ invoke: (...a: unknown[]) => invoke(...a) }));
 vi.mock('@tauri-apps/api/webviewWindow', () => ({
@@ -37,6 +38,9 @@ function emitEvent(name: string, payload: unknown): void {
 vi.mock('../composables/useBackend', () => ({
   getActiveBackend: () =>
     Promise.resolve({ id: 'local', usesMeetingPicker: usesMeetingPicker(), listMeetings: () => listMeetings() }),
+}));
+vi.mock('../composables/useMeetingNotifications', () => ({
+  emitNotificationsSync: () => emitNotificationsSync(),
 }));
 // RecordingAudioPlayer (rendered for local rows) and openNote/openTranscript go
 // through ../tauri; keep those mocked so jsdom never touches real IPC.
@@ -95,6 +99,13 @@ describe('LibraryView', () => {
     expect(rows).toHaveLength(2);
     expect(rows[0].text()).toContain('Second');
     expect(rows[1].text()).toContain('First');
+  });
+
+  it('broadcasts native sync after a successful meeting list refresh', async () => {
+    listMeetings.mockResolvedValue([item({ id: 'a', title: 'Synced' })]);
+    mount(LibraryView);
+    await flushPromises();
+    expect(emitNotificationsSync).toHaveBeenCalledTimes(1);
   });
 
   it('clicking a meeting item selects it (aria-pressed becomes true)', async () => {

--- a/src/views/LibraryView.vue
+++ b/src/views/LibraryView.vue
@@ -118,6 +118,7 @@ import {
 } from '../composables/groupMeetingsByDate';
 import MeetingDetailView from './MeetingDetailView.vue';
 import RecorderStrip from './RecorderStrip.vue';
+import { emitNotificationsSync } from '../composables/useMeetingNotifications';
 
 const meetings = ref<MeetingListItem[]>([]);
 const loading = ref(true);
@@ -234,6 +235,11 @@ async function loadMeetings(): Promise<void> {
     const next = await (await getActiveBackend()).listMeetings();
     if (requestId !== loadMeetingsRequest) return;
     meetings.value = next;
+    // The native tray owns its own meeting cache. When this visible list gets
+    // fresh data, nudge Rust to re-fetch so the menu-bar title updates now.
+    void emitNotificationsSync().catch((err) => {
+      console.warn('Failed to sync tray after meeting list refresh', err);
+    });
   } catch (e) {
     if (requestId !== loadMeetingsRequest) return;
     console.error('Failed to list meetings', e);

--- a/src/views/SettingsView.vue
+++ b/src/views/SettingsView.vue
@@ -450,6 +450,11 @@ async function selectBackend(next: 'ariso' | 'local') {
   if (next === backend.value) return;
   backend.value = next;
   await setBackendSetting(next);
+  // Native orchestrators (tray next-meeting, notifications) re-evaluate
+  // their backend/session gates via the bootstrap window's SYNC listener.
+  void emitNotificationsSync().catch((err) => {
+    console.warn('Failed to broadcast sync after backend change', err);
+  });
   if (next === 'local') {
     await refreshModelStatus();
     // Auto-start the STT download (needed to record). The LLM is opt-in via its button.


### PR DESCRIPTION
## Summary
- Add native next-meeting tray countdown and featured meeting row
- Add one-click record from the featured tray meeting
- Clear tray meeting state for recording, Local backend, and sign-out states

## Root cause fixed after smoke testing
Live macOS smoke testing showed `tray.set_title(None)` kept the previous status-item title while recording. The tray now clears with an explicit empty title and updates recording state before redrawing the tray.

## Validation
- npm test: 148 passed
- cd src-tauri && cargo test -- --test-threads=1: 71 passed, 1 ignored
- Live smoke: initial countdown, featured row/time row, minute promotion, one-click record, recording clear/restore, Local/Ariso backend clear/restore, and sign-out clearing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tray now highlights your next upcoming meeting with a countdown while idle.
  * Quick-record option for the featured meeting in the tray menu (will prompt sign‑in if needed).
  * App performs meeting/tray sync on startup, SYNC events, and when changing recording backends.

* **Improvements**
  * Tray menu ordering and title/idle behavior refined for clearer recording vs idle states.
  * Recording state updates and menu refreshes are more responsive and consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->