### PR TITLE
fix: show today's upcoming meetings and the next day in Up Next card

### DIFF
--- a/src/composables/groupMeetingsByDate.test.ts
+++ b/src/composables/groupMeetingsByDate.test.ts
@@ -3,6 +3,9 @@ import {
   groupMeetingsByDate,
   groupTodaysMeetings,
   dateLabel,
+  dayLabelWithDate,
+  todayLabel,
+  nextDaySection,
   upcomingRelLabel,
   isMeetingInProgress,
 } from './groupMeetingsByDate';
@@ -25,6 +28,57 @@ describe('dateLabel', () => {
   it('uses an uppercased weekday/month/day for other dates', () => {
     // 2026-06-07 is a Sunday.
     expect(dateLabel('2026-06-07', NOW)).toBe('SUN, JUN 7');
+  });
+});
+
+describe('dayLabelWithDate', () => {
+  it('appends the calendar date to the relative day labels', () => {
+    expect(dayLabelWithDate('2026-06-10', NOW)).toBe('TODAY · JUN 10');
+    expect(dayLabelWithDate('2026-06-11', NOW)).toBe('TOMORROW · JUN 11');
+    expect(dayLabelWithDate('2026-06-09', NOW)).toBe('YESTERDAY · JUN 9');
+  });
+
+  it('leaves other days as-is since they already carry the date', () => {
+    expect(dayLabelWithDate('2026-06-07', NOW)).toBe('SUN, JUN 7');
+  });
+
+  it('todayLabel labels the current day with its date', () => {
+    expect(todayLabel(NOW)).toBe('TODAY · JUN 10');
+  });
+});
+
+describe('nextDaySection', () => {
+  it('returns the earliest future day that has meetings, earliest-first', () => {
+    const meetings = [
+      m('today', '2026-06-10T18:00:00'),
+      m('tom-late', '2026-06-11T16:00:00'),
+      m('tom-early', '2026-06-11T09:00:00'),
+      m('far', '2026-06-13T10:00:00'),
+    ];
+    const section = nextDaySection(meetings, NOW);
+    expect(section?.key).toBe('2026-06-11');
+    expect(section?.label).toBe('TOMORROW · JUN 11');
+    expect(section?.items.map((x) => x.id)).toEqual(['tom-early', 'tom-late']);
+  });
+
+  it('skips empty days and lands on the next day that has meetings', () => {
+    // Nothing tomorrow (the 11th); the next meetings are on the 13th.
+    const section = nextDaySection([m('far', '2026-06-13T10:00:00')], NOW);
+    expect(section?.key).toBe('2026-06-13');
+    expect(section?.label).toBe('SAT, JUN 13');
+  });
+
+  it('ignores today and past meetings', () => {
+    const meetings = [
+      m('today', '2026-06-10T18:00:00'),
+      m('past', '2026-06-09T09:00:00'),
+    ];
+    expect(nextDaySection(meetings, NOW)).toBeNull();
+  });
+
+  it('returns null when there are no future meetings', () => {
+    expect(nextDaySection([], NOW)).toBeNull();
+    expect(nextDaySection([m('bad', 'nope')], NOW)).toBeNull();
   });
 });
 

--- a/src/composables/groupMeetingsByDate.ts
+++ b/src/composables/groupMeetingsByDate.ts
@@ -62,6 +62,48 @@ export function dateLabel(key: string, now: Date): string {
     .toUpperCase();
 }
 
+/** Like dateLabel but always carries the calendar date, so the relative days
+ *  read "TODAY · JUN 16" / "TOMORROW · JUN 17"; other days already include it. */
+export function dayLabelWithDate(key: string, now: Date): string {
+  const rel = dateLabel(key, now);
+  if (rel === 'TODAY' || rel === 'TOMORROW' || rel === 'YESTERDAY') {
+    const [y, mo, d] = key.split('-').map(Number);
+    const md = new Date(y, mo - 1, d)
+      .toLocaleDateString(undefined, { month: 'short', day: 'numeric' })
+      .toUpperCase();
+    return `${rel} · ${md}`;
+  }
+  return rel;
+}
+
+/** Today's date as a heading, e.g. "TODAY · JUN 16". */
+export function todayLabel(now: Date): string {
+  return dayLabelWithDate(localDateKey(now), now);
+}
+
+/** The earliest calendar day strictly after today that has any meetings, as a
+ *  labelled section ordered earliest-first; null when there are none. */
+export function nextDaySection(meetings: MeetingListItem[], now: Date): MeetingSection | null {
+  const today = localDateKey(now);
+  const buckets = new Map<string, MeetingListItem[]>();
+  for (const meeting of meetings) {
+    const d = new Date(meeting.timestamp);
+    if (Number.isNaN(d.getTime())) continue;
+    // Zero-padded YYYY-MM-DD keys compare lexically, so this keeps future days.
+    const key = localDateKey(d);
+    if (key <= today) continue;
+    const bucket = buckets.get(key);
+    if (bucket) bucket.push(meeting);
+    else buckets.set(key, [meeting]);
+  }
+  if (buckets.size === 0) return null;
+  const nextKey = [...buckets.keys()].sort()[0];
+  const items = [...buckets.get(nextKey)!].sort(
+    (a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime()
+  );
+  return { key: nextKey, label: dayLabelWithDate(nextKey, now), items };
+}
+
 /** Bucket every meeting under per-calendar-date headers, newest date first, and
  *  within each date ordered earliest-first (ascending by start time). */
 export function groupMeetingsByDate(meetings: MeetingListItem[], now: Date): MeetingSection[] {

--- a/src/views/UpNextCard.test.ts
+++ b/src/views/UpNextCard.test.ts
@@ -19,6 +19,7 @@ vi.mock('../composables/useBackend', async (importOriginal) => {
 });
 
 import UpNextCard from './UpNextCard.vue';
+import { todayLabel } from '../composables/groupMeetingsByDate';
 
 // Fixed "now"; meetings below are all in the future relative to it so they land
 // in the UPCOMING bucket.
@@ -154,10 +155,59 @@ describe('UpNextCard', () => {
     expect(wrapper.find('.head-title').text()).toBe('Second');
   });
 
-  it('shows the empty state when nothing is upcoming', async () => {
+  it('shows the empty state when nothing is upcoming today or later', async () => {
     const wrapper = mountCard([meeting({ id: 'past', timestamp: '2020-01-01T00:00:00Z', endTimestamp: '2020-01-01T01:00:00Z' })]);
     await flushPromises();
     expect(wrapper.find('.up-next-empty').exists()).toBe(true);
+    expect(wrapper.find('.up-next-empty--notice').exists()).toBe(false);
     expect(wrapper.find('.card').exists()).toBe(false);
+  });
+
+  it('labels the featured card with the current day and its date', async () => {
+    const wrapper = mountCard([meeting({ id: 'a', title: 'Discovery call' })]);
+    await flushPromises();
+    expect(wrapper.find('.up-next-empty--notice').exists()).toBe(false);
+    expect(wrapper.find('.up-next-day').text()).toBe(todayLabel(NOW));
+  });
+
+  it('falls back to the next day’s meetings when today is clear', async () => {
+    const wrapper = mountCard([
+      // Today's only meeting is already over.
+      meeting({ id: 'done', timestamp: '2026-06-16T09:00:00Z', endTimestamp: '2026-06-16T10:00:00Z' }),
+      // The next day has meetings — these should fill the card.
+      meeting({ id: 'tom-late', title: 'Sync', timestamp: '2026-06-17T16:00:00Z', endTimestamp: '2026-06-17T16:30:00Z' }),
+      meeting({ id: 'tom-early', title: 'Standup', timestamp: '2026-06-17T15:00:00Z', endTimestamp: '2026-06-17T15:15:00Z' }),
+    ]);
+    await flushPromises();
+    // The "no upcoming today" notice sits above the card…
+    expect(wrapper.find('.up-next-empty--notice').text()).toContain('No upcoming meetings today');
+    // …with the next day's earliest meeting featured and its date shown.
+    expect(wrapper.find('.card').exists()).toBe(true);
+    expect(wrapper.find('.head-title').text()).toBe('Standup');
+    expect(wrapper.find('.up-next-day').text()).toBeTruthy();
+    const rows = wrapper.findAll('.meeting-row:not(.meeting-row--more)');
+    expect(rows.map((r) => r.find('.row-title').text())).toEqual(['Sync']);
+    // The next day fills the main card, so there's no separate compact preview.
+    expect(wrapper.find('.card--compact').exists()).toBe(false);
+    expect(wrapper.find('.next-day-head').exists()).toBe(false);
+  });
+
+  it('shows the next day as a compact preview below today’s card', async () => {
+    const wrapper = mountCard([
+      meeting({ id: 'today', title: 'Discovery call', timestamp: '2026-06-16T16:00:00Z', endTimestamp: '2026-06-16T16:45:00Z' }),
+      meeting({ id: 'tom-late', title: 'Sync', timestamp: '2026-06-17T16:00:00Z', endTimestamp: '2026-06-17T16:30:00Z' }),
+      meeting({ id: 'tom-early', title: 'Standup', timestamp: '2026-06-17T15:00:00Z', endTimestamp: '2026-06-17T15:15:00Z' }),
+    ]);
+    await flushPromises();
+    // Today is still the featured card.
+    expect(wrapper.find('.up-next-empty--notice').exists()).toBe(false);
+    expect(wrapper.find('.head-title').text()).toBe('Discovery call');
+    expect(wrapper.find('.up-next-day').text()).toBe(todayLabel(NOW));
+    // The next day appears as a compact, date-headed list below it.
+    const preview = wrapper.find('.card--compact');
+    expect(preview.exists()).toBe(true);
+    expect(wrapper.find('.next-day-head').text()).toBeTruthy();
+    const rows = preview.findAll('.meeting-row:not(.meeting-row--more)');
+    expect(rows.map((r) => r.find('.row-title').text())).toEqual(['Standup', 'Sync']);
   });
 });

--- a/src/views/UpNextCard.vue
+++ b/src/views/UpNextCard.vue
@@ -21,10 +21,18 @@
     </div>
 
     <template v-if="featured">
-      <!-- "Up Next • in 22min" label with prev/next navigation across the
-           upcoming meetings. -->
+      <!-- Today is clear — say so, then show the next day's meetings below. -->
+      <div v-if="showingNextDay" class="up-next-empty up-next-empty--notice">
+        <p>No upcoming meetings today.</p>
+      </div>
+
+      <!-- "Up Next • in 22min" label, the day's date, and prev/next navigation
+           across the upcoming meetings. -->
       <div class="up-next-head">
-        <span class="up-next-label">Up Next<template v-if="featuredRel"> • {{ featuredRel }}</template></span>
+        <div class="up-next-head-main">
+          <span class="up-next-label">Up Next<template v-if="featuredRel"> • {{ featuredRel }}</template></span>
+          <span class="up-next-day">{{ dayLabel }}</span>
+        </div>
         <div v-if="upcoming.length > 1" class="up-next-nav">
           <button
             class="nav-chevron"
@@ -102,6 +110,26 @@
           {{ moreCount }} more…
         </div>
       </div>
+
+      <!-- Compact preview of the next day's meetings, beneath today's card. -->
+      <template v-if="nextDayPreview">
+        <div class="next-day-head">{{ nextDayPreview.label }}</div>
+        <div class="card card--compact">
+          <button
+            v-for="m in visibleNextDay"
+            :key="m.id"
+            class="meeting-row"
+            type="button"
+            @click="$emit('select', m)"
+          >
+            <span class="row-title">{{ m.title }}</span>
+            <span class="row-sub">{{ rowSub(m) }}</span>
+          </button>
+          <div v-if="nextDayMore > 0" class="meeting-row meeting-row--more">
+            {{ nextDayMore }} more…
+          </div>
+        </div>
+      </template>
     </template>
 
     <div v-else class="up-next-empty">
@@ -117,7 +145,12 @@ import {
   type MeetingListItem,
   type MeetingParticipantInfo,
 } from '../composables/useBackend';
-import { groupMeetingsByDate, upcomingRelLabel } from '../composables/groupMeetingsByDate';
+import {
+  groupTodaysMeetings,
+  nextDaySection,
+  todayLabel,
+  upcomingRelLabel,
+} from '../composables/groupMeetingsByDate';
 import oatsLogo from '../assets/oats-light.svg';
 
 const props = defineProps<{
@@ -155,12 +188,37 @@ const greeting = computed(() => {
   return `${weekday} ${month} ${d.getDate()} ${time}`;
 });
 
-// Reuse the sidebar's grouping so "upcoming" here means exactly what it means
-// in the list: future meetings and ones in progress, ordered earliest-first.
-const upcoming = computed<MeetingListItem[]>(() => {
-  const section = groupMeetingsByDate(props.meetings, props.now).find((s) => s.key === 'upcoming');
+// Today's still-to-come meetings, matching the sidebar's "today / upcoming"
+// split: future meetings and ones in progress, ordered earliest-first.
+const todaysUpcoming = computed<MeetingListItem[]>(() => {
+  const section = groupTodaysMeetings(props.meetings, props.now).find((s) => s.key === 'upcoming');
   return section?.items ?? [];
 });
+
+// The next calendar day that has meetings. Shown either as the main card (when
+// today is already done) or as a compact preview beneath today's card.
+const nextDay = computed(() => nextDaySection(props.meetings, props.now));
+const showingNextDay = computed(() => todaysUpcoming.value.length === 0 && nextDay.value !== null);
+
+// The meetings the main card pages through: today's upcoming, else the next day's.
+const upcoming = computed<MeetingListItem[]>(() =>
+  todaysUpcoming.value.length ? todaysUpcoming.value : (nextDay.value?.items ?? [])
+);
+
+// Date heading for whichever day the main card is showing.
+const dayLabel = computed(() =>
+  showingNextDay.value ? nextDay.value!.label : todayLabel(props.now)
+);
+
+// Next day's meetings as a compact preview below today's card — only when today
+// has its own meetings (otherwise the next day already fills the main card).
+const nextDayPreview = computed(() =>
+  showingNextDay.value ? null : nextDay.value
+);
+const visibleNextDay = computed(() => nextDayPreview.value?.items.slice(0, MAX_VISIBLE_REST) ?? []);
+const nextDayMore = computed(
+  () => (nextDayPreview.value?.items.length ?? 0) - visibleNextDay.value.length
+);
 
 // Which upcoming meeting is featured in the header; the chevrons page through
 // them. Clamp on read so a shrinking list (a meeting starting) never points
@@ -202,6 +260,13 @@ watch(
     }
   },
   { immediate: true }
+);
+
+// Reset paging when the card switches between today and the next day, so the
+// chevrons don't start mid-list against a freshly-swapped set of meetings.
+watch(
+  () => (showingNextDay.value ? nextDay.value?.key ?? null : 'today'),
+  () => { featuredIndex.value = 0; }
 );
 
 function step(delta: number): void {
@@ -345,10 +410,22 @@ function rowSub(m: MeetingListItem): string {
   padding: 0 2px 10px;
   flex-shrink: 0;
 }
+.up-next-head-main {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
 .up-next-label {
   font-size: 14px;
   font-weight: 600;
   color: #6f6f6f;
+}
+.up-next-day {
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  color: #9a9a9a;
 }
 .up-next-nav {
   display: flex;
@@ -380,6 +457,24 @@ function rowSub(m: MeetingListItem): string {
   border-radius: 16px;
   display: flex;
   flex-direction: column;
+  flex-shrink: 0;
+}
+
+/* Compact preview card for the next day: just rows, with a little breathing
+   room so the first/last rows sit clear of the rounded corners. */
+.card--compact {
+  padding: 6px 0;
+  overflow: hidden;
+}
+
+/* Date heading above the next day's compact preview. */
+.next-day-head {
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  color: #9a9a9a;
+  padding: 0 2px 8px;
+  margin-top: 18px;
   flex-shrink: 0;
 }
 
@@ -527,5 +622,12 @@ function rowSub(m: MeetingListItem): string {
   border-radius: 16px;
   color: #6f6f6f;
   font-size: 14px;
+}
+/* Compact variant shown above the next day's card when today is already done. */
+.up-next-empty--notice {
+  flex: 0 0 auto;
+  justify-content: flex-start;
+  padding: 14px 16px;
+  margin-bottom: 12px;
 }
 </style>


### PR DESCRIPTION
The Up Next card searched groupMeetingsByDate for an 'upcoming' key it never emits, so the card was always empty. Source today's still-to-come meetings from groupTodaysMeetings instead, and surface the next calendar day that has meetings:

- When today has meetings, list the next day beneath them as a compact, date-headed preview.
- When today is clear, show a "No upcoming meetings today." notice and promote the next day to the featured card.
- Add a per-day date heading (TODAY / TOMORROW / weekday + date) to each section via new dayLabelWithDate / todayLabel / nextDaySection helpers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * "Up Next" now distinguishes between today's upcoming meetings and a preview of the next day's meetings.
  * Added notice when no more meetings are scheduled for today.
  * Enhanced day labels with calendar dates for improved clarity.

* **Tests**
  * Expanded test coverage for date-based meeting grouping and labeling functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->