### PR TITLE
feat: AI Assessment tab + transcript audio player

### DIFF
--- a/src/views/MeetingDetailView.test.ts
+++ b/src/views/MeetingDetailView.test.ts
@@ -410,19 +410,35 @@ describe('MeetingDetailView audio player', () => {
     vi.spyOn(HTMLMediaElement.prototype, 'play').mockResolvedValue(undefined);
   });
 
-  it('shows the audio player for an Ariso meeting', async () => {
-    const wrapper = await mountWith(detail());
+  it('shows the audio player in the Transcript tab for an Ariso meeting', async () => {
+    // Transcript is the only content, so it is the active tab on mount.
+    const wrapper = await mountWith(detail({ hasTranscript: true }));
     expect(wrapper.find('.card-audio .play-btn').exists()).toBe(true);
   });
 
-  it('does not show the audio player for a local recording', async () => {
-    const wrapper = await mountWith(detail({ isLocal: true, note: 'hi' }));
+  it('renders the audio player only once the Transcript tab is opened', async () => {
+    // Digest makes AI Notes the default tab; the player lives behind Transcript.
+    const wrapper = await mountWith(detail({ digest: 'A quick digest', hasTranscript: true }));
+    expect(wrapper.find('.card-audio').exists()).toBe(false);
+
+    const transcriptTab = wrapper.findAll('.seg-btn').find((b) => b.text() === 'Transcript');
+    await transcriptTab!.trigger('click');
+    await flushPromises();
+
+    expect(wrapper.find('.card-audio .play-btn').exists()).toBe(true);
+  });
+
+  it('does not show the audio player for a local recording, even in the Transcript tab', async () => {
+    const wrapper = await mountWith(detail({ isLocal: true, note: 'hi', hasTranscript: true }));
+    const transcriptTab = wrapper.findAll('.seg-btn').find((b) => b.text() === 'Transcript');
+    await transcriptTab!.trigger('click');
+    await flushPromises();
     expect(wrapper.find('.card-audio').exists()).toBe(false);
   });
 
   it('clicking Play fetches audio through the backend that loaded the detail', async () => {
     getMeetingAudio.mockResolvedValue(new ArrayBuffer(4));
-    const wrapper = await mountWith(detail());
+    const wrapper = await mountWith(detail({ hasTranscript: true }));
     await wrapper.find('.card-audio .play-btn').trigger('click');
     await flushPromises();
     expect(getMeetingAudio).toHaveBeenCalledWith(item);
@@ -431,9 +447,60 @@ describe('MeetingDetailView audio player', () => {
 
   it('shows No audio when the meeting has no recording', async () => {
     getMeetingAudio.mockResolvedValue(null);
-    const wrapper = await mountWith(detail());
+    const wrapper = await mountWith(detail({ hasTranscript: true }));
     await wrapper.find('.card-audio .play-btn').trigger('click');
     await flushPromises();
     expect(wrapper.find('.card-audio .play-btn').text()).toContain('No audio');
+  });
+});
+
+describe('MeetingDetailView AI Assessment tab', () => {
+  const tabByLabel = (wrapper: ReturnType<typeof mount>, label: string) =>
+    wrapper.findAll('.seg-btn').find((b) => b.text() === label);
+
+  it('shows an "AI Assessment" tab last when the meeting has a score', async () => {
+    const wrapper = await mountWith(
+      detail({ digest: 'A quick digest', score: 5, rationale: 'Great focus', recommendation: 'Keep it up' })
+    );
+
+    const labels = wrapper.findAll('.seg-btn').map((b) => b.text());
+    expect(labels).toContain('AI Assessment');
+    expect(labels[labels.length - 1]).toBe('AI Assessment');
+  });
+
+  it('renders the assessment in its own tab, not in AI Notes', async () => {
+    const wrapper = await mountWith(
+      detail({ digest: 'A quick digest', score: 4, rationale: 'Solid', recommendation: 'Tighten the agenda' })
+    );
+
+    // Defaults to AI Notes (digest present); the assessment lives behind its own tab.
+    expect(tabByLabel(wrapper, 'AI Notes')!.classes()).toContain('seg-btn--active');
+    expect(tabByLabel(wrapper, 'AI Assessment')!.classes()).not.toContain('seg-btn--active');
+
+    await tabByLabel(wrapper, 'AI Assessment')!.trigger('click');
+    await flushPromises();
+
+    const circle = wrapper.find('.score-circle');
+    expect(circle.isVisible()).toBe(true);
+    expect(circle.text()).toBe('4');
+    expect(wrapper.text()).toContain('Tighten the agenda');
+  });
+
+  it('shows the tab for a coaching-only assessment (no score)', async () => {
+    const wrapper = await mountWith(
+      detail({ digest: 'A quick digest', coaching: { strengths: ['Clear ask'] } })
+    );
+    expect(tabByLabel(wrapper, 'AI Assessment')).toBeTruthy();
+  });
+
+  it('hides the tab when the meeting has no score or coaching', async () => {
+    const wrapper = await mountWith(detail({ digest: 'A quick digest' }));
+    expect(tabByLabel(wrapper, 'AI Assessment')).toBeUndefined();
+  });
+
+  it('opens the assessment tab by default when it is the only content', async () => {
+    const wrapper = await mountWith(detail({ score: 3, rationale: 'Mixed' }));
+    expect(wrapper.find('.score-circle').isVisible()).toBe(true);
+    expect(wrapper.find('.score-circle').text()).toBe('3');
   });
 });

--- a/src/views/MeetingDetailView.vue
+++ b/src/views/MeetingDetailView.vue
@@ -89,14 +89,6 @@
 
       <div v-else class="divider" />
 
-      <!-- Ariso audio playback. Local recordings keep audio on disk and are
-           not surfaced here (out of scope); keyed by meeting id so switching
-           selection remounts the player instead of leaking the previous
-           meeting's blob URL. -->
-      <div v-if="!detail.isLocal" class="card-audio">
-        <RecordingAudioPlayer :key="detail.id" :load="loadAudio" />
-      </div>
-
       <!-- Tabs + Chat -->
       <div v-if="availableTabs.length" class="card-tabs">
         <div class="segment">
@@ -153,41 +145,51 @@
                 <div v-if="showFullNotes" class="acc-body"><div class="md" v-html="renderMarkdown(detail.summary)" /></div>
               </div>
             </section>
-
-            <section v-if="detail.score !== undefined" class="sec">
-              <h3 class="sec-h">Meeting Assessment</h3>
-              <div class="assess-score">
-                <div class="score-circle" :style="{ background: scoreBadge?.bg, color: scoreBadge?.text, boxShadow: `0 0 0 4px ${scoreBadge?.ring}` }">{{ detail.score }}</div>
-                <div>
-                  <div class="score-label">{{ scoreBadge?.label }}</div>
-                  <div class="score-sub">out of 5</div>
-                </div>
-              </div>
-              <div v-if="detail.rationale" class="assess-block"><div class="assess-h">Why this score</div><p>{{ detail.rationale }}</p></div>
-              <div v-if="detail.recommendation" class="assess-block"><div class="assess-h">Recommendation</div><p>{{ detail.recommendation }}</p></div>
-            </section>
-
-            <section v-if="hasCoaching" class="sec">
-              <div class="coaching">
-                <h3 class="sec-h">Your Coaching</h3>
-                <div v-if="detail.coaching?.strengths?.length" class="coach-block">
-                  <div class="coach-h coach-h--green">Strengths</div>
-                  <ul class="coach-list"><li v-for="(s, i) in detail.coaching!.strengths" :key="i"><span class="bullet bullet--green">•</span>{{ s }}</li></ul>
-                </div>
-                <div v-if="detail.coaching?.improvements?.length" class="coach-block">
-                  <div class="coach-h coach-h--amber">Areas to Grow</div>
-                  <ul class="coach-list"><li v-for="(s, i) in detail.coaching!.improvements" :key="i"><span class="bullet bullet--amber">•</span>{{ s }}</li></ul>
-                </div>
-                <div v-if="detail.coaching?.patterns" class="coach-block coach-pattern">
-                  <div class="coach-h coach-h--purple">Pattern Observed</div>
-                  <p>{{ detail.coaching!.patterns }}</p>
-                </div>
-              </div>
-            </section>
           </template>
         </div>
 
+        <div v-show="activeTab === 'assessment'" class="tab-pane">
+          <section v-if="detail.score !== undefined" class="sec">
+            <h3 class="sec-h">Meeting Assessment</h3>
+            <div class="assess-score">
+              <div class="score-circle" :style="{ background: scoreBadge?.bg, color: scoreBadge?.text, boxShadow: `0 0 0 4px ${scoreBadge?.ring}` }">{{ detail.score }}</div>
+              <div>
+                <div class="score-label">{{ scoreBadge?.label }}</div>
+                <div class="score-sub">out of 5</div>
+              </div>
+            </div>
+            <div v-if="detail.rationale" class="assess-block"><div class="assess-h">Why this score</div><p>{{ detail.rationale }}</p></div>
+            <div v-if="detail.recommendation" class="assess-block"><div class="assess-h">Recommendation</div><p>{{ detail.recommendation }}</p></div>
+          </section>
+
+          <section v-if="hasCoaching" class="sec">
+            <div class="coaching">
+              <h3 class="sec-h">Your Coaching</h3>
+              <div v-if="detail.coaching?.strengths?.length" class="coach-block">
+                <div class="coach-h coach-h--green">Strengths</div>
+                <ul class="coach-list"><li v-for="(s, i) in detail.coaching!.strengths" :key="i"><span class="bullet bullet--green">•</span>{{ s }}</li></ul>
+              </div>
+              <div v-if="detail.coaching?.improvements?.length" class="coach-block">
+                <div class="coach-h coach-h--amber">Areas to Grow</div>
+                <ul class="coach-list"><li v-for="(s, i) in detail.coaching!.improvements" :key="i"><span class="bullet bullet--amber">•</span>{{ s }}</li></ul>
+              </div>
+              <div v-if="detail.coaching?.patterns" class="coach-block coach-pattern">
+                <div class="coach-h coach-h--purple">Pattern Observed</div>
+                <p>{{ detail.coaching!.patterns }}</p>
+              </div>
+            </div>
+          </section>
+        </div>
+
         <div v-show="activeTab === 'transcript'" class="tab-pane">
+          <!-- Ariso audio playback sits right under the tabs, surfaced only while the
+               Transcript tab is active (and never for local recordings, whose audio
+               stays on disk); keyed by meeting id so switching selection remounts the
+               player instead of leaking the previous blob URL. -->
+          <div v-if="activeTab === 'transcript' && !detail.isLocal" class="card-audio">
+            <RecordingAudioPlayer :key="detail.id" :load="loadAudio" />
+          </div>
+
           <div v-if="loadingTranscript" class="card-state"><span class="spinner" /><span>Loading transcript…</span></div>
           <div v-else-if="transcriptMarkdown" class="md" v-html="renderMarkdown(transcriptMarkdown)" />
           <ol v-else-if="transcriptChunks" class="transcript">
@@ -246,7 +248,7 @@ const loading = ref(false);
 const error = ref<string | null>(null);
 const detail = ref<MeetingDetail | null>(null);
 const showFullNotes = ref(false);
-const activeTab = ref<'note' | 'transcript' | 'mynote'>('note');
+const activeTab = ref<'note' | 'transcript' | 'mynote' | 'assessment'>('note');
 
 // Inline title editing. Both backends rename through Backend.renameMeeting
 // (ariso PATCHes the server; local rewrites meta.json). Local titles are
@@ -505,30 +507,38 @@ function coachingPresent(c?: MeetingCoaching | null): boolean {
   return !!(c && (c.strengths?.length || c.improvements?.length || c.patterns));
 }
 function notesPresent(d: MeetingDetail): boolean {
+  // The assessment (score/coaching) lives in its own "AI Assessment" tab, so it
+  // no longer counts toward the AI Notes tab's content.
   return d.isLocal
     ? !!d.note
-    : !!(d.digest || d.summary || d.actionItems.length || d.score !== undefined || coachingPresent(d.coaching));
+    : !!(d.digest || d.summary || d.actionItems.length);
+}
+function assessmentPresent(d: MeetingDetail): boolean {
+  return !d.isLocal && (d.score !== undefined || coachingPresent(d.coaching));
 }
 // The initial tab follows available content, but editable personal notes count
 // as available even before the first note has been saved.
-function firstTabFor(d: MeetingDetail, item: MeetingListItem): 'note' | 'transcript' | 'mynote' {
+function firstTabFor(d: MeetingDetail, item: MeetingListItem): 'note' | 'transcript' | 'mynote' | 'assessment' {
   if (notesPresent(d)) return 'note';
   if (d.hasTranscript) return 'transcript';
   if (d.hasIndividualNote || notesPersistence.canEdit(item)) return 'mynote';
+  if (assessmentPresent(d)) return 'assessment';
   return 'note';
 }
 
 // Tabs appear only when their content exists: AI Notes (generated/shared
-// meeting notes), Transcript, then My Notes (the user's editable note).
-const availableTabs = computed<{ key: 'note' | 'transcript' | 'mynote'; label: string }[]>(() => {
+// meeting notes), Transcript, My Notes (the user's editable note), then
+// AI Assessment (score, rationale, coaching) when the meeting has one.
+const availableTabs = computed<{ key: 'note' | 'transcript' | 'mynote' | 'assessment'; label: string }[]>(() => {
   const d = detail.value;
   if (!d) return [];
-  const out: { key: 'note' | 'transcript' | 'mynote'; label: string }[] = [];
+  const out: { key: 'note' | 'transcript' | 'mynote' | 'assessment'; label: string }[] = [];
   if (notesPresent(d)) out.push({ key: 'note', label: "AI Notes" });
   if (d.hasTranscript) out.push({ key: 'transcript', label: 'Transcript' });
   if ((props.item && notesPersistence.canEdit(props.item)) || d.hasIndividualNote) {
     out.push({ key: 'mynote', label: 'My Notes' });
   }
+  if (assessmentPresent(d)) out.push({ key: 'assessment', label: 'AI Assessment' });
   return out;
 });
 
@@ -793,7 +803,7 @@ const durationLabel = computed<string | null>(() => {
 
 /* Meta band — full-bleed strip below the header (Figma 2827:34384) */
 .card-meta { display: flex; flex-wrap: wrap; align-items: center; gap: 16px; padding: 11px 24px; background: #f7f6f4; border-bottom: 1px solid #e5e6e3; font-size: 14px; }
-.card-audio { display: flex; padding: 12px 24px 0; }
+.card-audio { display: flex; padding: 0 0 12px; }
 .meta-item { display: flex; align-items: center; gap: 4px; color: #6f6f6f; }
 .meta-item .ic { width: 15px; height: 15px; }
 .dur { color: #1c1c1c; font-size: 14px; }


### PR DESCRIPTION
## What

- **AI Assessment tab**: meeting assessment (score, rationale, recommendation, coaching) moves out of the AI Notes tab into its own **AI Assessment** tab, shown last when a backend meeting has a score or coaching.
- **Audio player**: relocated into the Transcript pane, mounting only while that tab is active, left-aligned under the tabs.

## Tests

`npm test` → 257 passed (added coverage for the assessment tab and the audio player's new location). `npm run vite:build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dedicated "AI Assessment" tab in Meeting Detail view to organize assessment content separately, displaying scores, recommendations, and coaching feedback.
  * Repositioned audio player for Ariso recordings to be accessible through the Transcript tab.

* **Tests**
  * Updated meeting detail view tests to reflect new audio player behavior and verify AI Assessment tab functionality across different scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->