### PR TITLE
fix(recording): require Ariso sign-in at in-app recording entry points

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -588,6 +588,26 @@ pub(crate) fn open_waveform_window(
     Ok(())
 }
 
+/// Gate recording on a valid session for the Ariso backend. The Local backend
+/// needs no auth and always passes. When the Ariso user is signed out, surface
+/// the (pre-created) Settings window and emit `tray://show-sign-in-prompt` so its
+/// sign-in banner appears, then report `false` so the caller aborts. Mirrors the
+/// tray's session gate so every recording entry point behaves identically.
+async fn ensure_recording_allowed(app: &tauri::AppHandle) -> bool {
+    if active_backend(app) != "ariso" {
+        return true;
+    }
+    if is_session_valid(app).await {
+        return true;
+    }
+    if let Some(win) = app.get_webview_window("settings") {
+        let _ = win.show();
+        let _ = win.set_focus();
+    }
+    let _ = app.emit("tray://show-sign-in-prompt", ());
+    false
+}
+
 /// Open the waveform recording window, optionally attaching to an existing
 /// meeting id. Closes the meeting-picker window if present and flips the
 /// tray menu to the recording state.
@@ -596,6 +616,9 @@ pub async fn start_recording_window(
     app: tauri::AppHandle,
     meeting_id: Option<i64>,
 ) -> Result<(), String> {
+    if !ensure_recording_allowed(&app).await {
+        return Err("sign-in required".to_string());
+    }
     open_waveform_window(&app, meeting_id, false)
 }
 
@@ -625,6 +648,9 @@ pub(crate) fn open_meeting_picker_window(app: &tauri::AppHandle) -> Result<(), S
 /// start-recording button for picker-using backends.
 #[tauri::command]
 pub async fn open_meeting_picker(app: tauri::AppHandle) -> Result<(), String> {
+    if !ensure_recording_allowed(&app).await {
+        return Err("sign-in required".to_string());
+    }
     open_meeting_picker_window(&app)
 }
 


### PR DESCRIPTION
## Problem

The tray menu already gated recording on a valid session for the Ariso backend (`tray.rs`), but the **in-app** recording entry points did not:

- **Library "+" button** with a meeting selected → called `start_recording_window` directly (no check)
- **Library "+" button** with nothing selected → opened the meeting picker (no check)
- **Meeting picker** "Start recording" / "Record a new meeting" → started recording (no check)

So a signed-out Ariso user could trigger a recording and only fail later with downstream 401s.

## Fix

Added a single shared gate, `ensure_recording_allowed`, at the two Rust command chokepoints every in-app path funnels through — `start_recording_window` and `open_meeting_picker`. It mirrors the tray's existing gate:

1. **Local backend** → always allowed (no auth needed)
2. **Ariso + valid session** → allowed
3. **Ariso + signed out** → shows/focuses the pre-created Settings window, emits `tray://show-sign-in-prompt`, and aborts the command with `Err`. SettingsView renders that as its "Please sign in to start recording." banner.

Because both commands now reject when blocked, the frontend's existing `try/catch` blocks skip the optimistic recording state — no frontend changes needed.

## Verification

- `cargo check` → exit 0
- `cargo check --tests` → exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Recording and meeting picker features now require valid authentication on Ariso backend. Users without an active session will be prompted to sign in before accessing these features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->