### PR TITLE
Group Meetings list by date, drop Upcoming section

### DIFF
--- a/src/composables/groupMeetingsByDate.test.ts
+++ b/src/composables/groupMeetingsByDate.test.ts
@@ -29,7 +29,7 @@ describe('dateLabel', () => {
 });
 
 describe('groupMeetingsByDate', () => {
-  it('buckets history by calendar date newest-first, with UPCOMING last', () => {
+  it('buckets every meeting by calendar date, newest date first, earliest-first within a date', () => {
     const meetings = [
       m('past1', '2026-06-09T09:00:00'),
       m('today1', '2026-06-10T09:00:00'),
@@ -38,28 +38,31 @@ describe('groupMeetingsByDate', () => {
       m('future', '2026-06-12T10:00:00'),
     ];
     const sections = groupMeetingsByDate(meetings, NOW);
-    expect(sections.map((s) => s.label)).toEqual(['TODAY', 'YESTERDAY', 'UPCOMING']);
-    expect(sections[0].items.map((x) => x.id)).toEqual(['today2', 'today1']);
-    expect(sections[2].items.map((x) => x.id)).toEqual(['soon', 'future']);
+    // No UPCOMING section: future meetings live under their own date header.
+    expect(sections.map((s) => s.label)).toEqual(['FRI, JUN 12', 'TODAY', 'YESTERDAY']);
+    // Within a date, earliest-first (ascending).
+    expect(sections[1].items.map((x) => x.id)).toEqual(['today1', 'today2', 'soon']);
+    expect(sections[0].items.map((x) => x.id)).toEqual(['future']);
   });
 
   it('returns an empty array for no meetings', () => {
     expect(groupMeetingsByDate([], NOW)).toEqual([]);
   });
 
-  it('keeps NaN-timestamp meetings under an UNDATED bucket at the end of history', () => {
+  it('keeps NaN-timestamp meetings under an UNDATED bucket at the end', () => {
     const sections = groupMeetingsByDate([m('bad', 'not-a-date'), m('t', '2026-06-10T09:00:00')], NOW);
     const labels = sections.map((s) => s.label);
     expect(labels).toContain('UNDATED');
     expect(labels.indexOf('UNDATED')).toBeGreaterThan(labels.indexOf('TODAY'));
   });
 
-  it('treats an in-progress meeting (not yet ended) as UPCOMING, not history', () => {
+  it('places an in-progress meeting under its date bucket in start order', () => {
     const sections = groupMeetingsByDate(
       [m('live', '2026-06-10T14:30:00', '2026-06-10T15:30:00'), m('past', '2026-06-10T09:00:00')],
       NOW
     );
-    expect(sections.find((s) => s.label === 'UPCOMING')?.items.map((x) => x.id)).toEqual(['live']);
+    expect(sections.map((s) => s.label)).toEqual(['TODAY']);
+    expect(sections[0].items.map((x) => x.id)).toEqual(['past', 'live']);
   });
 });
 

--- a/src/composables/groupMeetingsByDate.ts
+++ b/src/composables/groupMeetingsByDate.ts
@@ -62,20 +62,11 @@ export function dateLabel(key: string, now: Date): string {
     .toUpperCase();
 }
 
-/** Bucket meetings under per-calendar-date headers (newest date first) with a
- *  single trailing UPCOMING section for everything starting after `now`. */
+/** Bucket every meeting under per-calendar-date headers, newest date first, and
+ *  within each date ordered earliest-first (ascending by start time). */
 export function groupMeetingsByDate(meetings: MeetingListItem[], now: Date): MeetingSection[] {
-  const nowMs = now.getTime();
-  const history: MeetingListItem[] = [];
-  const upcoming: MeetingListItem[] = [];
-  for (const meeting of meetings) {
-    // "Upcoming" = not yet over: future meetings and ones in progress right now.
-    if (meetingEndMs(meeting) > nowMs) upcoming.push(meeting);
-    else history.push(meeting);
-  }
-
   const buckets = new Map<string, MeetingListItem[]>();
-  for (const meeting of history) {
+  for (const meeting of meetings) {
     const d = new Date(meeting.timestamp);
     const key = Number.isNaN(d.getTime()) ? 'unknown' : localDateKey(d);
     const bucket = buckets.get(key);
@@ -89,16 +80,12 @@ export function groupMeetingsByDate(meetings: MeetingListItem[], now: Date): Mee
   const datedKeys = [...buckets.keys()].filter((k) => k !== 'unknown').sort().reverse();
   for (const key of datedKeys) {
     const items = [...buckets.get(key)!].sort(
-      (a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime()
+      (a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime()
     );
     sections.push({ key, label: dateLabel(key, now), items });
   }
   if (buckets.has('unknown')) {
     sections.push({ key: 'unknown', label: 'UNDATED', items: buckets.get('unknown')! });
-  }
-  if (upcoming.length) {
-    upcoming.sort((a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime());
-    sections.push({ key: 'upcoming', label: 'UPCOMING', items: upcoming });
   }
   return sections;
 }

--- a/src/views/LibraryView.test.ts
+++ b/src/views/LibraryView.test.ts
@@ -459,10 +459,11 @@ describe('LibraryView', () => {
 
     const rows = wrapper.findAll('.meeting-item');
     expect(rows).toHaveLength(2);
-    // Synthetic row (14:30) sorts above Standup (10:00) on the same date.
-    expect(rows[0].text()).toContain('Recording 2026-06-02');
-    expect(rows[0].find('.mi-rec-dot').exists()).toBe(true);
-    expect(rows[0].attributes('aria-pressed')).toBe('true');
+    // Within a date, rows sort earliest-first: Standup (10:00) then the
+    // synthetic recording row (14:30).
+    expect(rows[1].text()).toContain('Recording 2026-06-02');
+    expect(rows[1].find('.mi-rec-dot').exists()).toBe(true);
+    expect(rows[1].attributes('aria-pressed')).toBe('true');
     // The embedded strip shows for the recorded meeting…
     expect(wrapper.find('.strip').exists()).toBe(true);
   });
@@ -475,13 +476,15 @@ describe('LibraryView', () => {
     await flushPromises();
     expect(wrapper.find('.strip').exists()).toBe(true);
 
+    // rows[0] is Standup (10:00); rows[1] is the recording (14:30). Click the
+    // other meeting (Standup) to move selection off the recording.
     const rows = wrapper.findAll('.meeting-item');
-    await rows[1].trigger('click');
+    await rows[0].trigger('click');
     await flushPromises();
 
-    expect(rows[1].attributes('aria-pressed')).toBe('true');
+    expect(rows[0].attributes('aria-pressed')).toBe('true');
     expect(wrapper.find('.strip').exists()).toBe(false);
-    expect(rows[0].find('.mi-rec-dot').exists()).toBe(true);
+    expect(rows[1].find('.mi-rec-dot').exists()).toBe(true);
   });
 
   it('reloads when the recording closes so the finalized row replaces the synthetic one', async () => {
@@ -508,9 +511,10 @@ describe('LibraryView', () => {
     expect(listMeetings).toHaveBeenCalledTimes(2);
     const rows = wrapper.findAll('.meeting-item');
     expect(rows).toHaveLength(2);
-    // The finalized recording keeps the selection under the same id.
-    expect(rows[0].attributes('aria-pressed')).toBe('true');
-    expect(rows[0].find('.mi-rec-dot').exists()).toBe(false);
+    // Earliest-first within the date keeps Standup (10:00) at rows[0] and the
+    // finalized recording (14:30) at rows[1]; selection stays on the same id.
+    expect(rows[1].attributes('aria-pressed')).toBe('true');
+    expect(rows[1].find('.mi-rec-dot').exists()).toBe(false);
   });
 
   it('falls back to the first meeting when a discarded recording leaves no row', async () => {
@@ -519,7 +523,9 @@ describe('LibraryView', () => {
     await flushPromises();
     emitEvent('recorder://state', localRecorderState());
     await flushPromises();
-    expect(wrapper.findAll('.meeting-item')[0].attributes('aria-pressed')).toBe('true');
+    // The synthetic recording row (14:30) sorts after Standup (10:00) and holds
+    // the selection at rows[1].
+    expect(wrapper.findAll('.meeting-item')[1].attributes('aria-pressed')).toBe('true');
 
     emitEvent('recorder://state', localRecorderState({ phase: 'closed' }));
     await flushPromises();

--- a/src/views/LibraryView.vue
+++ b/src/views/LibraryView.vue
@@ -193,7 +193,9 @@ const displayedSections = computed<MeetingSection[]>(() => {
 });
 
 // Only the next upcoming meeting (soonest, or the one in progress) carries a
-// relative-time chip; it's the first item of the trailing UPCOMING section.
+// relative-time chip; it's the first item of the Today view's UPCOMING section.
+// The Meetings view groups purely by date and has no UPCOMING section, so no
+// chip shows there.
 const nextUpcomingId = computed<string | null>(() => {
   const up = displayedSections.value.find((s) => s.key === 'upcoming');
   return up?.items[0]?.id ?? null;


### PR DESCRIPTION
## What

Adjusts the Meetings list (under the **Meetings** nav button):

1. Removes the **Upcoming** section.
2. Groups meetings by calendar date, newest date first.
3. Orders meetings earliest-first within each date.

Future and in-progress meetings now sit under their own date headers. The separate **Today** view is unchanged.

## Tests

Updated `groupMeetingsByDate` and `LibraryView` specs for the new ordering. `npx vitest run` → 251 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)