### PR TITLE
fix: capture mic raw so recording doesn't lower the user's voice on calls

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "vite:dev": "vite dev --port 1420",
     "vite:build": "vite build",
     "tauri:dev": "tauri dev",
-    "tauri:dev:debug": "VITE_DEBUG_AUDIO=true tauri dev --features mcp",
+    "tauri:dev:debug": "tauri dev --features mcp",
     "tauri:build": "tauri build",
     "dmg:compose": "bash scripts/compose-dmg.sh",
     "tauri:clean": "cd src-tauri && cargo clean",

--- a/src/composables/useRecorder.ts
+++ b/src/composables/useRecorder.ts
@@ -109,18 +109,24 @@ export function useRecorder() {
     }
 
     try {
-      const debug =
-        import.meta.env.DEV && import.meta.env.VITE_DEBUG_AUDIO === 'true';
-
       audioContext = new AudioContext({ sampleRate: 44100 });
       analyserNode = audioContext.createAnalyser();
 
       if (useMic) {
+        // Capture the mic raw — no echo cancellation, noise suppression, or
+        // auto gain control. Enabling any of these routes the mic through
+        // macOS Voice-Processing I/O, whose AGC drives the *shared* physical
+        // input device gain down. A video-conference app reading the same
+        // microphone then captures a quieter signal, so the remote end hears
+        // the user's voice drop while Oats records. We capture system audio on
+        // a separate channel anyway, so we don't need echo cancellation to keep
+        // the other participants out of the mic channel.
         micStream = await navigator.mediaDevices.getUserMedia({
           audio: {
             channelCount: 1,
-            echoCancellation: !debug,
-            noiseSuppression: !debug,
+            echoCancellation: false,
+            noiseSuppression: false,
+            autoGainControl: false,
             sampleRate: 44100,
           },
         });


### PR DESCRIPTION
Enabling `echoCancellation`/`noiseSuppression`/`autoGainControl` in `getUserMedia` routes the mic through macOS Voice-Processing I/O, whose AGC lowers the **shared** physical mic gain. A conference app reading the same device then captures a quieter signal — so the remote end hears the user's voice drop while Oats records.

Capture the mic raw instead. System audio is still captured cleanly on a separate channel.

**Verify:** join a video call, start an Oats recording, confirm the remote end no longer hears your voice drop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)