### PR TITLE
fix(settings): scope system audio to "System Audio Recording Only" + highlight active backend

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2630,10 +2630,12 @@ dependencies = [
  "futures-util",
  "objc2",
  "objc2-app-kit",
+ "objc2-core-audio",
+ "objc2-core-audio-types",
+ "objc2-core-foundation",
  "objc2-foundation",
  "objc2-user-notifications",
  "reqwest 0.12.28",
- "screencapturekit",
  "serde",
  "serde_json",
  "tauri",
@@ -2692,6 +2694,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-core-audio"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1eebcea8b0dbff5f7c8504f3107c68fc061a3eb44932051c8cf8a68d969c3b2"
+dependencies = [
+ "block2",
+ "dispatch2",
+ "libc",
+ "objc2",
+ "objc2-core-audio-types",
+ "objc2-core-foundation",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-audio-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a89f2ec274a0cf4a32642b2991e8b351a404d290da87bb6a9a9d8632490bd1c"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2",
+]
+
+[[package]]
 name = "objc2-core-data"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2709,7 +2736,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
  "bitflags 2.11.0",
+ "block2",
  "dispatch2",
+ "libc",
  "objc2",
 ]
 
@@ -3958,12 +3987,6 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "screencapturekit"
-version = "1.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99b732b2db50b25cfbcb171e1b7abda06e77873aeef493e635eb209482fdd149"
 
 [[package]]
 name = "security-framework"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -18,13 +18,19 @@ futures-util = "0.3"
 url = "2"
 chrono = "0.4"
 tauri-plugin-mcp = { git = "https://github.com/P3GLEG/tauri-plugin-mcp", optional = true }
-screencapturekit = { version = "1.5", features = ["macos_13_0"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 # UNUserNotificationCenter directly (the plugin has no desktop click API) so a
 # delegate can open the meeting-prep deep link when the notification is clicked.
 objc2 = "0.6"
 objc2-foundation = "0.3"
+# Core Audio process taps (macOS 14.4+) capture system audio under the narrow
+# "System Audio Recording" (NSAudioCaptureUsageDescription) permission rather
+# than the broad "Screen & System Audio Recording" permission ScreenCaptureKit
+# required. Default features pull AudioHardware, the type/CF bridges and block2.
+objc2-core-audio = "0.3"
+objc2-core-audio-types = "0.3"
+objc2-core-foundation = "0.3"
 objc2-user-notifications = { version = "0.3", features = [
     "UNNotificationContent",
     "UNNotificationRequest",

--- a/src-tauri/Info.plist
+++ b/src-tauri/Info.plist
@@ -6,7 +6,7 @@
 	<true/>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>oats needs microphone access to record meeting audio for transcription.</string>
-	<key>NSScreenCaptureUsageDescription</key>
-	<string>oats needs screen recording permission to capture system audio from video calls.</string>
+	<key>NSAudioCaptureUsageDescription</key>
+	<string>oats needs system audio recording permission to capture audio from video calls.</string>
 </dict>
 </plist>

--- a/src-tauri/src/audio_capture.rs
+++ b/src-tauri/src/audio_capture.rs
@@ -60,23 +60,15 @@ mod imp {
     type AudioObjectID = u32;
 
     /// Live capture resources, torn down in reverse creation order on stop.
+    /// All fields are plain integers; the IO block is owned by Core Audio
+    /// (retained via `Block_copy` inside `AudioDeviceCreateIOProcIDWithBlock`
+    /// and released by `AudioDeviceDestroyIOProcID`), so we don't need to
+    /// keep a !Send `RcBlock` in this cross-thread state.
     struct CaptureState {
         tap_id: AudioObjectID,
         aggregate_id: AudioObjectID,
         proc_id: AudioDeviceIOProcID,
-        // The IO block must outlive the running device; keep it pinned here.
-        _block: RcBlock<dyn Fn(
-            NonNull<AudioTimeStamp>,
-            NonNull<AudioBufferList>,
-            NonNull<AudioTimeStamp>,
-            NonNull<AudioBufferList>,
-            NonNull<AudioTimeStamp>,
-        )>,
     }
-
-    // The Core Audio object IDs are plain integers; the block is only ever
-    // touched on the IO thread before stop() joins it by destroying the proc.
-    unsafe impl Send for CaptureState {}
 
     static CAPTURE: Mutex<Option<CaptureState>> = Mutex::new(None);
 
@@ -344,11 +336,17 @@ mod imp {
                 return Err(format!("AudioDeviceStart failed: {status}"));
             }
 
+            // Core Audio copied the block during AudioDeviceCreateIOProcIDWithBlock
+            // and will release that copy in AudioDeviceDestroyIOProcID. Our local
+            // RcBlock retain is no longer needed; let it drop at end of scope on
+            // this start() thread (it's !Send, so we can't carry it across threads
+            // in CAPTURE).
+            drop(block);
+
             *guard = Some(CaptureState {
                 tap_id,
                 aggregate_id,
                 proc_id,
-                _block: block,
             });
         }
         Ok(())

--- a/src-tauri/src/audio_capture.rs
+++ b/src-tauri/src/audio_capture.rs
@@ -357,11 +357,30 @@ mod imp {
     pub fn stop() -> Result<(), String> {
         let mut guard = CAPTURE.lock().map_err(|e| e.to_string())?;
         if let Some(state) = guard.take() {
+            let mut errors: Vec<String> = Vec::new();
             unsafe {
-                AudioDeviceStop(state.aggregate_id, state.proc_id);
-                AudioDeviceDestroyIOProcID(state.aggregate_id, state.proc_id);
-                AudioHardwareDestroyAggregateDevice(state.aggregate_id);
-                AudioHardwareDestroyProcessTap(state.tap_id);
+                // Tear down in reverse creation order. Attempt every step even
+                // if an earlier one fails, so a single failure doesn't leak the
+                // remaining resources; collect statuses and report at the end.
+                let status = AudioDeviceStop(state.aggregate_id, state.proc_id);
+                if status != 0 {
+                    errors.push(format!("AudioDeviceStop failed: {status}"));
+                }
+                let status = AudioDeviceDestroyIOProcID(state.aggregate_id, state.proc_id);
+                if status != 0 {
+                    errors.push(format!("AudioDeviceDestroyIOProcID failed: {status}"));
+                }
+                let status = AudioHardwareDestroyAggregateDevice(state.aggregate_id);
+                if status != 0 {
+                    errors.push(format!("AudioHardwareDestroyAggregateDevice failed: {status}"));
+                }
+                let status = AudioHardwareDestroyProcessTap(state.tap_id);
+                if status != 0 {
+                    errors.push(format!("AudioHardwareDestroyProcessTap failed: {status}"));
+                }
+            }
+            if !errors.is_empty() {
+                return Err(errors.join("; "));
             }
         }
         Ok(())

--- a/src-tauri/src/audio_capture.rs
+++ b/src-tauri/src/audio_capture.rs
@@ -1,236 +1,484 @@
-use screencapturekit::prelude::*;
-use std::sync::{Arc, Mutex};
-use tauri::Emitter;
+//! System-audio capture via Core Audio process taps (macOS 14.4+).
+//!
+//! This replaces the previous ScreenCaptureKit implementation. ScreenCaptureKit
+//! gated audio behind the broad "Screen & System Audio Recording" permission;
+//! Core Audio process taps capture system audio under the narrow
+//! "System Audio Recording" permission (declared as `NSAudioCaptureUsageDescription`
+//! in Info.plist), which is what users see and grant.
+//!
+//! Flow: create a mono global process tap → wrap it in a private aggregate
+//! device whose main sub-device is the current default output → install an IO
+//! block that receives Float32 PCM at the device's native rate → downmix to
+//! mono, resample to 16 kHz, convert to Int16, and emit as `system-audio-data`
+//! (base64) to match the contract the recorder frontend already consumes.
 
-/// Holds the active SCStream so we can stop it later.
-struct CaptureState {
-    stream: Option<SCStream>,
+#[cfg(not(target_os = "macos"))]
+mod imp {
+    /// No system-audio capture off macOS; the recorder treats this as "no
+    /// system source available" and falls back to mic-only.
+    pub fn start(_app: tauri::AppHandle) -> Result<(), String> {
+        Err("System audio capture is only supported on macOS".into())
+    }
+    pub fn stop() -> Result<(), String> {
+        Ok(())
+    }
+    pub fn request_permission() -> bool {
+        true
+    }
+    pub fn check_permission() -> bool {
+        true
+    }
 }
 
-static CAPTURE: Mutex<Option<CaptureState>> = Mutex::new(None);
+#[cfg(target_os = "macos")]
+mod imp {
+    use block2::RcBlock;
+    use objc2::rc::Retained;
+    use objc2::AllocAnyThread;
+    use objc2_core_audio::{
+        kAudioAggregateDeviceIsPrivateKey, kAudioAggregateDeviceMainSubDeviceKey,
+        kAudioAggregateDeviceNameKey, kAudioAggregateDeviceSubDeviceListKey,
+        kAudioAggregateDeviceTapAutoStartKey, kAudioAggregateDeviceTapListKey,
+        kAudioAggregateDeviceUIDKey, kAudioDevicePropertyDeviceUID,
+        kAudioHardwarePropertyDefaultSystemOutputDevice, kAudioObjectPropertyElementMain,
+        kAudioObjectPropertyScopeGlobal, kAudioObjectSystemObject, kAudioSubDeviceUIDKey,
+        kAudioSubTapDriftCompensationKey, kAudioSubTapUIDKey, kAudioTapPropertyFormat,
+        AudioDeviceCreateIOProcIDWithBlock, AudioDeviceDestroyIOProcID, AudioDeviceIOProcID,
+        AudioDeviceStart, AudioDeviceStop, AudioHardwareCreateAggregateDevice,
+        AudioHardwareCreateProcessTap, AudioHardwareDestroyAggregateDevice,
+        AudioHardwareDestroyProcessTap, AudioObjectGetPropertyData, AudioObjectPropertyAddress,
+        CATapDescription, CATapMuteBehavior,
+    };
+    use objc2_core_audio_types::{AudioBufferList, AudioStreamBasicDescription, AudioTimeStamp};
+    use objc2_core_foundation::{CFDictionary, CFRetained, CFString};
+    use objc2_foundation::{NSArray, NSDictionary, NSNumber, NSObject, NSString};
+    use std::ffi::{c_void, CStr};
+    use std::ptr::NonNull;
+    use std::sync::{Arc, Mutex};
+    use tauri::Emitter;
 
-/// Start capturing system audio via ScreenCaptureKit.
-/// Audio samples are emitted as `system-audio-data` events containing
+    type AudioObjectID = u32;
+
+    /// Live capture resources, torn down in reverse creation order on stop.
+    struct CaptureState {
+        tap_id: AudioObjectID,
+        aggregate_id: AudioObjectID,
+        proc_id: AudioDeviceIOProcID,
+        // The IO block must outlive the running device; keep it pinned here.
+        _block: RcBlock<dyn Fn(
+            NonNull<AudioTimeStamp>,
+            NonNull<AudioBufferList>,
+            NonNull<AudioTimeStamp>,
+            NonNull<AudioBufferList>,
+            NonNull<AudioTimeStamp>,
+        )>,
+    }
+
+    // The Core Audio object IDs are plain integers; the block is only ever
+    // touched on the IO thread before stop() joins it by destroying the proc.
+    unsafe impl Send for CaptureState {}
+
+    static CAPTURE: Mutex<Option<CaptureState>> = Mutex::new(None);
+
+    fn ns(c: &CStr) -> Retained<NSString> {
+        NSString::from_str(c.to_str().expect("Core Audio key is valid UTF-8"))
+    }
+
+    /// Streaming linear resampler from `src_rate` to 16 kHz, carrying fractional
+    /// position and the last input sample across IO callbacks so block
+    /// boundaries don't click.
+    struct Resampler {
+        step: f64,
+        pos: f64,
+        prev: f32,
+        primed: bool,
+    }
+
+    impl Resampler {
+        fn new(src_rate: f64) -> Self {
+            Self {
+                step: src_rate / 16_000.0,
+                pos: 0.0,
+                prev: 0.0,
+                primed: false,
+            }
+        }
+
+        /// Resample `input` (mono f32) into `out` as little-endian Int16 bytes.
+        fn process(&mut self, input: &[f32], out: &mut Vec<u8>) {
+            if input.is_empty() {
+                return;
+            }
+            if !self.primed {
+                // Seed `prev` with the first sample so the leading interpolation
+                // doesn't ramp up from silence.
+                self.prev = input[0];
+                self.primed = true;
+            }
+            let n = input.len();
+            // Position coordinate: 0 == `prev`, k == input[k-1] for k in 1..=n.
+            let sample_at = |j: f64| -> f32 {
+                let idx = j as isize;
+                if idx <= 0 {
+                    self.prev
+                } else {
+                    input[(idx - 1).min(n as isize - 1) as usize]
+                }
+            };
+            while self.pos < n as f64 {
+                let base = self.pos.floor();
+                let frac = (self.pos - base) as f32;
+                let a = sample_at(base);
+                let b = sample_at(base + 1.0);
+                let s = a + (b - a) * frac;
+                let clamped = s.clamp(-1.0, 1.0);
+                let v: i16 = if clamped < 0.0 {
+                    (clamped * 32768.0) as i16
+                } else {
+                    (clamped * 32767.0) as i16
+                };
+                out.extend_from_slice(&v.to_le_bytes());
+                self.pos += self.step;
+            }
+            // Carry the unused fraction into the next block, whose origin moves
+            // to input[n-1].
+            self.pos -= n as f64;
+            self.prev = input[n - 1];
+        }
+    }
+
+    fn prop_address(selector: u32) -> AudioObjectPropertyAddress {
+        AudioObjectPropertyAddress {
+            mSelector: selector,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain,
+        }
+    }
+
+    /// Read a fixed-size Core Audio property into `T`.
+    unsafe fn get_property<T>(object: AudioObjectID, selector: u32) -> Result<T, String> {
+        let addr = prop_address(selector);
+        let mut value = std::mem::MaybeUninit::<T>::uninit();
+        let mut size = std::mem::size_of::<T>() as u32;
+        let status = unsafe {
+            AudioObjectGetPropertyData(
+                object,
+                NonNull::from(&addr),
+                0,
+                std::ptr::null(),
+                NonNull::from(&mut size),
+                NonNull::new(value.as_mut_ptr() as *mut c_void).unwrap(),
+            )
+        };
+        if status != 0 {
+            return Err(format!("AudioObjectGetPropertyData({selector}) failed: {status}"));
+        }
+        Ok(unsafe { value.assume_init() })
+    }
+
+    /// Build the aggregate-device description dictionary (toll-free bridged to
+    /// CFDictionary). Keys are the Core Audio C-string constants; values upcast
+    /// to `&NSObject` via deref coercion.
+    fn build_aggregate_dict(
+        agg_uid: &str,
+        output_uid: &NSString,
+        tap_uuid: &str,
+    ) -> Retained<NSDictionary<NSString, NSObject>> {
+        // Inner sub-device list: [{ kAudioSubDeviceUIDKey: <output uid> }]
+        let sub_dev_key = ns(kAudioSubDeviceUIDKey);
+        let sub_device =
+            NSDictionary::from_slices(&[&*sub_dev_key], &[output_uid as &NSObject]);
+        let sub_list = NSArray::from_retained_slice(&[sub_device]);
+
+        // Inner tap list: [{ drift: true, kAudioSubTapUIDKey: <tap uuid> }]
+        let tap_drift_key = ns(kAudioSubTapDriftCompensationKey);
+        let tap_uid_key = ns(kAudioSubTapUIDKey);
+        let tap_drift_val = NSNumber::numberWithBool(true);
+        let tap_uid_val = NSString::from_str(tap_uuid);
+        let tap = NSDictionary::from_slices(
+            &[&*tap_drift_key, &*tap_uid_key],
+            &[&*tap_drift_val as &NSObject, &*tap_uid_val],
+        );
+        let tap_list = NSArray::from_retained_slice(&[tap]);
+
+        let k_name = ns(kAudioAggregateDeviceNameKey);
+        let k_uid = ns(kAudioAggregateDeviceUIDKey);
+        let k_main = ns(kAudioAggregateDeviceMainSubDeviceKey);
+        let k_priv = ns(kAudioAggregateDeviceIsPrivateKey);
+        let k_auto = ns(kAudioAggregateDeviceTapAutoStartKey);
+        let k_subs = ns(kAudioAggregateDeviceSubDeviceListKey);
+        let k_taps = ns(kAudioAggregateDeviceTapListKey);
+
+        let v_name = NSString::from_str("Oats System Audio Tap");
+        let v_uid = NSString::from_str(agg_uid);
+        let v_priv = NSNumber::numberWithBool(true);
+        let v_auto = NSNumber::numberWithBool(true);
+
+        let keys: [&NSString; 7] = [
+            &k_name, &k_uid, &k_main, &k_priv, &k_auto, &k_subs, &k_taps,
+        ];
+        let values: [&NSObject; 7] = [
+            &v_name,
+            &v_uid,
+            output_uid,
+            &v_priv,
+            &v_auto,
+            &sub_list,
+            &tap_list,
+        ];
+        NSDictionary::from_slices(&keys, &values)
+    }
+
+    pub fn start(app: tauri::AppHandle) -> Result<(), String> {
+        let mut guard = CAPTURE.lock().map_err(|e| e.to_string())?;
+        if guard.is_some() {
+            return Err("System audio capture already running".into());
+        }
+
+        unsafe {
+            // 1. Mono global tap over the whole system (exclude nothing).
+            let exclude: Retained<NSArray<NSNumber>> = NSArray::new();
+            let tap_desc = CATapDescription::initMonoGlobalTapButExcludeProcesses(
+                CATapDescription::alloc(),
+                &exclude,
+            );
+            tap_desc.setName(&NSString::from_str("Oats System Audio Tap"));
+            tap_desc.setPrivate(true);
+            tap_desc.setMuteBehavior(CATapMuteBehavior::Unmuted);
+            let tap_uuid = tap_desc.UUID().UUIDString().to_string();
+
+            let mut tap_id: AudioObjectID = 0;
+            let status = AudioHardwareCreateProcessTap(Some(&tap_desc), &mut tap_id);
+            if status != 0 {
+                return Err(format!("AudioHardwareCreateProcessTap failed: {status}"));
+            }
+
+            // 2. Default output device + its UID (the aggregate's clock source).
+            let output_id: AudioObjectID = match get_property(
+                kAudioObjectSystemObject as AudioObjectID,
+                kAudioHardwarePropertyDefaultSystemOutputDevice,
+            ) {
+                Ok(v) => v,
+                Err(e) => {
+                    AudioHardwareDestroyProcessTap(tap_id);
+                    return Err(e);
+                }
+            };
+            let output_uid_cf: CFRetained<CFString> =
+                match get_property::<*const CFString>(output_id, kAudioDevicePropertyDeviceUID) {
+                    Ok(ptr) => CFRetained::from_raw(NonNull::new(ptr as *mut CFString).unwrap()),
+                    Err(e) => {
+                        AudioHardwareDestroyProcessTap(tap_id);
+                        return Err(e);
+                    }
+                };
+            let output_uid = NSString::from_str(&output_uid_cf.to_string());
+
+            // 3. Tap stream format → native sample rate for the resampler.
+            let asbd: AudioStreamBasicDescription =
+                match get_property(tap_id, kAudioTapPropertyFormat) {
+                    Ok(v) => v,
+                    Err(e) => {
+                        AudioHardwareDestroyProcessTap(tap_id);
+                        return Err(e);
+                    }
+                };
+            let src_rate = asbd.mSampleRate;
+
+            // 4. Private aggregate device wrapping the tap.
+            let agg_uid = format!("ai.ariso.oats.tap.{tap_uuid}");
+            let dict = build_aggregate_dict(&agg_uid, &output_uid, &tap_uuid);
+            let cf_dict: &CFDictionary =
+                &*(Retained::as_ptr(&dict) as *const CFDictionary);
+            let mut aggregate_id: AudioObjectID = 0;
+            let status =
+                AudioHardwareCreateAggregateDevice(cf_dict, NonNull::from(&mut aggregate_id));
+            if status != 0 {
+                AudioHardwareDestroyProcessTap(tap_id);
+                return Err(format!("AudioHardwareCreateAggregateDevice failed: {status}"));
+            }
+
+            // 5. IO block: downmix → resample → emit.
+            let app = Arc::new(app);
+            let resampler = Arc::new(Mutex::new(Resampler::new(src_rate)));
+            let app_cb = app.clone();
+            let block = RcBlock::new(
+                move |_now: NonNull<AudioTimeStamp>,
+                      input: NonNull<AudioBufferList>,
+                      _intime: NonNull<AudioTimeStamp>,
+                      _out: NonNull<AudioBufferList>,
+                      _outtime: NonNull<AudioTimeStamp>| {
+                    let mono = downmix_to_mono(input.as_ptr());
+                    if mono.is_empty() {
+                        return;
+                    }
+                    let mut bytes = Vec::with_capacity(mono.len() * 2);
+                    if let Ok(mut rs) = resampler.lock() {
+                        rs.process(&mono, &mut bytes);
+                    }
+                    if !bytes.is_empty() {
+                        let b64 = base64_encode(&bytes);
+                        let _ = app_cb.emit("system-audio-data", b64);
+                    }
+                },
+            );
+
+            let mut proc_id: AudioDeviceIOProcID = None;
+            let status = AudioDeviceCreateIOProcIDWithBlock(
+                NonNull::from(&mut proc_id),
+                aggregate_id,
+                None,
+                RcBlock::as_ptr(&block),
+            );
+            if status != 0 {
+                AudioHardwareDestroyAggregateDevice(aggregate_id);
+                AudioHardwareDestroyProcessTap(tap_id);
+                return Err(format!("AudioDeviceCreateIOProcIDWithBlock failed: {status}"));
+            }
+
+            let status = AudioDeviceStart(aggregate_id, proc_id);
+            if status != 0 {
+                AudioDeviceDestroyIOProcID(aggregate_id, proc_id);
+                AudioHardwareDestroyAggregateDevice(aggregate_id);
+                AudioHardwareDestroyProcessTap(tap_id);
+                return Err(format!("AudioDeviceStart failed: {status}"));
+            }
+
+            *guard = Some(CaptureState {
+                tap_id,
+                aggregate_id,
+                proc_id,
+                _block: block,
+            });
+        }
+        Ok(())
+    }
+
+    pub fn stop() -> Result<(), String> {
+        let mut guard = CAPTURE.lock().map_err(|e| e.to_string())?;
+        if let Some(state) = guard.take() {
+            unsafe {
+                AudioDeviceStop(state.aggregate_id, state.proc_id);
+                AudioDeviceDestroyIOProcID(state.aggregate_id, state.proc_id);
+                AudioHardwareDestroyAggregateDevice(state.aggregate_id);
+                AudioHardwareDestroyProcessTap(state.tap_id);
+            }
+        }
+        Ok(())
+    }
+
+    /// Average all channels of an interleaved Float32 `AudioBufferList` into a
+    /// mono Vec. Process taps deliver one buffer of interleaved floats.
+    unsafe fn downmix_to_mono(list: *const AudioBufferList) -> Vec<f32> {
+        let list = unsafe { &*list };
+        let n = list.mNumberBuffers as usize;
+        if n == 0 {
+            return Vec::new();
+        }
+        // mBuffers is a flexible array; index from its address.
+        let buffers = list.mBuffers.as_ptr();
+        let mut out: Vec<f32> = Vec::new();
+        for i in 0..n {
+            let buf = unsafe { &*buffers.add(i) };
+            if buf.mData.is_null() || buf.mDataByteSize == 0 {
+                continue;
+            }
+            let ch = buf.mNumberChannels.max(1);
+            let count = buf.mDataByteSize as usize / std::mem::size_of::<f32>();
+            let data = unsafe { std::slice::from_raw_parts(buf.mData as *const f32, count) };
+            if ch <= 1 {
+                out.extend_from_slice(data);
+            } else {
+                // Interleaved: average each frame's channels.
+                for frame in data.chunks_exact(ch as usize) {
+                    let sum: f32 = frame.iter().copied().sum();
+                    out.push(sum / ch as f32);
+                }
+            }
+        }
+        out
+    }
+
+    // macOS audio-capture (TCC) permission. There is no public API to preflight
+    // or request the system-audio permission directly; the OS surfaces the
+    // prompt the first time `AudioHardwareCreateProcessTap` actually taps audio.
+    // We approximate request/check by attempting a throwaway tap: if the tap
+    // creates successfully, access is (or has just been) granted.
+    pub fn request_permission() -> bool {
+        probe_tap()
+    }
+
+    pub fn check_permission() -> bool {
+        probe_tap()
+    }
+
+    fn probe_tap() -> bool {
+        unsafe {
+            let exclude: Retained<NSArray<NSNumber>> = NSArray::new();
+            let desc = CATapDescription::initMonoGlobalTapButExcludeProcesses(
+                CATapDescription::alloc(),
+                &exclude,
+            );
+            desc.setPrivate(true);
+            desc.setMuteBehavior(CATapMuteBehavior::Unmuted);
+            let mut tap_id: AudioObjectID = 0;
+            let status = AudioHardwareCreateProcessTap(Some(&desc), &mut tap_id);
+            if status == 0 {
+                AudioHardwareDestroyProcessTap(tap_id);
+                true
+            } else {
+                false
+            }
+        }
+    }
+
+    fn base64_encode(data: &[u8]) -> String {
+        const CHARS: &[u8; 64] =
+            b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+        let mut out = Vec::with_capacity(data.len().div_ceil(3) * 4);
+        for chunk in data.chunks(3) {
+            let b0 = chunk[0];
+            let b1 = chunk.get(1).copied().unwrap_or(0);
+            let b2 = chunk.get(2).copied().unwrap_or(0);
+            out.push(CHARS[(b0 >> 2) as usize]);
+            out.push(CHARS[((b0 & 0x03) << 4 | b1 >> 4) as usize]);
+            out.push(if chunk.len() > 1 {
+                CHARS[((b1 & 0x0f) << 2 | b2 >> 6) as usize]
+            } else {
+                b'='
+            });
+            out.push(if chunk.len() > 2 {
+                CHARS[(b2 & 0x3f) as usize]
+            } else {
+                b'='
+            });
+        }
+        // Safety: base64 output is always valid UTF-8.
+        unsafe { String::from_utf8_unchecked(out) }
+    }
+}
+
+/// Start capturing system audio. Emits `system-audio-data` events carrying
 /// base64-encoded PCM Int16 mono 16 kHz data.
 #[tauri::command]
 pub fn start_system_audio_capture(app: tauri::AppHandle) -> Result<(), String> {
-    let mut guard = CAPTURE.lock().map_err(|e| e.to_string())?;
-    if guard.is_some() {
-        return Err("System audio capture already running".into());
-    }
-
-    // Get the primary display for the content filter
-    let content = SCShareableContent::get().map_err(|e| format!("Failed to get content: {e}"))?;
-    let display = content
-        .displays()
-        .into_iter()
-        .next()
-        .ok_or("No display found")?;
-
-    // Filter: capture the whole display (we only care about audio)
-    let filter = SCContentFilter::create()
-        .with_display(&display)
-        .with_excluding_windows(&[])
-        .build();
-
-    // Configure: audio only at 16 kHz mono (matches Deepgram expectations)
-    let config = SCStreamConfiguration::new()
-        .with_width(2)
-        .with_height(2)
-        .with_captures_audio(true)
-        .with_sample_rate(16000)
-        .with_channel_count(1);
-
-    let app_handle = Arc::new(app);
-
-    let mut stream = SCStream::new(&filter, &config);
-
-    let app_for_handler = app_handle.clone();
-    stream.add_output_handler(
-        move |sample: CMSampleBuffer, of_type: SCStreamOutputType| {
-            if of_type != SCStreamOutputType::Audio {
-                return;
-            }
-
-            // Extract PCM audio data from the sample buffer
-            if let Some(data) = extract_audio_i16_bytes(&sample) {
-                // Send as base64 to the frontend
-                let b64 = base64_encode(&data);
-                let _ = app_for_handler.emit("system-audio-data", b64);
-            }
-        },
-        SCStreamOutputType::Audio,
-    );
-
-    stream
-        .start_capture()
-        .map_err(|e| format!("Failed to start capture: {e}"))?;
-
-    *guard = Some(CaptureState {
-        stream: Some(stream),
-    });
-
-    Ok(())
+    imp::start(app)
 }
 
 /// Stop the system audio capture.
 #[tauri::command]
 pub fn stop_system_audio_capture() -> Result<(), String> {
-    let mut guard = CAPTURE.lock().map_err(|e| e.to_string())?;
-    if let Some(mut state) = guard.take() {
-        if let Some(stream) = state.stream.take() {
-            stream
-                .stop_capture()
-                .map_err(|e| format!("Failed to stop capture: {e}"))?;
-        }
-    }
-    Ok(())
+    imp::stop()
 }
 
-// macOS Screen Recording permission (required to capture system audio via
-// ScreenCaptureKit). `request` surfaces the OS prompt the first time the user
-// is asked; once a decision exists it returns the current status without a
-// prompt. `check` (preflight) never prompts and is used to populate the
-// Settings UI on load.
-#[cfg(target_os = "macos")]
-#[link(name = "CoreGraphics", kind = "framework")]
-unsafe extern "C" {
-    fn CGRequestScreenCaptureAccess() -> bool;
-    fn CGPreflightScreenCaptureAccess() -> bool;
-}
-
+/// Prompt for / verify the macOS system-audio (audio recording) permission.
 #[tauri::command]
 pub fn request_screen_capture_permission() -> bool {
-    #[cfg(target_os = "macos")]
-    {
-        unsafe { CGRequestScreenCaptureAccess() }
-    }
-    #[cfg(not(target_os = "macos"))]
-    {
-        true
-    }
+    imp::request_permission()
 }
 
+/// Current system-audio permission status.
 #[tauri::command]
 pub fn check_screen_capture_permission() -> bool {
-    #[cfg(target_os = "macos")]
-    {
-        unsafe { CGPreflightScreenCaptureAccess() }
-    }
-    #[cfg(not(target_os = "macos"))]
-    {
-        true
-    }
-}
-
-/// Extract raw PCM Int16 bytes from a CMSampleBuffer.
-/// ScreenCaptureKit delivers audio as Float32 PCM; we convert to Int16
-/// to match the Deepgram linear16 format.
-fn extract_audio_i16_bytes(sample: &CMSampleBuffer) -> Option<Vec<u8>> {
-    let audio_buffers = sample.audio_buffer_list()?;
-    let num_buffers = audio_buffers.num_buffers();
-
-    let mut all_bytes: Vec<u8> = Vec::new();
-
-    for i in 0..num_buffers {
-        let Some(buffer) = audio_buffers.buffer(i) else {
-            continue;
-        };
-        let data: &[u8] = buffer.data();
-        if data.is_empty() {
-            continue;
-        }
-
-        // ScreenCaptureKit delivers Float32 PCM — parse safely without alignment assumptions
-        for chunk in data.chunks_exact(std::mem::size_of::<f32>()) {
-            let s = f32::from_ne_bytes(chunk.try_into().unwrap());
-            let clamped = s.clamp(-1.0, 1.0);
-            let i16_val: i16 = if clamped < 0.0 {
-                (clamped * 32768.0) as i16
-            } else {
-                (clamped * 32767.0) as i16
-            };
-            all_bytes.extend_from_slice(&i16_val.to_le_bytes());
-        }
-    }
-
-    if all_bytes.is_empty() {
-        None
-    } else {
-        Some(all_bytes)
-    }
-}
-
-fn base64_encode(data: &[u8]) -> String {
-    use std::io::Write;
-    let mut buf = Vec::with_capacity(data.len() * 4 / 3 + 4);
-    let mut encoder = Base64Encoder::new(&mut buf);
-    encoder.write_all(data).unwrap();
-    encoder.finish();
-    // Safety: base64 output is always valid UTF-8
-    unsafe { String::from_utf8_unchecked(buf) }
-}
-
-/// Minimal base64 encoder (avoids adding a dependency)
-struct Base64Encoder<'a> {
-    out: &'a mut Vec<u8>,
-    buf: [u8; 3],
-    len: usize,
-}
-
-const B64_CHARS: &[u8; 64] =
-    b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
-
-impl<'a> Base64Encoder<'a> {
-    fn new(out: &'a mut Vec<u8>) -> Self {
-        Self {
-            out,
-            buf: [0; 3],
-            len: 0,
-        }
-    }
-
-    fn flush_buf(&mut self) {
-        if self.len == 0 {
-            return;
-        }
-        let b = self.buf;
-        self.out.push(B64_CHARS[(b[0] >> 2) as usize]);
-        self.out
-            .push(B64_CHARS[((b[0] & 0x03) << 4 | b[1] >> 4) as usize]);
-        if self.len > 1 {
-            self.out
-                .push(B64_CHARS[((b[1] & 0x0f) << 2 | b[2] >> 6) as usize]);
-        } else {
-            self.out.push(b'=');
-        }
-        if self.len > 2 {
-            self.out.push(B64_CHARS[(b[2] & 0x3f) as usize]);
-        } else {
-            self.out.push(b'=');
-        }
-        self.buf = [0; 3];
-        self.len = 0;
-    }
-
-    fn finish(mut self) {
-        self.flush_buf();
-    }
-}
-
-impl<'a> std::io::Write for Base64Encoder<'a> {
-    fn write(&mut self, data: &[u8]) -> std::io::Result<usize> {
-        for &byte in data {
-            self.buf[self.len] = byte;
-            self.len += 1;
-            if self.len == 3 {
-                self.flush_buf();
-            }
-        }
-        Ok(data.len())
-    }
-
-    fn flush(&mut self) -> std::io::Result<()> {
-        Ok(())
-    }
+    imp::check_permission()
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -35,7 +35,8 @@
     ],
     "macOS": {
       "entitlements": "entitlements.plist",
-      "infoPlist": "Info.plist"
+      "infoPlist": "Info.plist",
+      "minimumSystemVersion": "14.4"
     },
     "createUpdaterArtifacts": true
   },

--- a/src/composables/useRecordingPermissions.ts
+++ b/src/composables/useRecordingPermissions.ts
@@ -57,7 +57,12 @@ export async function ensureMicPermission(): Promise<boolean> {
   }
 }
 
-/** Prompt for / verify macOS Screen Recording permission (system audio). */
+/**
+ * Prompt for / verify the macOS "System Audio Recording" permission. System
+ * audio is captured via Core Audio process taps (macOS 14.4+), so the OS lists
+ * the app under the "System Audio Recording Only" section of Privacy &
+ * Security → Screen & System Audio Recording — not full screen recording.
+ */
 export async function ensureSystemAudioPermission(): Promise<boolean> {
   try {
     return await invoke<boolean>('request_screen_capture_permission');
@@ -66,7 +71,8 @@ export async function ensureSystemAudioPermission(): Promise<boolean> {
   }
 }
 
-/** Current Screen Recording status without prompting (for initial UI state). */
+/** Current system-audio recording status (best-effort; there is no public
+ * preflight API, so this attempts a throwaway tap). */
 export async function checkSystemAudioPermission(): Promise<boolean> {
   try {
     return await invoke<boolean>('check_screen_capture_permission');
@@ -81,7 +87,11 @@ export async function openMicSettings(): Promise<void> {
   await openUrl('x-apple.systempreferences:com.apple.preference.security?Privacy_Microphone');
 }
 
-/** Open System Settings → Privacy → Screen Recording. macOS only; no-op elsewhere. */
+/**
+ * Open System Settings → Privacy → Screen & System Audio Recording. The
+ * "System Audio Recording Only" entries live in a section of this same pane.
+ * macOS only; no-op elsewhere.
+ */
 export async function openSystemAudioSettings(): Promise<void> {
   if (!isMac()) return;
   await openUrl('x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture');

--- a/src/views/SettingsView.vue
+++ b/src/views/SettingsView.vue
@@ -311,7 +311,6 @@ import {
   setSystemAudioEnabled,
   ensureMicPermission,
   ensureSystemAudioPermission,
-  checkSystemAudioPermission,
   openMicSettings,
   openSystemAudioSettings,
 } from '../composables/useRecordingPermissions';
@@ -728,12 +727,10 @@ onMounted(async () => {
     systemAudioEnabled.value = enabled.systemAudio;
     autoRecordSupported.value = await isAutoRecordSupported();
     autoRecordEnabled.value = await isAutoRecordEnabled();
-    // Reflect the current Screen Recording status without prompting. (Mic status
-    // is intentionally left blank on load — there's no silent mic preflight as
-    // clean as CGPreflightScreenCaptureAccess, and getUserMedia would prompt.)
-    if (enabled.systemAudio) {
-      systemAudioStatus.value = (await checkSystemAudioPermission()) ? 'granted' : 'denied';
-    }
+    // Both mic and system-audio status are left blank on load: there's no
+    // silent preflight for either (getUserMedia prompts; the system-audio
+    // probe creates a process tap, which trips the TCC dialog on first use).
+    // The status fills in when the user toggles the row.
   } catch (e) {
     console.warn('Failed to initialize recording settings', e);
   }

--- a/src/views/SettingsView.vue
+++ b/src/views/SettingsView.vue
@@ -1122,8 +1122,10 @@ async function handleSignOut() {
   color: #ffffff;
 }
 
-.backend-option--active:hover {
+.backend-option--active:hover,
+.backend-option--active:focus-visible {
   background: #1c1c1c;
+  color: #ffffff;
 }
 
 .about-header {


### PR DESCRIPTION
## What

- **System audio permission**: migrate capture from ScreenCaptureKit to Core Audio process taps (macOS 14.4+). The app now requests the narrow **"System Audio Recording Only"** permission instead of the broad **"Screen & System Audio Recording"**. `Info.plist` swapped to `NSAudioCaptureUsageDescription`.
- **Backend dropdown**: the selected option now keeps its dark background + white text/icon when focused (`:focus-visible` was overriding `--active`).

## Testing

- `cargo check` clean; full frontend suite 204/204 passing.
- Verified on a release bundle: oats appears under **System Audio Recording Only** (not the broad section) and system-audio recording works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated macOS system audio permission guidance and settings navigation text.

* **Improvements**
  * Upgraded macOS system-audio capture to a new Core Audio–based pipeline (including improved resampling and mono downmix).
  * Updated permission handling to probe availability via capture capability.
  * Settings now leave system-audio/mic status blank until the user interacts with the toggles.
  * Set macOS minimum system version to 14.4.

* **Style**
  * Improved keyboard focus styling for active backend options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->