### PR TITLE
feat(meetings): record a new meeting from the picker

### DIFF
--- a/src/composables/useMeetingApi.ts
+++ b/src/composables/useMeetingApi.ts
@@ -94,6 +94,28 @@ function assertOk(res: { status: number; data: unknown }, expected: number, acti
   }
 }
 
+// The POST /meeting-notes/audio response shape isn't strictly pinned, so pull
+// the new meeting id from the handful of shapes the API uses elsewhere: a bare
+// `{ id }` / `{ meetingId }`, or a nested meeting / meeting-note object.
+function extractMeetingId(data: unknown): number | null {
+  if (!data || typeof data !== 'object') return null;
+  const d = data as Record<string, unknown>;
+  const nested = (key: string): unknown =>
+    (d[key] as Record<string, unknown> | undefined)?.id;
+  const candidates: unknown[] = [
+    d.id,
+    d.meetingId,
+    nested('meeting'),
+    nested('meetingNote'),
+    nested('meeting_note'),
+  ];
+  for (const c of candidates) {
+    if (typeof c === 'number' && Number.isSafeInteger(c)) return c;
+    if (typeof c === 'string' && /^\d+$/.test(c)) return Number(c);
+  }
+  return null;
+}
+
 export function useMeetingApi() {
   async function getDeepgramToken(): Promise<string> {
     const res = await api.request('POST', '/desktop/deepgram-token');
@@ -111,6 +133,30 @@ export function useMeetingApi() {
     const res = await api.request('POST', '/desktop/meetings', { title });
     assertOk(res, 201, 'create meeting');
     return res.data as { meeting: Meeting };
+  }
+
+  // Create an ad-hoc meeting to record straight into. The backend seeds it with
+  // the current user as the sole participant; we only supply an optional title
+  // and the start time. Returns the new meeting's id so the recorder can attach
+  // its upload to it.
+  async function createAudioMeeting(
+    title?: string
+  ): Promise<{ meetingId: number }> {
+    const trimmed = title?.trim();
+    const body: { startAt: string; title?: string } = {
+      startAt: new Date().toISOString(),
+    };
+    if (trimmed) body.title = trimmed;
+    const res = await api.request('POST', '/meeting-notes/audio', body);
+    if (res.status !== 200 && res.status !== 201) {
+      const data = res.data as { error?: string } | null;
+      throw new Error(data?.error || `Failed to create meeting (${res.status})`);
+    }
+    const meetingId = extractMeetingId(res.data);
+    if (meetingId == null) {
+      throw new Error('Server did not return a meeting id');
+    }
+    return { meetingId };
   }
 
   async function listMeetings(
@@ -356,6 +402,7 @@ export function useMeetingApi() {
   return {
     getDeepgramToken,
     createMeeting,
+    createAudioMeeting,
     listMeetings,
     listScheduledMeetings,
     listMeetingsInWindow,

--- a/src/views/LibraryView.test.ts
+++ b/src/views/LibraryView.test.ts
@@ -494,6 +494,98 @@ describe('LibraryView', () => {
     expect(rows[0].attributes('aria-pressed')).toBe('true');
   });
 
+  // An ad-hoc Ariso meeting (created via "Record a new meeting") isn't a
+  // calendar-scheduled meeting, so listMeetings() never returns it. The library
+  // pins it (fetching its metadata) so it stays in the sidebar after the
+  // recording stops instead of vanishing on the post-recording reload.
+  it('keeps an ad-hoc Ariso meeting in the list after its recording stops', async () => {
+    backendId.mockReturnValue('ariso');
+    usesMeetingPicker.mockReturnValue(true);
+    // The calendar list never carries the ad-hoc meeting (id 77).
+    listMeetings.mockResolvedValue([item({ id: '5', title: 'Calendar Sync', files: undefined })]);
+    getMeetingDetail.mockImplementation((m) =>
+      Promise.resolve({
+        id: m.id,
+        title: m.id === '77' ? 'My ad-hoc meeting' : m.title,
+        startAt: '2026-06-02T14:30:00Z',
+        participants: [],
+        actionItems: [],
+        isLocal: false,
+      })
+    );
+
+    const wrapper = mount(LibraryView);
+    await flushPromises();
+    expect(wrapper.text()).not.toContain('My ad-hoc meeting');
+
+    // Recording starts against the freshly created meeting 77.
+    emitEvent('recorder://state', {
+      bars: [0, 0, 0],
+      durationSeconds: 1,
+      isPaused: false,
+      meetingId: 77,
+      phase: 'recording',
+    });
+    await flushPromises();
+
+    let adhoc = wrapper.findAll('.meeting-item').find((r) => r.text().includes('My ad-hoc meeting'));
+    expect(adhoc).toBeTruthy();
+    expect(adhoc!.find('.mi-rec-dot').exists()).toBe(true);
+
+    // Recording stops — the strip clears, the library reloads (still no 77 from
+    // the calendar), but the pinned row must remain.
+    emitEvent('recorder://state', {
+      bars: [0, 0, 0],
+      durationSeconds: 1,
+      isPaused: false,
+      meetingId: 77,
+      phase: 'closed',
+    });
+    await flushPromises();
+
+    adhoc = wrapper.findAll('.meeting-item').find((r) => r.text().includes('My ad-hoc meeting'));
+    expect(adhoc).toBeTruthy();
+    expect(adhoc!.find('.mi-rec-dot').exists()).toBe(false);
+  });
+
+  it('unpins an ad-hoc meeting once the backend list starts returning it', async () => {
+    backendId.mockReturnValue('ariso');
+    usesMeetingPicker.mockReturnValue(true);
+    // After the recording, a reload finally surfaces meeting 77 from the backend.
+    listMeetings
+      .mockResolvedValueOnce([item({ id: '5', title: 'Calendar Sync', files: undefined })])
+      .mockResolvedValue([
+        item({ id: '77', title: 'My ad-hoc meeting', timestamp: '2026-06-02T14:30:00Z', files: undefined }),
+        item({ id: '5', title: 'Calendar Sync', files: undefined }),
+      ]);
+    getMeetingDetail.mockImplementation((m) =>
+      Promise.resolve({
+        id: m.id,
+        title: m.id === '77' ? 'My ad-hoc meeting' : m.title,
+        startAt: '2026-06-02T14:30:00Z',
+        participants: [],
+        actionItems: [],
+        isLocal: false,
+      })
+    );
+
+    const wrapper = mount(LibraryView);
+    await flushPromises();
+
+    emitEvent('recorder://state', {
+      bars: [0, 0, 0], durationSeconds: 1, isPaused: false, meetingId: 77, phase: 'recording',
+    });
+    await flushPromises();
+    emitEvent('recorder://state', {
+      bars: [0, 0, 0], durationSeconds: 1, isPaused: false, meetingId: 77, phase: 'closed',
+    });
+    await flushPromises();
+
+    // Exactly one row for 77 (the backend's), not a pinned duplicate.
+    const adhocRows = wrapper.findAll('.meeting-item').filter((r) => r.text().includes('My ad-hoc meeting'));
+    expect(adhocRows).toHaveLength(1);
+  });
+
   it('start-recording button opens the recorder directly for local backend', async () => {
     usesMeetingPicker.mockReturnValue(false);
     listMeetings.mockResolvedValue([]);

--- a/src/views/LibraryView.vue
+++ b/src/views/LibraryView.vue
@@ -134,6 +134,12 @@ type MeetingDetailViewExposed = InstanceType<typeof MeetingDetailView> & {
 const detailView = ref<MeetingDetailViewExposed | null>(null);
 // Meeting currently being recorded (reported by the strip) — red dot in the list.
 const recordingMeetingId = ref<string | null>(null);
+// Ad-hoc meetings we recorded this session that the backend list doesn't surface
+// yet (e.g. "Record a new meeting" — created via /meeting-notes/audio, so it
+// isn't a calendar-scheduled meeting and never appears in listMeetings()). We
+// fetch their metadata and keep them in the sidebar during AND after recording,
+// until a reload naturally includes them. Keyed by id.
+const pinnedMeetings = ref<Map<string, MeetingListItem>>(new Map());
 
 // A ticking "now" so relative labels ("in 20min" → "Now") and the upcoming/past
 // split stay fresh while the window sits open.
@@ -148,10 +154,17 @@ const activeView = ref<'today' | 'meetings'>('meetings');
 // the red dot, selection, and the recorder strip have a home that survives the
 // post-recording reload.
 const displayMeetings = computed<MeetingListItem[]>(() => {
+  // Layer pinned ad-hoc meetings the backend list hasn't caught up to on top of
+  // the loaded list (deduped by id), so they survive the post-recording reload.
+  const pinned = [...pinnedMeetings.value.values()].filter(
+    (p) => !meetings.value.some((m) => m.id === p.id)
+  );
+  const base = pinned.length ? [...pinned, ...meetings.value] : meetings.value;
+
   const id = recordingMeetingId.value;
-  if (!id || meetings.value.some((m) => m.id === id)) return meetings.value;
+  if (!id || base.some((m) => m.id === id)) return base;
   const timestamp = timestampFromLocalRecordingId(id);
-  if (!timestamp) return meetings.value; // an Ariso meeting outside the loaded window
+  if (!timestamp) return base; // an Ariso meeting outside the loaded window
   return [
     {
       id,
@@ -159,7 +172,7 @@ const displayMeetings = computed<MeetingListItem[]>(() => {
       timestamp,
       files: { hasAudio: false, hasNote: false, hasTranscript: false },
     },
-    ...meetings.value,
+    ...base,
   ];
 });
 
@@ -276,6 +289,14 @@ async function loadMeetings(): Promise<void> {
     const next = await (await getActiveBackend()).listMeetings();
     if (requestId !== loadMeetingsRequest) return;
     meetings.value = next;
+    // Drop any pinned ad-hoc meeting the backend list now surfaces on its own.
+    if (pinnedMeetings.value.size) {
+      const pruned = new Map(pinnedMeetings.value);
+      for (const id of [...pruned.keys()]) {
+        if (next.some((m) => m.id === id)) pruned.delete(id);
+      }
+      if (pruned.size !== pinnedMeetings.value.size) pinnedMeetings.value = pruned;
+    }
     // The native tray owns its own meeting cache. When this visible list gets
     // fresh data, nudge Rust to re-fetch so the menu-bar title updates now.
     void emitNotificationsSync().catch((err) => {
@@ -347,18 +368,40 @@ async function onRecordingStarted(event: { payload: { meetingId: number | null }
   await selectRecordingMeeting(event.payload?.meetingId);
 }
 
+// Fetch an ad-hoc Ariso meeting's metadata and keep it in the sidebar until a
+// reload includes it. Local recordings (timestamp-encoded ids) already get a
+// synthetic row from displayMeetings, so only numeric Ariso ids are pinned.
+async function pinRecordedMeeting(id: string): Promise<void> {
+  if (!/^\d+$/.test(id)) return;
+  if (meetings.value.some((m) => m.id === id) || pinnedMeetings.value.has(id)) return;
+  try {
+    const backend = await getActiveBackend();
+    if (backend.id !== 'ariso') return;
+    const detail = await backend.getMeetingDetail({ id, title: '', timestamp: new Date().toISOString() });
+    pinnedMeetings.value = new Map(pinnedMeetings.value).set(id, {
+      id,
+      title: detail.title,
+      timestamp: detail.startAt,
+      endTimestamp: detail.endAt,
+    });
+  } catch (e) {
+    console.error('Failed to pin recorded meeting', id, e);
+  }
+}
+
 // Shared resolver for "the recording is attached to meeting X, surface it in
 // the detail panel". Used by both the live `recording://started` event and the
 // mount-time backend query that recovers state after the library was closed.
 async function selectRecordingMeeting(id: number | null | undefined): Promise<void> {
   if (id == null) return;
   const idStr = String(id);
-  let m = meetings.value.find((x) => x.id === idStr);
+  let m = displayMeetings.value.find((x) => x.id === idStr);
   if (!m) {
-    // The picker can start a meeting the library hasn't loaded yet (e.g. it
-    // appeared on the calendar after our last refresh) — reload once.
+    // The picker can start a meeting the library hasn't loaded yet — reload, and
+    // pin it if it's an ad-hoc meeting the list still won't surface.
     await loadMeetings();
-    m = meetings.value.find((x) => x.id === idStr);
+    await pinRecordedMeeting(idStr);
+    m = displayMeetings.value.find((x) => x.id === idStr);
   }
   if (m) await selectMeeting(m);
 }
@@ -369,14 +412,18 @@ async function selectRecordingMeeting(id: number | null | undefined): Promise<vo
 // replaces the synthetic row under the same id.
 watch(recordingMeetingId, async (id, prevId) => {
   if (id) {
+    // Ensure the recorded meeting has a sidebar row even when it's an ad-hoc
+    // Ariso meeting the calendar list doesn't carry.
+    await pinRecordedMeeting(id);
     const m = displayMeetings.value.find((x) => x.id === id);
     if (m && selectedItem.value?.id !== id) await selectMeeting(m);
     return;
   }
   await loadMeetings();
-  if (prevId && selectedItem.value?.id === prevId && !meetings.value.some((m) => m.id === prevId)) {
-    // Discarded/crashed recording — its synthetic row is gone; fall back.
-    selectedItem.value = meetings.value[0] ?? null;
+  if (prevId && selectedItem.value?.id === prevId && !displayMeetings.value.some((m) => m.id === prevId)) {
+    // Discarded/crashed recording — its row is gone (and nothing pinned it);
+    // fall back to the first available meeting.
+    selectedItem.value = displayMeetings.value[0] ?? null;
   }
 });
 

--- a/src/views/MeetingPickerView.test.ts
+++ b/src/views/MeetingPickerView.test.ts
@@ -1,0 +1,83 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mount, flushPromises, enableAutoUnmount } from '@vue/test-utils';
+
+const invoke = vi.fn(() => Promise.resolve());
+const listScheduledMeetings = vi.fn(() => Promise.resolve([] as unknown[]));
+const createAudioMeeting = vi.fn(() => Promise.resolve({ meetingId: 77 }));
+
+vi.mock('@tauri-apps/api/core', () => ({ invoke: (...a: unknown[]) => invoke(...a) }));
+vi.mock('../composables/useMeetingApi', () => ({
+  useMeetingApi: () => ({
+    listScheduledMeetings: (...a: unknown[]) => listScheduledMeetings(...a),
+    createAudioMeeting: (...a: unknown[]) => createAudioMeeting(...a),
+  }),
+}));
+
+import MeetingPickerView from './MeetingPickerView.vue';
+
+function byText(wrapper: ReturnType<typeof mount>, text: string) {
+  return wrapper.findAll('button').find((b) => b.text() === text);
+}
+
+enableAutoUnmount(afterEach);
+beforeEach(() => {
+  vi.clearAllMocks();
+  listScheduledMeetings.mockResolvedValue([]);
+  createAudioMeeting.mockResolvedValue({ meetingId: 77 });
+});
+
+describe('MeetingPickerView — record a new meeting', () => {
+  it('renders the renamed button and hides the title prompt by default', async () => {
+    const wrapper = mount(MeetingPickerView);
+    await flushPromises();
+    expect(byText(wrapper, 'Record a new meeting')).toBeTruthy();
+    expect(byText(wrapper, 'Record without meeting')).toBeFalsy();
+    expect(wrapper.find('input').exists()).toBe(false);
+  });
+
+  it('prompts for a title, creates the meeting, then opens the recorder for it', async () => {
+    const wrapper = mount(MeetingPickerView);
+    await flushPromises();
+
+    await byText(wrapper, 'Record a new meeting')!.trigger('click');
+    await flushPromises();
+
+    const input = wrapper.find('input');
+    expect(input.exists()).toBe(true);
+    await input.setValue('Sync with Sam');
+
+    await byText(wrapper, 'Start recording')!.trigger('click');
+    await flushPromises();
+
+    expect(createAudioMeeting).toHaveBeenCalledWith('Sync with Sam');
+    expect(invoke).toHaveBeenCalledWith('start_recording_window', { meetingId: 77 });
+  });
+
+  it('keeps the title optional — an empty title still starts recording', async () => {
+    const wrapper = mount(MeetingPickerView);
+    await flushPromises();
+
+    await byText(wrapper, 'Record a new meeting')!.trigger('click');
+    await flushPromises();
+    await byText(wrapper, 'Start recording')!.trigger('click');
+    await flushPromises();
+
+    expect(createAudioMeeting).toHaveBeenCalledWith('');
+    expect(invoke).toHaveBeenCalledWith('start_recording_window', { meetingId: 77 });
+  });
+
+  it('surfaces an error and does not open the recorder when creation fails', async () => {
+    createAudioMeeting.mockRejectedValueOnce(new Error('boom'));
+    const wrapper = mount(MeetingPickerView);
+    await flushPromises();
+
+    await byText(wrapper, 'Record a new meeting')!.trigger('click');
+    await flushPromises();
+    await byText(wrapper, 'Start recording')!.trigger('click');
+    await flushPromises();
+
+    expect(invoke).not.toHaveBeenCalledWith('start_recording_window', { meetingId: 77 });
+    expect(wrapper.text()).toContain('boom');
+  });
+});

--- a/src/views/MeetingPickerView.vue
+++ b/src/views/MeetingPickerView.vue
@@ -49,14 +49,44 @@
       </button>
     </template>
 
-    <button class="skip-btn" :disabled="isChoosing" @click="choose(null)">
-      Record without meeting
-    </button>
+    <div class="new-meeting">
+      <button
+        v-if="!showTitlePrompt"
+        class="skip-btn"
+        :disabled="isChoosing"
+        @click="openNewMeetingPrompt"
+      >
+        Record a new meeting
+      </button>
+
+      <template v-else>
+        <input
+          ref="titleInput"
+          v-model="titleDraft"
+          class="title-input"
+          type="text"
+          placeholder="Meeting title (optional)"
+          :disabled="isChoosing"
+          aria-label="Meeting title"
+          @keydown.enter.prevent="startNewMeeting"
+          @keydown.esc.prevent="cancelNewMeeting"
+        />
+        <div class="new-meeting-actions">
+          <button class="btn btn-secondary" type="button" :disabled="isChoosing" @click="cancelNewMeeting">
+            Cancel
+          </button>
+          <button class="btn btn-primary" :disabled="isChoosing" @click="startNewMeeting">
+            Start recording
+          </button>
+        </div>
+        <p v-if="createError" class="create-error">{{ createError }}</p>
+      </template>
+    </div>
   </div>
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, ref } from 'vue';
+import { computed, nextTick, onMounted, ref } from 'vue';
 import { invoke } from '@tauri-apps/api/core';
 import { useMeetingApi, type ScheduledMeeting } from '../composables/useMeetingApi';
 import { pickDefaultMeeting } from '../composables/pickDefaultMeeting';
@@ -68,6 +98,10 @@ const state = ref<PickerState>('loading');
 const meetings = ref<ScheduledMeeting[]>([]);
 const isChoosing = ref(false);
 const showAll = ref(false);
+const showTitlePrompt = ref(false);
+const titleDraft = ref('');
+const createError = ref<string | null>(null);
+const titleInput = ref<HTMLInputElement | null>(null);
 const now = new Date();
 
 const defaultMeeting = computed(() => pickDefaultMeeting(meetings.value, now));
@@ -95,6 +129,37 @@ async function choose(meetingId: number | null): Promise<void> {
     await invoke('start_recording_window', { meetingId });
   } catch (err) {
     console.error('Failed to start recording window:', err);
+    isChoosing.value = false;
+  }
+}
+
+async function openNewMeetingPrompt(): Promise<void> {
+  createError.value = null;
+  showTitlePrompt.value = true;
+  await nextTick();
+  titleInput.value?.focus();
+}
+
+function cancelNewMeeting(): void {
+  showTitlePrompt.value = false;
+  titleDraft.value = '';
+  createError.value = null;
+}
+
+// Create a fresh meeting (current user as the only participant, set server-side)
+// and open the recorder attached to it. Title is optional — an empty draft just
+// leaves the meeting untitled.
+async function startNewMeeting(): Promise<void> {
+  if (isChoosing.value) return;
+  isChoosing.value = true;
+  createError.value = null;
+  try {
+    const { meetingId } = await meetingApi.createAudioMeeting(titleDraft.value);
+    await invoke('start_recording_window', { meetingId });
+  } catch (err) {
+    console.error('Failed to start a new meeting:', err);
+    createError.value =
+      err instanceof Error ? err.message : 'Could not start the meeting.';
     isChoosing.value = false;
   }
 }
@@ -254,8 +319,81 @@ onMounted(async () => {
   color: #6f6f6f;
 }
 
-.skip-btn {
+.new-meeting {
   margin-top: 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.title-input {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 10px 12px;
+  border-radius: 12px;
+  border: 1px solid #d6d6d6;
+  background: #ffffff;
+  color: #1c1c1c;
+  font-family: inherit;
+  font-size: 14px;
+}
+
+.title-input:focus {
+  outline: none;
+  border-color: #9a9a96;
+}
+
+.new-meeting-actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 10px;
+}
+
+.btn {
+  padding: 9px 16px;
+  border-radius: 12px;
+  font-family: inherit;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.1s, box-shadow 0.1s, background 0.12s;
+}
+
+.btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.btn-secondary {
+  border: 1px solid #d6d6d6;
+  background: #ffffff;
+  color: #1c1c1c;
+}
+
+.btn-secondary:not(:disabled):hover {
+  background: rgba(0, 0, 0, 0.03);
+}
+
+.btn-primary {
+  border: 1px solid #1c1c1c;
+  background: #1c1c1c;
+  color: #f7f6f4;
+  box-shadow: 2px 2px 0 #e7e5e2;
+}
+
+.btn-primary:not(:disabled):hover {
+  box-shadow: 1px 1px 0 #e7e5e2;
+  transform: translate(1px, 1px);
+}
+
+.create-error {
+  margin: 0;
+  font-size: 12px;
+  color: #d96a5a;
+}
+
+.skip-btn {
   padding: 10px 14px;
   border-radius: 12px;
   border: 1px solid #d6d6d6;

--- a/src/views/MeetingPickerView.vue
+++ b/src/views/MeetingPickerView.vue
@@ -160,6 +160,7 @@ async function startNewMeeting(): Promise<void> {
     console.error('Failed to start a new meeting:', err);
     createError.value =
       err instanceof Error ? err.message : 'Could not start the meeting.';
+  } finally {
     isChoosing.value = false;
   }
 }

--- a/src/views/RecorderStrip.vue
+++ b/src/views/RecorderStrip.vue
@@ -34,7 +34,7 @@
             <rect x="8.5" y="1" width="3.5" height="12" rx="1" fill="currentColor" />
           </svg>
           <svg v-else width="14" height="14" viewBox="0 0 14 14">
-            <path d="M3 1.8v10.4c0 .7.8 1.2 1.4.8l8.1-5.2c.6-.4.6-1.2 0-1.6L4.4 1c-.6-.4-1.4.1-1.4.8z" fill="currentColor" />
+            <circle cx="7" cy="7" r="5.5" fill="currentColor" />
           </svg>
         </button>
         <button class="ctrl-btn stop-btn" aria-label="Stop recording" @click.stop.prevent="control('tray://stop-recording')">


### PR DESCRIPTION
## What

- Rename the meeting picker's **"Record without meeting" → "Record a new meeting"**.
- Clicking it prompts for an **optional title** (Cancel + primary Start recording buttons), then creates the meeting up front via `POST /meeting-notes/audio` (`{ title, startAt }`) with the current user as the sole participant, and records into it.
- **Keep the ad-hoc meeting in the library** during and after recording — it isn't a calendar meeting so `listMeetings()` never returns it; the library now pins it (fetching its metadata) and unpins once a reload surfaces it.
- Match the detail-panel recorder strip's **resume icon** to the floating recorder pill.

## Notes

- Notes will render once available; the refresh trigger (Pusher event on notes generation) is a follow-up PR.
- Pinning persists within the session.

## Tests

New `MeetingPickerView.test.ts` + added LibraryView cases. Full suite: 181 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Create ad-hoc audio meetings directly in the app, with an optional title.
  * “Record a new meeting” inline flow added to start recording without calendar scheduling.
  * Ad-hoc meetings are pinned in your library for the current session until they appear in the backend list.
* **Bug Fixes**
  * Prevents duplicate “My ad-hoc meeting” entries by unpinning once the official list includes them.
* **Tests**
  * Added/extended coverage for ad-hoc meeting pinning behavior and recording error handling.
* **Style**
  * Updated the pause button icon for clearer paused-state visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->