### PR TITLE
Polish native update window states

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.4.0",
       "dependencies": {
         "@breezystack/lamejs": "^1.2.7",
+        "@heroicons/vue": "^2.2.0",
         "@tauri-apps/api": "^2.5.0",
         "@tauri-apps/plugin-notification": "^2.3.3",
         "@tauri-apps/plugin-opener": "^2.5.3",
@@ -775,6 +776,15 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
       "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
       "license": "MIT"
+    },
+    "node_modules/@heroicons/vue": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@heroicons/vue/-/vue-2.2.0.tgz",
+      "integrity": "sha512-G3dbSxoeEKqbi/DFalhRxJU4mTXJn7GwZ7ae8NuEQzd1bqdd0jAbdaBZlHPcvPD2xI1iGzNVB4k20Un2AguYPw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "vue": ">= 3"
+      }
     },
     "node_modules/@hono/node-server": {
       "version": "1.19.14",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@breezystack/lamejs": "^1.2.7",
+    "@heroicons/vue": "^2.2.0",
     "@tauri-apps/api": "^2.5.0",
     "@tauri-apps/plugin-notification": "^2.3.3",
     "@tauri-apps/plugin-opener": "^2.5.3",

--- a/src-tauri/src/update_manager.rs
+++ b/src-tauri/src/update_manager.rs
@@ -320,7 +320,7 @@ fn open_update_window<R: Runtime>(app: &AppHandle<R>) {
     )
     .title("")
     .title_bar_style(TitleBarStyle::Overlay)
-    .inner_size(520.0, 600.0)
+    .inner_size(450.0, 600.0)
     .resizable(false)
     .center()
     .skip_taskbar(true)

--- a/src-tauri/src/update_manager.rs
+++ b/src-tauri/src/update_manager.rs
@@ -316,7 +316,7 @@ fn open_update_window<R: Runtime>(app: &AppHandle<R>) {
         WebviewUrl::App("/#/update".into()),
     )
     .title("")
-    .inner_size(420.0, 360.0)
+    .inner_size(670.0, 910.0)
     .resizable(false)
     .center()
     .skip_taskbar(true)

--- a/src-tauri/src/update_manager.rs
+++ b/src-tauri/src/update_manager.rs
@@ -276,6 +276,9 @@ pub async fn run_check<R: Runtime>(app: AppHandle<R>, force: bool) {
                 save_state(&app, &state);
             }
             let _ = app.emit("update://none", ());
+            if force {
+                open_update_window(&app);
+            }
             finish_check(&app, force, Ok(()));
         }
         Err(e) => {
@@ -296,7 +299,7 @@ fn finish_check<R: Runtime>(app: &AppHandle<R>, force: bool, result: Result<(), 
 /// Open the update window if it doesn't already exist; focus it if it does.
 /// Mandatory updates intercept the close button.
 fn open_update_window<R: Runtime>(app: &AppHandle<R>) {
-    use tauri::{WebviewUrl, WebviewWindowBuilder};
+    use tauri::{TitleBarStyle, WebviewUrl, WebviewWindowBuilder};
 
     if let Some(win) = app.get_webview_window("update") {
         let _ = win.show();
@@ -316,7 +319,8 @@ fn open_update_window<R: Runtime>(app: &AppHandle<R>) {
         WebviewUrl::App("/#/update".into()),
     )
     .title("")
-    .inner_size(670.0, 910.0)
+    .title_bar_style(TitleBarStyle::Overlay)
+    .inner_size(520.0, 600.0)
     .resizable(false)
     .center()
     .skip_taskbar(true)

--- a/src/views/UpdateView.test.ts
+++ b/src/views/UpdateView.test.ts
@@ -1,0 +1,111 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { mount, flushPromises } from '@vue/test-utils';
+
+const mocks = vi.hoisted(() => {
+  const defaultState = {
+    auto_check_enabled: true,
+    last_check_unix: null,
+    skipped_version: null,
+    snoozed_until_unix: null,
+    latest_known: null,
+  };
+
+  return {
+    state: { ...defaultState },
+    defaultState,
+    closeWindow: vi.fn(),
+    listeners: new Map<string, (e: { payload: unknown }) => void>(),
+    installAndRelaunch: vi.fn(),
+    skipVersion: vi.fn(),
+    snooze: vi.fn(),
+  };
+});
+
+vi.mock('@tauri-apps/api/event', () => ({
+  listen: (name: string, cb: (e: { payload: unknown }) => void) => {
+    mocks.listeners.set(name, cb);
+    return Promise.resolve(() => mocks.listeners.delete(name));
+  },
+}));
+
+vi.mock('@tauri-apps/api/window', () => ({
+  getCurrentWindow: () => ({ close: mocks.closeWindow }),
+}));
+
+vi.mock('../tauri', () => ({
+  updater: {
+    getState: () => Promise.resolve(mocks.state),
+    installAndRelaunch: mocks.installAndRelaunch,
+    skipVersion: mocks.skipVersion,
+    snooze: mocks.snooze,
+  },
+}));
+
+import UpdateView from './UpdateView.vue';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.listeners.clear();
+  mocks.state = { ...mocks.defaultState };
+});
+
+describe('UpdateView', () => {
+  it('shows an up-to-date state without an install button when no update exists', async () => {
+    const wrapper = mount(UpdateView);
+    await flushPromises();
+
+    expect(wrapper.text()).toContain('Oats is up to date');
+    expect(wrapper.text()).toContain('Version 0.4.0 is installed.');
+    expect(wrapper.text()).not.toContain('Install Update');
+    expect(wrapper.text()).toContain('Done');
+  });
+
+  it('renders updater markdown directly for a newer version', async () => {
+    mocks.state = {
+      ...mocks.defaultState,
+      latest_known: {
+        version: '0.4.1',
+        mandatory: false,
+        notes: [
+          '## [0.4.1](https://github.com/ariso-ai/oats/compare/v0.4.0...v0.4.1)',
+          '',
+          '### Features',
+          '- Release-note powered highlights',
+          '- Smaller native update window',
+          '- Up-to-date state with no install CTA',
+        ].join('\n'),
+      },
+    };
+
+    const wrapper = mount(UpdateView);
+    await flushPromises();
+
+    expect(wrapper.text()).toContain('What’s new for Oats?');
+    expect(wrapper.text()).toContain('Version 0.4.1 is ready. You have 0.4.0.');
+    expect(wrapper.text()).toContain('Features');
+    expect(wrapper.text()).toContain('Release-note powered highlights');
+    expect(wrapper.text()).toContain('Smaller native update window');
+    expect(wrapper.text()).toContain('Up-to-date state with no install CTA');
+    expect(wrapper.text()).not.toContain('Faster meeting notes');
+    expect(wrapper.text()).toContain('Install Update');
+  });
+
+  it('treats a same-version update snapshot as current', async () => {
+    mocks.state = {
+      ...mocks.defaultState,
+      latest_known: {
+        version: '0.4.0',
+        mandatory: false,
+        notes: '- Should not show as pending',
+      },
+    };
+
+    const wrapper = mount(UpdateView);
+    await flushPromises();
+
+    expect(wrapper.text()).toContain('Oats is up to date');
+    expect(wrapper.text()).not.toContain('Install Update');
+    expect(wrapper.text()).not.toContain('Should not show as pending');
+  });
+});

--- a/src/views/UpdateView.test.ts
+++ b/src/views/UpdateView.test.ts
@@ -108,4 +108,27 @@ describe('UpdateView', () => {
     expect(wrapper.text()).not.toContain('Install Update');
     expect(wrapper.text()).not.toContain('Should not show as pending');
   });
+
+  it('can seed the dev download state for native visual review', async () => {
+    mocks.state = {
+      ...mocks.defaultState,
+      latest_known: {
+        version: '0.4.1',
+        mandatory: false,
+        notes: '### Features\n\n- Release-note powered highlights',
+      },
+    };
+
+    const wrapper = mount(UpdateView);
+    await flushPromises();
+
+    mocks.listeners.get('update://debug-download-progress')?.({
+      payload: { downloaded: 42, total: 100 },
+    });
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.text()).toContain('Downloading update');
+    expect(wrapper.text()).toContain('42%');
+    expect(wrapper.text()).not.toContain('Install Update');
+  });
 });

--- a/src/views/UpdateView.vue
+++ b/src/views/UpdateView.vue
@@ -1,17 +1,21 @@
 <template>
   <div class="update-window">
-    <img class="app-icon" src="../assets/oats-light.png" alt="" />
+    <header class="update-hero">
+      <img class="app-icon" src="../assets/oats-light.png" alt="Ariso" />
 
-    <h1 class="title">Update Available</h1>
-
-    <div class="subtitle">
-      <span class="version-chip">{{ info.version }}</span>
-      <span class="dot">·</span>
-      <span>You have {{ currentVersion }}</span>
-    </div>
+      <div class="hero-copy">
+        <p class="eyebrow">Ariso for Mac</p>
+        <h1 class="title">Update Available</h1>
+        <div class="subtitle">
+          <span class="version-chip">{{ info.version }}</span>
+          <span class="dot">·</span>
+          <span>You have {{ currentVersion }}</span>
+        </div>
+      </div>
+    </header>
 
     <div class="notes-card">
-      <div class="notes-title">What's New</div>
+      <div class="notes-title">What's new</div>
       <div class="notes-body" v-html="renderedNotes"></div>
     </div>
 
@@ -65,11 +69,11 @@ const progressPct = computed(() => {
   return Math.min(100, Math.floor((downloaded.value / total.value) * 100));
 });
 
-// Render Markdown-ish release notes. We deliberately do not pull in a
-// full Markdown parser — GitHub release bodies are bullet-list-heavy
-// and a tiny renderer covers 99% of cases without the dependency cost.
+// Render Markdown-ish release notes for the compact updater window. GitHub
+// release bodies are bullet-list-heavy, so this keeps the window fast and
+// predictable without bringing a full Markdown parser into the desktop shell.
 const renderedNotes = computed(() => {
-  const text = info.value.notes || '_No release notes provided._';
+  const text = info.value.notes || 'No release notes provided.';
   return text
     .split('\n')
     .map((line) => {
@@ -168,81 +172,127 @@ async function onLater() {
 
 <style scoped>
 .update-window {
-  background: white;
-  padding: 22px 22px 18px;
-  font-family: -apple-system, system-ui, sans-serif;
+  background: #f5f5f7;
+  padding: 24px 28px 20px;
+  box-sizing: border-box;
+  width: 100vw;
+  font-family: Polymath, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   min-height: 100vh;
+  max-height: 100vh;
   display: flex;
   flex-direction: column;
+  color: #1d1d1f;
+  overflow: hidden;
+}
+
+.update-hero {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 14px;
+  margin: 6px 0 18px;
 }
 
 .app-icon {
-  width: 64px;
-  height: 64px;
-  border-radius: 14px;
-  align-self: center;
-  box-shadow: 0 4px 12px rgba(99, 102, 241, 0.25);
-  margin-bottom: 12px;
+  width: 68px;
+  height: 68px;
+  object-fit: contain;
+  flex: 0 0 auto;
+}
+
+.hero-copy {
+  min-width: 0;
+}
+
+.eyebrow {
+  margin: 0 0 2px;
+  font-size: 12px;
+  font-weight: 600;
+  color: #6b7280;
 }
 
 .title {
-  font-size: 16px;
+  font-size: 24px;
+  line-height: 1.08;
   font-weight: 700;
-  color: #1d1d1f;
-  text-align: center;
-  margin: 0 0 4px 0;
+  color: #202124;
+  margin: 0 0 7px 0;
+  letter-spacing: 0;
 }
 
 .subtitle {
-  font-size: 12px;
-  color: #86868b;
-  text-align: center;
-  margin-bottom: 16px;
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  font-size: 13px;
+  color: #6f7785;
 }
 
 .version-chip {
-  background: #eef2ff;
-  color: #4f46e5;
-  padding: 1px 7px;
-  border-radius: 4px;
+  background: #ffcb14;
+  color: #111113;
+  padding: 2px 8px 3px;
+  border-radius: 999px;
   font-weight: 600;
+  line-height: 1;
 }
 
 .dot {
-  margin: 0 5px;
+  color: #9ca3af;
 }
 
 .notes-card {
-  background: #f5f5f7;
+  background: rgba(255, 255, 255, 0.82);
+  border: 1px solid #e2e5ea;
   border-radius: 8px;
-  padding: 12px 14px;
+  padding: 13px 15px;
+  width: min(100%, calc(100vw - 56px));
+  max-width: 364px;
+  box-sizing: border-box;
+  align-self: flex-start;
   flex: 1;
+  min-height: 0;
   overflow-y: auto;
-  font-size: 12px;
-  line-height: 1.6;
-  color: #1d1d1f;
-  max-height: 140px;
+  overflow-x: hidden;
+  font-size: 13px;
+  line-height: 1.48;
+  color: #2d3138;
+  box-shadow: 0 1px 2px rgba(17, 24, 39, 0.05);
+  scrollbar-width: thin;
+  scrollbar-color: #c9ced8 transparent;
 }
 
 .notes-title {
-  font-weight: 600;
-  margin-bottom: 6px;
-  font-size: 12px;
+  position: sticky;
+  top: -13px;
+  z-index: 1;
+  margin: -13px -15px 10px;
+  padding: 11px 15px 8px;
+  background: rgba(255, 255, 255, 0.96);
+  border-bottom: 1px solid #eceff3;
+  font-weight: 700;
+  font-size: 13px;
+  color: #202124;
 }
 
-.notes-body .bullet { padding-left: 4px; }
-.notes-body .h2    { font-weight: 700; margin: 6px 0 2px; }
-.notes-body .h3    { font-weight: 600; margin: 4px 0 2px; }
+.notes-body {
+  overflow-wrap: anywhere;
+}
+
+.notes-body .bullet { padding-left: 2px; }
+.notes-body .h2    { font-weight: 700; margin: 8px 0 3px; color: #202124; }
+.notes-body .h3    { font-weight: 600; margin: 6px 0 2px; color: #202124; }
 
 .error-line {
-  margin-top: 10px;
+  margin-top: 9px;
   font-size: 12px;
-  color: #dc2626;
+  color: #b42318;
   text-align: center;
+  font-weight: 500;
 }
 
 .progress-row {
-  margin-top: 16px;
+  margin-top: 14px;
   display: flex;
   align-items: center;
   gap: 10px;
@@ -250,40 +300,49 @@ async function onLater() {
 
 .progress-track {
   flex: 1;
-  height: 6px;
-  background: #e5e7eb;
-  border-radius: 3px;
+  height: 7px;
+  background: #e1e5ec;
+  border-radius: 999px;
   overflow: hidden;
 }
 
 .progress-fill {
   height: 100%;
-  background: linear-gradient(to right, #6366f1, #4f46e5);
+  background: #ffcb14;
   transition: width 0.2s;
 }
 
 .progress-label {
   font-size: 11px;
-  color: #6b7280;
+  color: #6f7785;
   width: 32px;
   text-align: right;
+  font-weight: 600;
 }
 
 .actions {
-  margin-top: 16px;
+  margin-top: 14px;
+  width: min(100%, calc(100vw - 56px));
+  max-width: 364px;
+  box-sizing: border-box;
+  align-self: flex-start;
   display: flex;
   justify-content: space-between;
   align-items: center;
+  gap: 16px;
+  flex: 0 0 auto;
 }
 
 .left-actions {
+  flex: 1 1 auto;
   display: flex;
-  gap: 14px;
+  gap: 16px;
 }
 
 .link-action {
-  font-size: 12px;
-  color: #86868b;
+  font-size: 13px;
+  font-weight: 600;
+  color: #737987;
   text-decoration: none;
   cursor: pointer;
 }
@@ -293,17 +352,22 @@ async function onLater() {
 }
 
 .install-btn {
+  flex: 0 0 auto;
+  width: 128px;
+  box-sizing: border-box;
   font-size: 13px;
-  padding: 6px 18px;
-  border-radius: 6px;
-  border: none;
-  background: linear-gradient(to bottom, #6366f1, #4f46e5);
-  color: white;
-  font-weight: 600;
+  padding: 9px 12px;
+  border-radius: 10px;
+  border: 1px solid #111113;
+  background: #111113;
+  color: #fffbeb;
+  font-weight: 700;
+  white-space: nowrap;
   cursor: pointer;
+  box-shadow: 0 1px 1px rgba(17, 24, 39, 0.16);
 }
 
 .install-btn:hover {
-  filter: brightness(1.05);
+  background: #2b2d31;
 }
 </style>

--- a/src/views/UpdateView.vue
+++ b/src/views/UpdateView.vue
@@ -1,23 +1,29 @@
 <template>
   <div class="update-window">
     <header class="update-hero">
-      <img class="app-icon" src="../assets/oats-light.png" alt="Ariso" />
+      <img class="app-icon" src="../assets/oats-light.svg" alt="Ariso" />
 
       <div class="hero-copy">
-        <p class="eyebrow">Ariso for Mac</p>
-        <h1 class="title">Update Available</h1>
-        <div class="subtitle">
-          <span class="version-chip">{{ info.version }}</span>
-          <span class="dot">·</span>
-          <span>You have {{ currentVersion }}</span>
-        </div>
+        <h1 class="title">What&rsquo;s new for Oats?</h1>
+        <p class="subtitle">
+          Version {{ displayVersion }} is ready. You have {{ currentVersion }}.
+        </p>
       </div>
     </header>
 
-    <div class="notes-card">
-      <div class="notes-title">What's new</div>
-      <div class="notes-body" v-html="renderedNotes"></div>
-    </div>
+    <main class="update-content">
+      <section class="highlights-section" aria-labelledby="update-highlights">
+        <h2 id="update-highlights" class="section-title">Highlights</h2>
+        <ul class="highlights-list">
+          <li v-for="item in highlights" :key="item">{{ item }}</li>
+        </ul>
+      </section>
+
+      <section class="benefit-section" aria-label="Update benefit">
+        <MicrophoneIcon class="mic-icon" aria-hidden="true" />
+        <p>Keeps recording and transcription improvements up to date</p>
+      </section>
+    </main>
 
     <div v-if="downloadState === 'idle' && downloadError" class="error-line">
       {{ downloadError }}
@@ -30,7 +36,7 @@
       <div class="progress-label">{{ progressPct }}%</div>
     </div>
 
-    <div v-if="downloadState === 'idle'" class="actions">
+    <footer v-if="downloadState === 'idle'" class="actions">
       <div class="left-actions">
         <a
           v-if="!info.mandatory"
@@ -46,7 +52,7 @@
         >Later</a>
       </div>
       <button class="install-btn" @click="onInstall">Install Update</button>
-    </div>
+    </footer>
   </div>
 </template>
 
@@ -54,11 +60,16 @@
 import { ref, computed, onMounted, onUnmounted } from 'vue';
 import { listen, type UnlistenFn } from '@tauri-apps/api/event';
 import { getCurrentWindow } from '@tauri-apps/api/window';
+import { MicrophoneIcon } from '@heroicons/vue/24/outline';
 import { updater, type UpdateInfo } from '../tauri';
 
 const currentVersion = __APP_VERSION__;
 
-const info = ref<UpdateInfo>({ version: '', notes: '', mandatory: false });
+const info = ref<UpdateInfo>({
+  version: '',
+  notes: '',
+  mandatory: false,
+});
 const downloadState = ref<'idle' | 'downloading'>('idle');
 const downloadError = ref('');
 const downloaded = ref(0);
@@ -69,36 +80,28 @@ const progressPct = computed(() => {
   return Math.min(100, Math.floor((downloaded.value / total.value) * 100));
 });
 
-// Render Markdown-ish release notes for the compact updater window. GitHub
-// release bodies are bullet-list-heavy, so this keeps the window fast and
-// predictable without bringing a full Markdown parser into the desktop shell.
-const renderedNotes = computed(() => {
-  const text = info.value.notes || 'No release notes provided.';
-  return text
-    .split('\n')
-    .map((line) => {
-      const trimmed = line.trim();
-      if (trimmed.startsWith('- ') || trimmed.startsWith('* ')) {
-        return `<div class="bullet">• ${escapeHtml(trimmed.slice(2))}</div>`;
-      }
-      if (trimmed.startsWith('### ')) {
-        return `<div class="h3">${escapeHtml(trimmed.slice(4))}</div>`;
-      }
-      if (trimmed.startsWith('## ')) {
-        return `<div class="h2">${escapeHtml(trimmed.slice(3))}</div>`;
-      }
-      if (trimmed === '') return '<br/>';
-      return `<div>${escapeHtml(trimmed)}</div>`;
-    })
-    .join('');
-});
+const displayVersion = computed(() => info.value.version || '0.4.0');
 
-function escapeHtml(s: string): string {
-  return s
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;');
-}
+// Pull the first few Markdown bullet lines into the large Highlights section.
+// Release bodies vary, so the fallback keeps preview and empty-note states
+// aligned with the product design instead of showing raw markdown.
+const highlights = computed(() => {
+  const items = info.value.notes
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.startsWith('- ') || line.startsWith('* '))
+    .map((line) => line.slice(2).trim())
+    .filter(Boolean)
+    .slice(0, 3);
+
+  return items.length > 0
+    ? items
+    : [
+        'Faster meeting notes',
+        'Improved local transcription',
+        'Cleaner update flow',
+      ];
+});
 
 let unlistenProgress: UnlistenFn | null = null;
 let unlistenAvailable: UnlistenFn | null = null;
@@ -112,7 +115,20 @@ onMounted(async () => {
       info.value = snap.latest_known;
     }
   } catch (e) {
-    downloadError.value = e instanceof Error ? e.message : String(e);
+    if (isBrowserPreviewError(e)) {
+      info.value = {
+        version: '0.4.0',
+        notes: [
+          '## Highlights',
+          '- Faster meeting notes',
+          '- Improved local transcription',
+          '- Cleaner update flow',
+        ].join('\n'),
+        mandatory: false,
+      };
+    } else {
+      downloadError.value = e instanceof Error ? e.message : String(e);
+    }
   }
 
   // Stay in sync if a fresh check fires while we're open.
@@ -168,123 +184,156 @@ async function onLater() {
     downloadError.value = e instanceof Error ? e.message : String(e);
   }
 }
+
+// Plain browser previews do not have Tauri IPC, but designers still need a
+// faithful visual render. Only that missing-IPC case falls back to mock content.
+function isBrowserPreviewError(error: unknown): boolean {
+  return error instanceof TypeError && error.message.includes('invoke');
+}
 </script>
 
 <style scoped>
+:global(html),
+:global(body),
+:global(#app) {
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  overflow: hidden;
+}
+
 .update-window {
-  background: #f5f5f7;
-  padding: 24px 28px 20px;
+  background: #fbfbfa;
+  padding: 0;
   box-sizing: border-box;
-  width: 100vw;
+  width: 100%;
   font-family: Polymath, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   min-height: 100vh;
   max-height: 100vh;
   display: flex;
   flex-direction: column;
-  color: #1d1d1f;
+  color: #09090b;
   overflow: hidden;
 }
 
 .update-hero {
   display: flex;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 14px;
-  margin: 6px 0 18px;
+  gap: 10px;
+  padding: 54px 48px 28px;
+  text-align: center;
+  flex: 0 0 auto;
 }
 
 .app-icon {
-  width: 68px;
-  height: 68px;
+  width: 232px;
+  height: auto;
   object-fit: contain;
   flex: 0 0 auto;
 }
 
 .hero-copy {
   min-width: 0;
-}
-
-.eyebrow {
-  margin: 0 0 2px;
-  font-size: 12px;
-  font-weight: 600;
-  color: #6b7280;
+  margin-top: -10px;
 }
 
 .title {
-  font-size: 24px;
-  line-height: 1.08;
+  font-size: 48px;
+  line-height: 1.06;
   font-weight: 700;
-  color: #202124;
-  margin: 0 0 7px 0;
+  color: #060607;
+  margin: 0 0 15px 0;
   letter-spacing: 0;
 }
 
 .subtitle {
-  display: flex;
-  align-items: center;
-  gap: 7px;
-  font-size: 13px;
-  color: #6f7785;
+  margin: 0;
+  font-size: 30px;
+  line-height: 1.28;
+  font-weight: 400;
+  color: #5b606d;
 }
 
-.version-chip {
-  background: #ffcb14;
-  color: #111113;
-  padding: 2px 8px 3px;
-  border-radius: 999px;
-  font-weight: 600;
-  line-height: 1;
+.update-content {
+  width: calc(100% - 96px);
+  max-width: 572px;
+  margin: 0 auto;
+  border-top: 1px solid #d9d9d8;
+  border-bottom: 1px solid #d9d9d8;
+  flex: 1 1 auto;
+  overflow: hidden;
 }
 
-.dot {
-  color: #9ca3af;
+.highlights-section {
+  padding: 40px 10px 22px;
 }
 
-.notes-card {
-  background: rgba(255, 255, 255, 0.82);
-  border: 1px solid #e2e5ea;
-  border-radius: 8px;
-  padding: 13px 15px;
-  width: min(100%, calc(100vw - 56px));
-  max-width: 364px;
-  box-sizing: border-box;
-  align-self: flex-start;
-  flex: 1;
-  min-height: 0;
-  overflow-y: auto;
-  overflow-x: hidden;
-  font-size: 13px;
-  line-height: 1.48;
-  color: #2d3138;
-  box-shadow: 0 1px 2px rgba(17, 24, 39, 0.05);
-  scrollbar-width: thin;
-  scrollbar-color: #c9ced8 transparent;
-}
-
-.notes-title {
-  position: sticky;
-  top: -13px;
-  z-index: 1;
-  margin: -13px -15px 10px;
-  padding: 11px 15px 8px;
-  background: rgba(255, 255, 255, 0.96);
-  border-bottom: 1px solid #eceff3;
+.section-title {
+  margin: 0 0 28px;
+  font-size: 32px;
+  line-height: 1.1;
   font-weight: 700;
-  font-size: 13px;
-  color: #202124;
+  color: #060607;
 }
 
-.notes-body {
-  overflow-wrap: anywhere;
+.highlights-list {
+  display: grid;
+  gap: 24px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  font-size: 28px;
+  line-height: 1.18;
+  color: #0a0a0c;
 }
 
-.notes-body .bullet { padding-left: 2px; }
-.notes-body .h2    { font-weight: 700; margin: 8px 0 3px; color: #202124; }
-.notes-body .h3    { font-weight: 600; margin: 6px 0 2px; color: #202124; }
+.highlights-list li {
+  display: grid;
+  grid-template-columns: 14px 1fr;
+  align-items: baseline;
+  column-gap: 30px;
+}
+
+.highlights-list li::before {
+  content: "";
+  width: 10px;
+  height: 10px;
+  border-radius: 999px;
+  background: #ffc20a;
+  transform: translateY(-3px);
+}
+
+.benefit-section {
+  display: grid;
+  grid-template-columns: 72px 1fr;
+  gap: 24px;
+  align-items: center;
+  border-top: 1px solid #d9d9d8;
+  padding: 42px 14px 28px;
+}
+
+.mic-icon {
+  width: 66px;
+  height: 66px;
+  fill: none;
+  stroke: #545966;
+  stroke-width: 3.3;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.benefit-section p {
+  margin: 0;
+  color: #535966;
+  font-size: 26px;
+  line-height: 1.28;
+  font-weight: 400;
+}
 
 .error-line {
-  margin-top: 9px;
+  margin: 12px 48px 0;
   font-size: 12px;
   color: #b42318;
   text-align: center;
@@ -321,16 +370,19 @@ async function onLater() {
 }
 
 .actions {
-  margin-top: 14px;
-  width: min(100%, calc(100vw - 56px));
-  max-width: 364px;
+  margin-top: 0;
+  width: 100%;
   box-sizing: border-box;
-  align-self: flex-start;
+  align-self: stretch;
   display: flex;
   justify-content: space-between;
   align-items: center;
-  gap: 16px;
+  gap: 24px;
   flex: 0 0 auto;
+  min-height: 110px;
+  padding: 0 40px 0 46px;
+  background: rgba(246, 246, 245, 0.92);
+  border-top: 1px solid #d9d9d8;
 }
 
 .left-actions {
@@ -340,9 +392,9 @@ async function onLater() {
 }
 
 .link-action {
-  font-size: 13px;
+  font-size: 27px;
   font-weight: 600;
-  color: #737987;
+  color: #555b68;
   text-decoration: none;
   cursor: pointer;
 }
@@ -353,21 +405,21 @@ async function onLater() {
 
 .install-btn {
   flex: 0 0 auto;
-  width: 128px;
+  min-width: 214px;
   box-sizing: border-box;
-  font-size: 13px;
-  padding: 9px 12px;
+  font-size: 25px;
+  padding: 14px 30px 15px;
   border-radius: 10px;
-  border: 1px solid #111113;
-  background: #111113;
-  color: #fffbeb;
+  border: 1px solid #f7b800;
+  background: #ffc20a;
+  color: #080809;
   font-weight: 700;
   white-space: nowrap;
   cursor: pointer;
-  box-shadow: 0 1px 1px rgba(17, 24, 39, 0.16);
+  box-shadow: 0 1px 1px rgba(120, 86, 0, 0.18);
 }
 
 .install-btn:hover {
-  background: #2b2d31;
+  background: #f5b900;
 }
 </style>

--- a/src/views/UpdateView.vue
+++ b/src/views/UpdateView.vue
@@ -243,15 +243,6 @@ function isBrowserPreviewError(error: unknown): boolean {
 </script>
 
 <style scoped>
-:global(html),
-:global(body),
-:global(#app) {
-  width: 100%;
-  height: 100%;
-  margin: 0;
-  overflow: hidden;
-}
-
 .update-window {
   /* Keep the update dialog on the same type and color tokens as Settings. */
   background: #f7f6f4;
@@ -259,6 +250,7 @@ function isBrowserPreviewError(error: unknown): boolean {
   padding: 0;
   box-sizing: border-box;
   width: 100%;
+  height: 100vh;
   font-family: 'Polymath', -apple-system, system-ui, sans-serif;
   min-height: 100vh;
   max-height: 100vh;

--- a/src/views/UpdateView.vue
+++ b/src/views/UpdateView.vue
@@ -1,25 +1,52 @@
 <template>
-  <div class="update-window">
+  <div class="update-window" :class="{ 'is-current': !hasUpdate }">
     <header class="update-hero">
       <img class="app-icon" src="../assets/oats-light.svg" alt="Ariso" />
 
       <div class="hero-copy">
-        <h1 class="title">What&rsquo;s new for Oats?</h1>
-        <p class="subtitle">
-          Version {{ displayVersion }} is ready. You have {{ currentVersion }}.
+        <h1 class="title">{{ titleText }}</h1>
+        <p v-if="hasUpdate && updateInfo" class="subtitle">
+          Version <span class="version-number">{{ updateInfo.version }}</span> is
+          ready. You have {{ currentVersion }}.
+        </p>
+        <p v-else class="subtitle">
+          Version <span class="version-number">{{ currentVersion }}</span> is
+          installed.
         </p>
       </div>
     </header>
 
-    <main class="update-content">
-      <section class="highlights-section" aria-labelledby="update-highlights">
-        <h2 id="update-highlights" class="section-title">Highlights</h2>
-        <ul class="highlights-list">
-          <li v-for="item in highlights" :key="item">{{ item }}</li>
-        </ul>
+    <main class="update-content" :class="{ 'is-current': !hasUpdate }">
+      <section
+        v-if="hasUpdate"
+        class="release-notes-section"
+        aria-label="Release notes"
+      >
+        <div
+          v-if="releaseNotesHtml"
+          class="release-notes"
+          v-html="releaseNotesHtml"
+        />
+        <p v-else class="notes-empty">
+          Release notes aren&rsquo;t available for this update.
+        </p>
       </section>
 
-      <section class="benefit-section" aria-label="Update benefit">
+      <section
+        v-else
+        class="current-section"
+        aria-labelledby="current-version"
+      >
+        <CheckCircleIcon class="status-icon" aria-hidden="true" />
+        <div>
+          <h2 id="current-version" class="current-title">
+            You&rsquo;re on the latest version
+          </h2>
+          <p>Oats {{ currentVersion }} is installed.</p>
+        </div>
+      </section>
+
+      <section v-if="hasUpdate" class="benefit-section" aria-label="Update benefit">
         <MicrophoneIcon class="mic-icon" aria-hidden="true" />
         <p>Keeps recording and transcription improvements up to date</p>
       </section>
@@ -37,21 +64,26 @@
     </div>
 
     <footer v-if="downloadState === 'idle'" class="actions">
-      <div class="left-actions">
+      <div v-if="hasUpdate" class="left-actions">
         <a
-          v-if="!info.mandatory"
+          v-if="!updateInfo?.mandatory"
           href="#"
           @click.prevent="onSkip"
           class="link-action"
         >Skip</a>
         <a
-          v-if="!info.mandatory"
+          v-if="!updateInfo?.mandatory"
           href="#"
           @click.prevent="onLater"
           class="link-action"
         >Later</a>
       </div>
-      <button class="install-btn" @click="onInstall">Install Update</button>
+      <button
+        v-if="hasUpdate"
+        class="install-btn"
+        @click="onInstall"
+      >Install Update</button>
+      <button v-else class="done-btn" @click="onDone">Done</button>
     </footer>
   </div>
 </template>
@@ -60,16 +92,13 @@
 import { ref, computed, onMounted, onUnmounted } from 'vue';
 import { listen, type UnlistenFn } from '@tauri-apps/api/event';
 import { getCurrentWindow } from '@tauri-apps/api/window';
-import { MicrophoneIcon } from '@heroicons/vue/24/outline';
+import { CheckCircleIcon, MicrophoneIcon } from '@heroicons/vue/24/outline';
 import { updater, type UpdateInfo } from '../tauri';
+import { renderMarkdown } from '../utils/markdown';
 
 const currentVersion = __APP_VERSION__;
 
-const info = ref<UpdateInfo>({
-  version: '',
-  notes: '',
-  mandatory: false,
-});
+const updateInfo = ref<UpdateInfo | null>(null);
 const downloadState = ref<'idle' | 'downloading'>('idle');
 const downloadError = ref('');
 const downloaded = ref(0);
@@ -80,31 +109,22 @@ const progressPct = computed(() => {
   return Math.min(100, Math.floor((downloaded.value / total.value) * 100));
 });
 
-const displayVersion = computed(() => info.value.version || '0.4.0');
-
-// Pull the first few Markdown bullet lines into the large Highlights section.
-// Release bodies vary, so the fallback keeps preview and empty-note states
-// aligned with the product design instead of showing raw markdown.
-const highlights = computed(() => {
-  const items = info.value.notes
-    .split('\n')
-    .map((line) => line.trim())
-    .filter((line) => line.startsWith('- ') || line.startsWith('* '))
-    .map((line) => line.slice(2).trim())
-    .filter(Boolean)
-    .slice(0, 3);
-
-  return items.length > 0
-    ? items
-    : [
-        'Faster meeting notes',
-        'Improved local transcription',
-        'Cleaner update flow',
-      ];
+const hasUpdate = computed(() => {
+  const version = updateInfo.value?.version.trim();
+  return Boolean(version && version !== currentVersion);
 });
+
+const titleText = computed(() =>
+  hasUpdate.value ? 'What’s new for Oats?' : 'Oats is up to date'
+);
+
+const releaseNotesHtml = computed(() =>
+  updateInfo.value?.notes.trim() ? renderMarkdown(updateInfo.value.notes) : ''
+);
 
 let unlistenProgress: UnlistenFn | null = null;
 let unlistenAvailable: UnlistenFn | null = null;
+let unlistenNone: UnlistenFn | null = null;
 
 onMounted(async () => {
   // Initial state (covers the case where the window is opened from
@@ -112,28 +132,21 @@ onMounted(async () => {
   try {
     const snap = await updater.getState();
     if (snap.latest_known) {
-      info.value = snap.latest_known;
+      updateInfo.value = snap.latest_known;
     }
   } catch (e) {
-    if (isBrowserPreviewError(e)) {
-      info.value = {
-        version: '0.4.0',
-        notes: [
-          '## Highlights',
-          '- Faster meeting notes',
-          '- Improved local transcription',
-          '- Cleaner update flow',
-        ].join('\n'),
-        mandatory: false,
-      };
-    } else {
+    if (!isBrowserPreviewError(e)) {
       downloadError.value = e instanceof Error ? e.message : String(e);
     }
   }
 
   // Stay in sync if a fresh check fires while we're open.
   unlistenAvailable = await listen<UpdateInfo>('update://available', (e) => {
-    info.value = e.payload;
+    updateInfo.value = e.payload;
+  });
+
+  unlistenNone = await listen('update://none', () => {
+    updateInfo.value = null;
   });
 
   unlistenProgress = await listen<{ downloaded: number; total: number | null }>(
@@ -148,6 +161,7 @@ onMounted(async () => {
 onUnmounted(() => {
   unlistenProgress?.();
   unlistenAvailable?.();
+  unlistenNone?.();
 });
 
 async function onInstall() {
@@ -167,8 +181,9 @@ async function onInstall() {
 
 async function onSkip() {
   downloadError.value = '';
+  if (!updateInfo.value?.version) return;
   try {
-    await updater.skipVersion(info.value.version);
+    await updater.skipVersion(updateInfo.value.version);
     await getCurrentWindow().close();
   } catch (e) {
     downloadError.value = e instanceof Error ? e.message : String(e);
@@ -185,8 +200,14 @@ async function onLater() {
   }
 }
 
-// Plain browser previews do not have Tauri IPC, but designers still need a
-// faithful visual render. Only that missing-IPC case falls back to mock content.
+// Closes the informational up-to-date dialog. This is separate from Skip/Later
+// because no update version exists when the user is already current.
+async function onDone() {
+  await getCurrentWindow().close();
+}
+
+// Plain browser previews do not have Tauri IPC, so missing invoke errors are
+// treated as "current" instead of filling the release rail with fake bullets.
 function isBrowserPreviewError(error: unknown): boolean {
   return error instanceof TypeError && error.message.includes('invoke');
 }
@@ -203,16 +224,17 @@ function isBrowserPreviewError(error: unknown): boolean {
 }
 
 .update-window {
-  background: #fbfbfa;
+  /* Keep the update dialog on the same type and color tokens as Settings. */
+  background: #f7f6f4;
   padding: 0;
   box-sizing: border-box;
   width: 100%;
-  font-family: Polymath, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-family: 'Polymath', -apple-system, system-ui, sans-serif;
   min-height: 100vh;
   max-height: 100vh;
   display: flex;
   flex-direction: column;
-  color: #09090b;
+  color: #1c1c1c;
   overflow: hidden;
 }
 
@@ -221,14 +243,14 @@ function isBrowserPreviewError(error: unknown): boolean {
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 10px;
-  padding: 54px 48px 28px;
+  gap: 7px;
+  padding: 46px 36px 15px;
   text-align: center;
   flex: 0 0 auto;
 }
 
 .app-icon {
-  width: 232px;
+  width: 88px;
   height: auto;
   object-fit: contain;
   flex: 0 0 auto;
@@ -240,95 +262,205 @@ function isBrowserPreviewError(error: unknown): boolean {
 }
 
 .title {
-  font-size: 48px;
-  line-height: 1.06;
+  font-size: 24px;
+  line-height: 1.12;
   font-weight: 700;
-  color: #060607;
-  margin: 0 0 15px 0;
+  color: #1c1c1c;
+  margin: 0 0 8px 0;
   letter-spacing: 0;
 }
 
 .subtitle {
   margin: 0;
-  font-size: 30px;
-  line-height: 1.28;
+  font-size: 15px;
+  line-height: 1.35;
   font-weight: 400;
-  color: #5b606d;
+  color: #6f6f6f;
+}
+
+.version-number {
+  display: inline-block;
+  margin-right: 0.16em;
+  font-variant-numeric: tabular-nums;
 }
 
 .update-content {
-  width: calc(100% - 96px);
-  max-width: 572px;
+  width: calc(100% - 72px);
+  max-width: 448px;
   margin: 0 auto;
-  border-top: 1px solid #d9d9d8;
-  border-bottom: 1px solid #d9d9d8;
+  border-top: 1px solid #d6d6d6;
   flex: 1 1 auto;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
   overflow: hidden;
 }
 
-.highlights-section {
-  padding: 40px 10px 22px;
+.release-notes-section {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  scrollbar-gutter: stable;
+  padding: 22px 12px 16px 8px;
 }
 
-.section-title {
-  margin: 0 0 28px;
-  font-size: 32px;
-  line-height: 1.1;
-  font-weight: 700;
-  color: #060607;
+.release-notes-section::-webkit-scrollbar {
+  width: 8px;
 }
 
-.highlights-list {
-  display: grid;
-  gap: 24px;
-  margin: 0;
-  padding: 0;
-  list-style: none;
-  font-size: 28px;
-  line-height: 1.18;
-  color: #0a0a0c;
+.release-notes-section::-webkit-scrollbar-track {
+  background: transparent;
 }
 
-.highlights-list li {
-  display: grid;
-  grid-template-columns: 14px 1fr;
-  align-items: baseline;
-  column-gap: 30px;
-}
-
-.highlights-list li::before {
-  content: "";
-  width: 10px;
-  height: 10px;
+.release-notes-section::-webkit-scrollbar-thumb {
+  background: #d6d6d6;
   border-radius: 999px;
-  background: #ffc20a;
-  transform: translateY(-3px);
+}
+
+.release-notes-section::-webkit-scrollbar-thumb:hover {
+  background: #c4c4bf;
+}
+
+.release-notes {
+  font-size: 15px;
+  line-height: 1.35;
+  font-weight: 400;
+  color: #1c1c1c;
+}
+
+.release-notes :deep(h1),
+.release-notes :deep(h2),
+.release-notes :deep(h3),
+.release-notes :deep(h4),
+.release-notes :deep(h5),
+.release-notes :deep(h6) {
+  margin: 0 0 14px;
+  color: #1c1c1c;
+  font-weight: 600;
+  line-height: 1.2;
+}
+
+.release-notes :deep(h1) { font-size: 18px; }
+.release-notes :deep(h2) { font-size: 17px; }
+.release-notes :deep(h3) { font-size: 16px; }
+.release-notes :deep(h4),
+.release-notes :deep(h5),
+.release-notes :deep(h6) { font-size: 15px; }
+
+.release-notes :deep(p) {
+  margin: 0 0 12px;
+  color: #6f6f6f;
+}
+
+.release-notes :deep(ul),
+.release-notes :deep(ol) {
+  margin: 0 0 12px;
+  padding-left: 22px;
+}
+
+.release-notes :deep(ul) {
+  list-style-type: disc;
+}
+
+.release-notes :deep(ol) {
+  list-style-type: decimal;
+}
+
+.release-notes :deep(li) {
+  display: list-item;
+  list-style-position: outside;
+  line-height: 1.35;
+  margin-bottom: 9px;
+}
+
+.release-notes :deep(li::marker) {
+  color: #ffc20a;
+}
+
+.release-notes :deep(a) {
+  color: inherit;
+  text-decoration: underline;
+  text-decoration-color: #c7c7c2;
+  text-underline-offset: 2px;
+}
+
+.release-notes :deep(code) {
+  background: #f0eeed;
+  border-radius: 4px;
+  padding: 1px 5px;
+  font-size: 0.9em;
+}
+
+.release-notes :deep(*:last-child) {
+  margin-bottom: 0;
+}
+
+.notes-empty {
+  margin: 0;
+  color: #6f6f6f;
+  font-size: 14px;
+  font-weight: 400;
+  line-height: 1.35;
 }
 
 .benefit-section {
   display: grid;
-  grid-template-columns: 72px 1fr;
-  gap: 24px;
+  grid-template-columns: 46px 1fr;
+  gap: 18px;
   align-items: center;
-  border-top: 1px solid #d9d9d8;
-  padding: 42px 14px 28px;
+  border-top: 1px solid #d6d6d6;
+  flex: 0 0 auto;
+  padding: 18px 10px 16px;
+}
+
+.current-section {
+  min-height: 176px;
+  display: grid;
+  grid-template-columns: 50px 1fr;
+  gap: 18px;
+  align-items: center;
+  padding: 30px 10px;
+}
+
+.current-section p {
+  margin: 0;
+  color: #6f6f6f;
+  font-size: 14px;
+  line-height: 1.35;
+  font-weight: 400;
+}
+
+.current-title {
+  margin: 0 0 8px;
+  font-size: 18px;
+  line-height: 1.2;
+  font-weight: 700;
+  color: #1c1c1c;
+}
+
+.status-icon {
+  width: 36px;
+  height: 36px;
+  color: #14a34a;
+  stroke-width: 1.9;
 }
 
 .mic-icon {
-  width: 66px;
-  height: 66px;
+  width: 36px;
+  height: 36px;
   fill: none;
-  stroke: #545966;
-  stroke-width: 3.3;
+  stroke: #6f6f6f;
+  stroke-width: 2.4;
   stroke-linecap: round;
   stroke-linejoin: round;
 }
 
 .benefit-section p {
   margin: 0;
-  color: #535966;
-  font-size: 26px;
-  line-height: 1.28;
+  color: #6f6f6f;
+  font-size: 14px;
+  line-height: 1.35;
   font-weight: 400;
 }
 
@@ -377,24 +509,24 @@ function isBrowserPreviewError(error: unknown): boolean {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  gap: 24px;
+  gap: 20px;
   flex: 0 0 auto;
-  min-height: 110px;
-  padding: 0 40px 0 46px;
-  background: rgba(246, 246, 245, 0.92);
-  border-top: 1px solid #d9d9d8;
+  min-height: 78px;
+  padding: 0 32px 0 36px;
+  background: rgba(247, 246, 244, 0.96);
+  border-top: 1px solid #d6d6d6;
 }
 
 .left-actions {
   flex: 1 1 auto;
   display: flex;
-  gap: 16px;
+  gap: 17px;
 }
 
 .link-action {
-  font-size: 27px;
-  font-weight: 600;
-  color: #555b68;
+  font-size: 14px;
+  font-weight: 500;
+  color: #6f6f6f;
   text-decoration: none;
   cursor: pointer;
 }
@@ -403,17 +535,18 @@ function isBrowserPreviewError(error: unknown): boolean {
   color: #1d1d1f;
 }
 
-.install-btn {
+.install-btn,
+.done-btn {
   flex: 0 0 auto;
-  min-width: 214px;
+  min-width: 164px;
   box-sizing: border-box;
-  font-size: 25px;
-  padding: 14px 30px 15px;
-  border-radius: 10px;
+  font-size: 14px;
+  padding: 12px 23px 13px;
+  border-radius: 9px;
   border: 1px solid #f7b800;
   background: #ffc20a;
-  color: #080809;
-  font-weight: 700;
+  color: #1c1c1c;
+  font-weight: 600;
   white-space: nowrap;
   cursor: pointer;
   box-shadow: 0 1px 1px rgba(120, 86, 0, 0.18);
@@ -421,5 +554,9 @@ function isBrowserPreviewError(error: unknown): boolean {
 
 .install-btn:hover {
   background: #f5b900;
+}
+
+.done-btn {
+  margin-left: auto;
 }
 </style>

--- a/src/views/UpdateView.vue
+++ b/src/views/UpdateView.vue
@@ -1,5 +1,9 @@
 <template>
   <div class="update-window" :class="{ 'is-current': !hasUpdate }">
+    <!-- Mirrors the native overlay titlebar as an invisible drag target so the
+         blended chrome still behaves like a normal movable macOS window. -->
+    <div class="window-drag-region" data-tauri-drag-region></div>
+
     <header class="update-hero">
       <img class="app-icon" src="../assets/oats-light.svg" alt="Ariso" />
 
@@ -57,10 +61,13 @@
     </div>
 
     <div v-if="downloadState === 'downloading'" class="progress-row">
-      <div class="progress-track">
+      <div class="progress-copy">
+        <span>Downloading update</span>
+        <span>{{ progressLabel }}</span>
+      </div>
+      <div class="progress-track" aria-hidden="true">
         <div class="progress-fill" :style="{ width: progressPct + '%' }"></div>
       </div>
-      <div class="progress-label">{{ progressPct }}%</div>
     </div>
 
     <footer v-if="downloadState === 'idle'" class="actions">
@@ -109,6 +116,12 @@ const progressPct = computed(() => {
   return Math.min(100, Math.floor((downloaded.value / total.value) * 100));
 });
 
+// Mirrors the real updater progress event while keeping unknown totals readable
+// during the short "starting download" phase.
+const progressLabel = computed(() =>
+  total.value ? `${progressPct.value}%` : 'Starting…'
+);
+
 const hasUpdate = computed(() => {
   const version = updateInfo.value?.version.trim();
   return Boolean(version && version !== currentVersion);
@@ -125,6 +138,7 @@ const releaseNotesHtml = computed(() =>
 let unlistenProgress: UnlistenFn | null = null;
 let unlistenAvailable: UnlistenFn | null = null;
 let unlistenNone: UnlistenFn | null = null;
+let unlistenDebugDownload: UnlistenFn | null = null;
 
 onMounted(async () => {
   // Initial state (covers the case where the window is opened from
@@ -156,12 +170,27 @@ onMounted(async () => {
       total.value = e.payload.total;
     }
   );
+
+  if (import.meta.env.DEV) {
+    // Dev-only visual seam for the native update dialog. It lets us seed the
+    // in-progress download state without depending on a real signed updater.
+    unlistenDebugDownload = await listen<{
+      downloaded?: number;
+      total?: number | null;
+    }>('update://debug-download-progress', (e) => {
+      downloadError.value = '';
+      downloadState.value = 'downloading';
+      downloaded.value = e.payload.downloaded ?? 0;
+      total.value = e.payload.total ?? null;
+    });
+  }
 });
 
 onUnmounted(() => {
   unlistenProgress?.();
   unlistenAvailable?.();
   unlistenNone?.();
+  unlistenDebugDownload?.();
 });
 
 async function onInstall() {
@@ -226,6 +255,7 @@ function isBrowserPreviewError(error: unknown): boolean {
 .update-window {
   /* Keep the update dialog on the same type and color tokens as Settings. */
   background: #f7f6f4;
+  position: relative;
   padding: 0;
   box-sizing: border-box;
   width: 100%;
@@ -236,6 +266,15 @@ function isBrowserPreviewError(error: unknown): boolean {
   flex-direction: column;
   color: #1c1c1c;
   overflow: hidden;
+}
+
+.window-drag-region {
+  position: absolute;
+  inset: 0 0 auto 0;
+  height: 70px;
+  z-index: 10;
+  background: transparent;
+  -webkit-app-region: drag;
 }
 
 .update-hero {
@@ -473,16 +512,36 @@ function isBrowserPreviewError(error: unknown): boolean {
 }
 
 .progress-row {
-  margin-top: 14px;
+  width: 100%;
+  box-sizing: border-box;
+  flex: 0 0 auto;
+  min-height: 78px;
+  padding: 16px 36px 17px;
+  background: rgba(247, 246, 244, 0.96);
+  border-top: 1px solid #d6d6d6;
   display: flex;
+  flex-direction: column;
+  justify-content: center;
   align-items: center;
-  gap: 10px;
+  gap: 9px;
+}
+
+.progress-copy {
+  width: 100%;
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 16px;
+  font-size: 14px;
+  line-height: 1.2;
+  font-weight: 600;
+  color: #1c1c1c;
 }
 
 .progress-track {
-  flex: 1;
-  height: 7px;
-  background: #e1e5ec;
+  width: 100%;
+  height: 8px;
+  background: #e4e0da;
   border-radius: 999px;
   overflow: hidden;
 }
@@ -491,14 +550,6 @@ function isBrowserPreviewError(error: unknown): boolean {
   height: 100%;
   background: #ffcb14;
   transition: width 0.2s;
-}
-
-.progress-label {
-  font-size: 11px;
-  color: #6f7785;
-  width: 32px;
-  text-align: right;
-  font-weight: 600;
 }
 
 .actions {


### PR DESCRIPTION

<img width="610" height="828" alt="Screenshot 2026-06-16 at 10 58 52 AM" src="https://github.com/user-attachments/assets/beab3d2f-1c3e-43b8-b1f9-cfa3c3171439" />

<img width="615" height="822" alt="Screenshot 2026-06-16 at 10 59 11 AM" src="https://github.com/user-attachments/assets/ba30adb0-3d4a-4641-8583-ba128066b1c4" />

<img width="586" height="737" alt="Screenshot 2026-06-15 at 1 42 32 PM" src="https://github.com/user-attachments/assets/2d87a0f9-63f4-4e7f-a410-9b638b418004" />

## Summary

- Redesign the native update window to match the Oats branded update treatment: logo-first header, Polymath typography, light titlebar/background, pinned benefit row, and footer actions.
- Render release notes directly from updater markdown between the separators instead of hard-coded highlights.
- Add explicit states for update available, already up to date, and downloading/installing progress.
- Keep the overlay titlebar visually blended while adding a transparent Tauri drag region so the update window can still be moved.
- Open the update window after a forced manual check even when the app is already current, so Settings can show the up-to-date state.

## Verification

- `npm test -- src/views/UpdateView.test.ts`
- `npm run vite:build`
- `cargo check --manifest-path src-tauri/Cargo.toml`
- Live native smoke with `target/debug/oats`: seeded long markdown release notes, confirmed the release-notes section scrolls independently, seeded download progress at 67%, and confirmed the update webview exposes `data-tauri-drag-region` at the top of the window.

## Review Notes

CodeRabbit: please focus on the update state transitions, the markdown rendering surface, and whether the dev-only seeded download event is scoped tightly enough behind `import.meta.env.DEV`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Redesigned update experience with clearer up-to-date vs update-available states
  * Release notes rendered from Markdown, plus improved progress messaging (“Starting…”, real-time download percentage)
* **Bug Fixes**
  * Update window now opens for forced checks and correctly handles “no update available”
  * Updated update window appearance (title bar style) and size
* **Tests**
  * Added automated coverage for up-to-date, available/current version states, and download-progress UI
* **Chores**
  * Added the `@heroicons/vue` dependency for updated UI icon support
<!-- end of auto-generated comment: release notes by coderabbit.ai -->