### PR TITLE
fix: pin recorder strip and red dot to the recorded meeting on both backends

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -822,7 +822,13 @@ pub async fn get_active_recording_meeting_id(app: tauri::AppHandle) -> Option<i6
 
 #[tauri::command]
 pub async fn create_library_window(app: tauri::AppHandle) -> Result<(), String> {
-    use tauri::{TitleBarStyle, WebviewUrl, WebviewWindowBuilder};
+    open_library_window(&app)
+}
+
+/// Open (or focus) the meetings library window. Shared by the
+/// `create_library_window` command and the macOS dock-icon Reopen handler.
+pub(crate) fn open_library_window(app: &tauri::AppHandle) -> Result<(), String> {
+    use tauri::{Manager, TitleBarStyle, WebviewUrl, WebviewWindowBuilder};
     // The library window has no hide-on-close handler, so it is destroyed on
     // close and recreated (with fresh data) on the next open. This branch only
     // fires if it is opened again while still visible — just focus it.
@@ -836,7 +842,7 @@ pub async fn create_library_window(app: tauri::AppHandle) -> Result<(), String> 
     // Overlay title bar (with the native title hidden) lets the web content
     // extend under the traffic lights, so the in-app panel toggle can sit on
     // the same row, just to the right of them.
-    WebviewWindowBuilder::new(&app, "library", WebviewUrl::App("/#/library".into()))
+    WebviewWindowBuilder::new(app, "library", WebviewUrl::App("/#/library".into()))
         .title("Meetings")
         .title_bar_style(TitleBarStyle::Overlay)
         .hidden_title(true)

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -164,6 +164,17 @@ fn main() {
     }
 
     builder
-        .run(tauri::generate_context!())
-        .expect("error while running tauri application");
+        .build(tauri::generate_context!())
+        .expect("error while running tauri application")
+        .run(|_app, _event| {
+            // macOS: clicking the Dock icon re-activates the app (Reopen).
+            // Surface the meetings window — every other window is a hidden
+            // utility (bootstrap, settings) or transient (recorder pill).
+            #[cfg(target_os = "macos")]
+            if let tauri::RunEvent::Reopen { .. } = _event {
+                if let Err(e) = commands::open_library_window(_app) {
+                    eprintln!("Failed to open meetings window on dock reopen: {e}");
+                }
+            }
+        });
 }

--- a/src/composables/localRecordingId.test.ts
+++ b/src/composables/localRecordingId.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { localRecordingIdFromStart, timestampFromLocalRecordingId } from './localRecordingId';
+
+// These mirror the Rust sanitize_iso_to_id tests in src-tauri/src/storage.rs —
+// the two implementations must agree or the library pins UI to the wrong row.
+describe('localRecordingIdFromStart', () => {
+  it('sanitizes an ISO timestamp with millis', () => {
+    expect(localRecordingIdFromStart('2026-06-02T14:30:05.123Z')).toBe('2026-06-02T14-30-05Z');
+  });
+
+  it('sanitizes an ISO timestamp without millis', () => {
+    expect(localRecordingIdFromStart('2026-06-02T14:30:05Z')).toBe('2026-06-02T14-30-05Z');
+  });
+
+  it('drops a +HH:MM offset', () => {
+    expect(localRecordingIdFromStart('2026-06-02T14:30:05+00:00')).toBe('2026-06-02T14-30-05Z');
+  });
+});
+
+describe('timestampFromLocalRecordingId', () => {
+  it('round-trips a sanitized id back to seconds-precision ISO', () => {
+    expect(timestampFromLocalRecordingId('2026-06-02T14-30-05Z')).toBe('2026-06-02T14:30:05Z');
+  });
+
+  it('returns null for non-local ids (e.g. numeric Ariso meeting ids)', () => {
+    expect(timestampFromLocalRecordingId('42')).toBeNull();
+    expect(timestampFromLocalRecordingId('not-a-recording')).toBeNull();
+  });
+});

--- a/src/composables/localRecordingId.ts
+++ b/src/composables/localRecordingId.ts
@@ -1,0 +1,23 @@
+/** The id a local recording will be stored under is deterministic: the Rust
+ *  side derives it from the recording's start timestamp (`sanitize_iso_to_id`
+ *  in storage.rs). Mirroring that mapping lets the library address the
+ *  recording — red dot, selection, the embedded recorder strip — while the
+ *  capture is still running, and have that identity survive finalize. */
+
+/** TS mirror of Rust `sanitize_iso_to_id`: drop a `+HH:MM` offset and
+ *  sub-second precision, replace `:` with `-`, and re-append `Z`.
+ *  `2026-06-02T14:30:05.123Z` → `2026-06-02T14-30-05Z`. */
+export function localRecordingIdFromStart(iso: string): string {
+  const noOffset = iso.split('+')[0];
+  const dot = noOffset.indexOf('.');
+  const head = dot >= 0 ? noOffset.slice(0, dot) : noOffset.replace(/Z$/, '');
+  return `${head.replaceAll(':', '-')}Z`;
+}
+
+/** Inverse of `localRecordingIdFromStart` (seconds precision). Returns null
+ *  for anything that is not a local recording id — e.g. a numeric Ariso
+ *  meeting id — so callers can tell the two apart. */
+export function timestampFromLocalRecordingId(id: string): string | null {
+  const m = id.match(/^(\d{4}-\d{2}-\d{2}T\d{2})-(\d{2})-(\d{2})Z$/);
+  return m ? `${m[1]}:${m[2]}:${m[3]}Z` : null;
+}

--- a/src/composables/localRecordingId.ts
+++ b/src/composables/localRecordingId.ts
@@ -4,13 +4,13 @@
  *  recording — red dot, selection, the embedded recorder strip — while the
  *  capture is still running, and have that identity survive finalize. */
 
-/** TS mirror of Rust `sanitize_iso_to_id`: drop a `+HH:MM` offset and
- *  sub-second precision, replace `:` with `-`, and re-append `Z`.
- *  `2026-06-02T14:30:05.123Z` → `2026-06-02T14-30-05Z`. */
+/** TS mirror of Rust `sanitize_iso_to_id`: drop a trailing `Z` or
+ *  `±HH:MM` offset and sub-second precision, replace `:` with `-`, and
+ *  re-append `Z`. `2026-06-02T14:30:05.123Z` → `2026-06-02T14-30-05Z`. */
 export function localRecordingIdFromStart(iso: string): string {
-  const noOffset = iso.split('+')[0];
+  const noOffset = iso.replace(/([+-]\d{2}:\d{2}|Z)$/, '');
   const dot = noOffset.indexOf('.');
-  const head = dot >= 0 ? noOffset.slice(0, dot) : noOffset.replace(/Z$/, '');
+  const head = dot >= 0 ? noOffset.slice(0, dot) : noOffset;
   return `${head.replaceAll(':', '-')}Z`;
 }
 

--- a/src/composables/useBackend.ts
+++ b/src/composables/useBackend.ts
@@ -156,7 +156,7 @@ async function blobToBytes(blob: Blob): Promise<number[]> {
   return [...new Uint8Array(await blob.arrayBuffer())];
 }
 
-function timestampTitle(iso: string): string {
+export function timestampTitle(iso: string): string {
   const d = new Date(iso);
   if (Number.isNaN(d.getTime())) return `Recording ${iso}`;
   // Build a consistent LOCAL "YYYY-MM-DD HH:MM" — both parts must use the same

--- a/src/views/LibraryView.test.ts
+++ b/src/views/LibraryView.test.ts
@@ -38,15 +38,19 @@ vi.mock('@tauri-apps/api/event', () => ({
 function emitEvent(name: string, payload: unknown): void {
   for (const cb of [...(eventHandlers.get(name) ?? [])]) cb({ payload });
 }
-vi.mock('../composables/useBackend', () => ({
-  getActiveBackend: () =>
-    Promise.resolve({
-      id: backendId(),
-      usesMeetingPicker: usesMeetingPicker(),
-      listMeetings: () => listMeetings(),
-      getMeetingDetail: (meeting: unknown) => getMeetingDetail(meeting),
-    }),
-}));
+vi.mock('../composables/useBackend', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../composables/useBackend')>();
+  return {
+    ...actual,
+    getActiveBackend: () =>
+      Promise.resolve({
+        id: backendId(),
+        usesMeetingPicker: usesMeetingPicker(),
+        listMeetings: () => listMeetings(),
+        getMeetingDetail: (meeting: unknown) => getMeetingDetail(meeting),
+      }),
+  };
+});
 // RecordingAudioPlayer (rendered for local rows) and openNote/openTranscript go
 // through ../tauri; keep those mocked so jsdom never touches real IPC.
 vi.mock('../tauri', () => ({
@@ -381,6 +385,102 @@ describe('LibraryView', () => {
     await flushPromises();
     expect(listMeetings).toHaveBeenCalledTimes(2);
     expect(wrapper.find('.empty-card').exists()).toBe(false);
+  });
+
+  // A local recording has no list row until finalize; the library synthesizes
+  // one under the recording's deterministic id so the red dot, selection, and
+  // the embedded strip have a home.
+  function localRecorderState(over: Record<string, unknown> = {}) {
+    return {
+      bars: [0, 0, 0],
+      durationSeconds: 1,
+      isPaused: false,
+      meetingId: null,
+      localRecordingId: '2026-06-02T14-30-05Z',
+      phase: 'recording',
+      ...over,
+    };
+  }
+
+  it('synthesizes a red-dot row for an in-progress local recording and selects it', async () => {
+    listMeetings.mockResolvedValue([item({ id: 'a', title: 'Standup' })]);
+    const wrapper = mount(LibraryView);
+    await flushPromises();
+    expect(wrapper.findAll('.meeting-item')).toHaveLength(1);
+
+    emitEvent('recorder://state', localRecorderState());
+    await flushPromises();
+
+    const rows = wrapper.findAll('.meeting-item');
+    expect(rows).toHaveLength(2);
+    // Synthetic row (14:30) sorts above Standup (10:00) on the same date.
+    expect(rows[0].text()).toContain('Recording 2026-06-02');
+    expect(rows[0].find('.mi-rec-dot').exists()).toBe(true);
+    expect(rows[0].attributes('aria-pressed')).toBe('true');
+    // The embedded strip shows for the recorded meeting…
+    expect(wrapper.find('.strip').exists()).toBe(true);
+  });
+
+  it('hides the recorder strip when another meeting is selected, keeping the red dot', async () => {
+    listMeetings.mockResolvedValue([item({ id: 'a', title: 'Standup' })]);
+    const wrapper = mount(LibraryView);
+    await flushPromises();
+    emitEvent('recorder://state', localRecorderState());
+    await flushPromises();
+    expect(wrapper.find('.strip').exists()).toBe(true);
+
+    const rows = wrapper.findAll('.meeting-item');
+    await rows[1].trigger('click');
+    await flushPromises();
+
+    expect(rows[1].attributes('aria-pressed')).toBe('true');
+    expect(wrapper.find('.strip').exists()).toBe(false);
+    expect(rows[0].find('.mi-rec-dot').exists()).toBe(true);
+  });
+
+  it('reloads when the recording closes so the finalized row replaces the synthetic one', async () => {
+    listMeetings
+      .mockResolvedValueOnce([item({ id: 'a', title: 'Standup' })])
+      .mockResolvedValue([
+        item({
+          id: '2026-06-02T14-30-05Z',
+          title: 'Recording 2026-06-02 14:30',
+          timestamp: '2026-06-02T14:30:05Z',
+          files: { hasAudio: true, hasNote: false, hasTranscript: true },
+        }),
+        item({ id: 'a', title: 'Standup' }),
+      ]);
+    const wrapper = mount(LibraryView);
+    await flushPromises();
+    emitEvent('recorder://state', localRecorderState());
+    await flushPromises();
+    expect(listMeetings).toHaveBeenCalledTimes(1);
+
+    emitEvent('recorder://state', localRecorderState({ phase: 'closed' }));
+    await flushPromises();
+
+    expect(listMeetings).toHaveBeenCalledTimes(2);
+    const rows = wrapper.findAll('.meeting-item');
+    expect(rows).toHaveLength(2);
+    // The finalized recording keeps the selection under the same id.
+    expect(rows[0].attributes('aria-pressed')).toBe('true');
+    expect(rows[0].find('.mi-rec-dot').exists()).toBe(false);
+  });
+
+  it('falls back to the first meeting when a discarded recording leaves no row', async () => {
+    listMeetings.mockResolvedValue([item({ id: 'a', title: 'Standup' })]);
+    const wrapper = mount(LibraryView);
+    await flushPromises();
+    emitEvent('recorder://state', localRecorderState());
+    await flushPromises();
+    expect(wrapper.findAll('.meeting-item')[0].attributes('aria-pressed')).toBe('true');
+
+    emitEvent('recorder://state', localRecorderState({ phase: 'closed' }));
+    await flushPromises();
+
+    const rows = wrapper.findAll('.meeting-item');
+    expect(rows).toHaveLength(1);
+    expect(rows[0].attributes('aria-pressed')).toBe('true');
   });
 
   it('start-recording button opens the recorder directly for local backend', async () => {

--- a/src/views/LibraryView.vue
+++ b/src/views/LibraryView.vue
@@ -51,9 +51,9 @@
             :aria-pressed="selectedItem?.id === m.id"
             @click="selectMeeting(m)"
           >
+            <span v-if="recordingMeetingId === m.id" class="mi-rec-dot" aria-hidden="true" />
             <span class="mi-head">
               <span class="mi-title">{{ m.title }}</span>
-              <span v-if="recordingMeetingId === m.id" class="mi-rec-dot" aria-hidden="true" />
               <span v-if="relLabel(m)" class="mi-rel" :class="{ 'mi-rel--now': isNextNow(m) }">{{ relLabel(m) }}</span>
             </span>
             <span class="mi-sub" :class="{ 'mi-sub--now': isNextNow(m) }">{{ subFor(m) }}</span>
@@ -105,11 +105,12 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted, onUnmounted } from 'vue';
+import { ref, computed, watch, onMounted, onUnmounted } from 'vue';
 import { invoke } from '@tauri-apps/api/core';
 import { listen, type UnlistenFn } from '@tauri-apps/api/event';
 import { getAllWebviewWindows } from '@tauri-apps/api/webviewWindow';
-import { getActiveBackend, type MeetingListItem } from '../composables/useBackend';
+import { getActiveBackend, timestampTitle, type MeetingListItem } from '../composables/useBackend';
+import { timestampFromLocalRecordingId } from '../composables/localRecordingId';
 import {
   groupMeetingsByDate,
   groupTodaysMeetings,
@@ -141,11 +142,31 @@ const monthName = computed(() => now.value.toLocaleString(undefined, { month: 'l
 
 const activeView = ref<'today' | 'meetings'>('meetings');
 
+// An in-progress local recording has no list row yet (the entry is created on
+// finalize). Synthesize one under the id the finalized recording will use, so
+// the red dot, selection, and the recorder strip have a home that survives the
+// post-recording reload.
+const displayMeetings = computed<MeetingListItem[]>(() => {
+  const id = recordingMeetingId.value;
+  if (!id || meetings.value.some((m) => m.id === id)) return meetings.value;
+  const timestamp = timestampFromLocalRecordingId(id);
+  if (!timestamp) return meetings.value; // an Ariso meeting outside the loaded window
+  return [
+    {
+      id,
+      title: timestampTitle(timestamp),
+      timestamp,
+      files: { hasAudio: false, hasNote: false, hasTranscript: false },
+    },
+    ...meetings.value,
+  ];
+});
+
 const displayedSections = computed<MeetingSection[]>(() => {
   if (activeView.value === 'today') {
-    return groupTodaysMeetings(meetings.value, now.value);
+    return groupTodaysMeetings(displayMeetings.value, now.value);
   }
-  return groupMeetingsByDate(meetings.value, now.value);
+  return groupMeetingsByDate(displayMeetings.value, now.value);
 });
 
 // Only the next upcoming meeting (soonest, or the one in progress) carries a
@@ -336,6 +357,23 @@ async function selectRecordingMeeting(id: number | null | undefined): Promise<vo
   if (m) await selectMeeting(m);
 }
 
+// Keep the detail panel on the recorded meeting: surface its row when the
+// strip reports a recording (the synthetic row for local, the scheduled row
+// for Ariso), and reload when it ends so the finalized local recording
+// replaces the synthetic row under the same id.
+watch(recordingMeetingId, async (id, prevId) => {
+  if (id) {
+    const m = displayMeetings.value.find((x) => x.id === id);
+    if (m && selectedItem.value?.id !== id) await selectMeeting(m);
+    return;
+  }
+  await loadMeetings();
+  if (prevId && selectedItem.value?.id === prevId && !meetings.value.some((m) => m.id === prevId)) {
+    // Discarded/crashed recording — its synthetic row is gone; fall back.
+    selectedItem.value = meetings.value[0] ?? null;
+  }
+});
+
 function onWindowFocus(): void {
   now.value = new Date();
   void loadMeetings();
@@ -483,6 +521,7 @@ onUnmounted(() => {
 }
 
 .meeting-item {
+  position: relative; /* anchors the recording dot to the row's corner */
   display: flex;
   flex-direction: column;
   gap: 3px;
@@ -501,17 +540,19 @@ onUnmounted(() => {
   border-color: #1c1c1c;
   box-shadow: 3px 3px 0 #e7e5e2;
 }
-/* Title hugs the left, rel-label pushed right; the recording dot (when
-   present) sits right after the title's end. */
+/* Title hugs the left, rel-label pushed right. */
 .mi-head { display: flex; align-items: baseline; gap: 8px; }
 .mi-rel { margin-left: auto; }
+/* Recording dot pinned to the row's top-right corner, out of the text flow so
+   the title/rel-label layout is unaffected. */
 .mi-rec-dot {
-  flex-shrink: 0;
+  position: absolute;
+  top: 8px;
+  right: 8px;
   width: 7px;
   height: 7px;
   border-radius: 50%;
   background: #e0443e;
-  align-self: center;
   animation: rec-pulse 1s infinite;
 }
 @keyframes rec-pulse {

--- a/src/views/RecorderStrip.test.ts
+++ b/src/views/RecorderStrip.test.ts
@@ -112,12 +112,36 @@ describe('RecorderStrip', () => {
     expect(wrapper.find('.strip').exists()).toBe(false);
   });
 
-  it('shows regardless of selection when the recording has no meeting', async () => {
+  it('shows regardless of selection when the recording has no id at all', async () => {
     const wrapper = mount(RecorderStrip, { props: { meetingId: '7' } });
     await flushPromises();
-    sendState(recording({ meetingId: null }));
+    sendState(recording({ meetingId: null, localRecordingId: null }));
     await flushPromises();
     expect(wrapper.find('.strip').exists()).toBe(true);
+  });
+
+  it('pins a local recording to its (future) recording row', async () => {
+    const id = '2026-06-02T14-30-05Z';
+    const wrapper = mount(RecorderStrip, { props: { meetingId: id } });
+    await flushPromises();
+    sendState(recording({ meetingId: null, localRecordingId: id }));
+    await flushPromises();
+    expect(wrapper.find('.strip').exists()).toBe(true);
+
+    await wrapper.setProps({ meetingId: '7' });
+    expect(wrapper.find('.strip').exists()).toBe(false);
+
+    await wrapper.setProps({ meetingId: null });
+    expect(wrapper.find('.strip').exists()).toBe(false);
+  });
+
+  it('reports the local recording id to its parent', async () => {
+    const id = '2026-06-02T14-30-05Z';
+    const wrapper = mount(RecorderStrip, { props: { meetingId: null } });
+    await flushPromises();
+    sendState(recording({ meetingId: null, localRecordingId: id }));
+    await flushPromises();
+    expect(wrapper.emitted('recording-change')?.at(-1)).toEqual([id]);
   });
 
   it('reports the recorded meeting id to its parent, and null when over', async () => {

--- a/src/views/RecorderStrip.vue
+++ b/src/views/RecorderStrip.vue
@@ -59,6 +59,8 @@ interface RecorderState {
   durationSeconds: number;
   isPaused: boolean;
   meetingId: number | null;
+  /** Deterministic id of an in-progress local recording (null for Ariso). */
+  localRecordingId?: string | null;
   phase: 'recording' | 'uploading' | 'success' | 'failed' | 'closed';
 }
 
@@ -77,17 +79,26 @@ const state = ref<RecorderState | null>(null);
 let unlistenState: UnlistenFn | null = null;
 let staleTimer: ReturnType<typeof setTimeout> | null = null;
 
+// The sidebar id of the row being recorded: the Ariso meeting id when one is
+// attached, otherwise the local recording's deterministic id.
+function recordedMeetingId(s: RecorderState): string | null {
+  if (s.meetingId != null) return String(s.meetingId);
+  return s.localRecordingId ?? null;
+}
+
 // The strip belongs to the recorded meeting: render it only while the detail
-// panel shows that meeting. Meeting-less recordings have no home section, so
-// they show wherever the user is.
+// panel shows that meeting. Recordings with no id at all (e.g. an Ariso
+// auto-recording awaiting confirmation) have no home row, so they show
+// wherever the user is.
 const visible = computed(() => {
   if (!state.value) return false;
-  if (state.value.meetingId == null) return true;
-  return String(state.value.meetingId) === props.meetingId;
+  const id = recordedMeetingId(state.value);
+  if (id == null) return true;
+  return id === props.meetingId;
 });
 
 watch(state, (s) => {
-  emitToParent('recording-change', s && s.meetingId != null ? String(s.meetingId) : null);
+  emitToParent('recording-change', s ? recordedMeetingId(s) : null);
 });
 
 const formattedDuration = computed(() => {

--- a/src/views/WaveformView.test.ts
+++ b/src/views/WaveformView.test.ts
@@ -209,6 +209,22 @@ describe('WaveformView vertical pill', () => {
     vi.useRealTimers();
   });
 
+  it('broadcasts the deterministic local recording id for the local backend', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    mount(WaveformView);
+    await vi.runOnlyPendingTimersAsync();
+    await vi.advanceTimersByTimeAsync(1_100); // heartbeat
+
+    const state = emitEvent.mock.calls
+      .filter(([name]) => name === 'recorder://state')
+      .map(([, payload]) => payload as { localRecordingId: string | null })
+      .at(-1);
+    // Mirrors Rust sanitize_iso_to_id over the mocked startedAt.
+    expect(state?.localRecordingId).toBe('2026-06-09T10-00-00Z');
+    vi.useRealTimers();
+  });
+
   it('auto mode with no calendar match shows the confirm overlay', async () => {
     routeQuery = { auto: '1' };
     listScheduledMeetings.mockResolvedValue([]);

--- a/src/views/WaveformView.vue
+++ b/src/views/WaveformView.vue
@@ -97,6 +97,7 @@ import { loadRecordingEnabled } from '../composables/useRecordingPermissions';
 import { deriveRecordingMode } from './recordingSettings';
 import { centerWeightedBars } from './waveformBars';
 import { shouldAutoStop } from '../composables/silenceWatch';
+import { localRecordingIdFromStart } from '../composables/localRecordingId';
 import { resolveAssociation } from '../composables/useAutoTrigger';
 import { useMeetingApi } from '../composables/useMeetingApi';
 
@@ -163,6 +164,13 @@ function broadcastState(phase: RecorderPhase = currentPhase()): void {
     durationSeconds: recorder.durationSeconds.value,
     isPaused: recorder.isPaused.value,
     meetingId: effectiveMeetingId.value,
+    // Local recordings have no meeting id, but their finalized recording id is
+    // deterministic from the start time — broadcast it so the library can pin
+    // the strip / red dot to the row the recording will land on.
+    localRecordingId:
+      backend.value?.id === 'local' && recorder.startedAt.value
+        ? localRecordingIdFromStart(recorder.startedAt.value)
+        : null,
     phase,
   }).catch(() => { /* no listeners / shutting down */ });
 }


### PR DESCRIPTION
## Problem

- The embedded recorder strip showed under *any* selected meeting during a local recording (it was only pinned for Ariso meeting ids).
- The sidebar red dot never appeared for local recordings, since they have no meeting id while capturing.

## Fix

A local recording's finalized id is deterministic (`sanitize_iso_to_id` over its start time), so the recording can be addressed before it exists on disk:

- `localRecordingId.ts` (new): TS mirror of Rust's `sanitize_iso_to_id` + inverse, tested against the Rust unit tests.
- `WaveformView` broadcasts `localRecordingId` in `recorder://state` for the local backend.
- `RecorderStrip` renders only while the detail panel shows the recorded meeting (Ariso meeting id or local recording id) and reports that id to the library.
- `LibraryView` synthesizes a sidebar row under that id while capture runs — red dot at the row's top-right corner, auto-selected — and reloads on close so the finalized row replaces it under the same id (selection carries over).

Side effect: notes typed during a local recording land in the recording's future directory and survive finalize.

## Testing

- `vitest run`: 174 passed (new coverage for id round-trip, strip pinning, synthetic row / red dot / reload-on-close).
- `vite build`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Temporary library row for in‑progress local recordings with a persistent red‑dot and stable selection
  * Deterministic local recording IDs; recorder strip pins to local/in‑progress recordings and stays visible
  * Library auto-reloads when recordings finalize; UI dot positioning improved for consistent layout
  * macOS reopen now attempts to open the library window on Dock reopen

* **Tests**
  * Added coverage for local recording ID handling, recorder strip behavior, waveform state emission, and library interactions
<!-- end of auto-generated comment: release notes by coderabbit.ai -->