### PR TITLE
Prompt before auto-recording; skip server-side auto-join meetings

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -37,6 +37,8 @@ objc2-user-notifications = { version = "0.3", features = [
     "UNNotificationResponse",
     "UNNotification",
     "UNNotificationTrigger",
+    "UNNotificationAction",
+    "UNNotificationCategory",
     "UNUserNotificationCenter",
     "UNError",
     "block2",

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -570,6 +570,26 @@ pub(crate) fn open_waveform_window(
         .build()
         .map_err(|e| e.to_string())?;
 
+    // When the pill is the visible recording UI (the meetings window is hidden,
+    // minimized, or closed), dock it to the right edge of the primary screen,
+    // vertically centered, rather than leaving it at the OS default spot. When
+    // the meetings window owns the UI the pill is painted-empty, so its position
+    // doesn't matter.
+    if !pill_hidden {
+        if let Ok(Some(monitor)) = win.primary_monitor() {
+            let scale = monitor.scale_factor();
+            let msize = monitor.size();
+            let mpos = monitor.position();
+            // Window outer size is the fixed inner size (no decorations).
+            let win_w = (92.0 * scale).round() as i32;
+            let win_h = (284.0 * scale).round() as i32;
+            let margin = (16.0 * scale).round() as i32;
+            let x = mpos.x + msize.width as i32 - win_w - margin;
+            let y = mpos.y + (msize.height as i32 - win_h) / 2;
+            let _ = win.set_position(tauri::PhysicalPosition::new(x, y));
+        }
+    }
+
     let source = if auto {
         crate::recording_state::RecordingSource::Auto
     } else {

--- a/src-tauri/src/meeting_notifications.rs
+++ b/src-tauri/src/meeting_notifications.rs
@@ -10,7 +10,7 @@
 //! fetch of the inbox and surface any meeting-prep we haven't notified yet.
 
 use std::collections::HashSet;
-use std::sync::Mutex;
+use std::sync::{Mutex, OnceLock};
 use std::time::Duration;
 
 use futures_util::{SinkExt, StreamExt};
@@ -19,6 +19,7 @@ use serde_json::{json, Value};
 use tauri::{AppHandle, Manager};
 use tauri_plugin_notification::NotificationExt;
 use tauri_plugin_store::StoreExt;
+use tokio::sync::oneshot;
 use tokio_tungstenite::tungstenite::Message;
 
 use crate::commands::{
@@ -473,6 +474,87 @@ fn prep_url(prep_id: i64) -> String {
     format!("{}/my/meeting-prep-v2/{prep_id}", web_app_base_url())
 }
 
+// ---------------------------------------------------------------------------
+// Auto-record confirm/deny prompt
+//
+// When the mic monitor detects a meeting it asks here for a decision via a
+// notification carrying Record / Dismiss buttons. The user has 10 seconds to
+// choose; if they don't, the caller's mode default applies (record when
+// auto-record is on, skip when it's off). Lives in this module because there
+// is a single UNUserNotificationCenter delegate and it must route both the
+// meeting-prep clicks and these action buttons.
+// ---------------------------------------------------------------------------
+
+/// Identifiers for the auto-record prompt. The category id tells macOS which
+/// action buttons to attach to the notification; the action ids come back in
+/// the delegate's `didReceive` so we know which button was tapped.
+const AUTO_RECORD_CATEGORY: &str = "ai.ariso.auto-record";
+const AUTO_RECORD_ACTION_RECORD: &str = "ai.ariso.auto-record.record";
+const AUTO_RECORD_ACTION_DISMISS: &str = "ai.ariso.auto-record.dismiss";
+
+/// How long the prompt stays actionable before the caller's mode default wins.
+const AUTO_RECORD_PROMPT_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// One-shot sender for the in-flight auto-record prompt. The notification
+/// delegate (ObjC callback, main thread) fills it when a button is tapped; the
+/// awaiting `prompt_auto_record` task receives the choice. Only one prompt is
+/// ever live at a time — the mic monitor stays in its Recording phase until the
+/// meeting ends — so a new prompt simply replaces any stale sender.
+fn prompt_slot() -> &'static Mutex<Option<oneshot::Sender<bool>>> {
+    static SLOT: OnceLock<Mutex<Option<oneshot::Sender<bool>>>> = OnceLock::new();
+    SLOT.get_or_init(|| Mutex::new(None))
+}
+
+/// Deliver the user's choice from the notification delegate to the awaiting
+/// `prompt_auto_record`. No-op if nothing is waiting (already timed out).
+fn deliver_auto_record_decision(record: bool) {
+    if let Some(tx) = prompt_slot().lock().unwrap().take() {
+        let _ = tx.send(record);
+    }
+}
+
+/// Show the auto-record confirm/deny notification and await the user's choice.
+/// Resolves `true` to start recording. Returns `default_record` if the user
+/// doesn't respond within the 10s window — or on a build where the action
+/// buttons aren't available (the plugin fallback can't report a tap).
+pub async fn prompt_auto_record(app: &AppHandle, default_record: bool) -> bool {
+    let (tx, rx) = oneshot::channel();
+    *prompt_slot().lock().unwrap() = Some(tx);
+    eprintln!("auto-record: showing prompt (is_dev={}, default_record={default_record})", tauri::is_dev());
+    show_auto_record_prompt(app);
+    match tokio::time::timeout(AUTO_RECORD_PROMPT_TIMEOUT, rx).await {
+        Ok(Ok(record)) => record,
+        // Timed out, or the sender was dropped/replaced — apply the mode
+        // default and drop any stale sender we still own.
+        _ => {
+            let _ = prompt_slot().lock().unwrap().take();
+            default_record
+        }
+    }
+}
+
+/// Show the prompt notification with Record/Dismiss buttons. On a signed macOS
+/// bundle this uses UNUserNotificationCenter (the only path that renders action
+/// buttons). In dev / on other platforms it falls back to a plain banner with
+/// no buttons — the prompt then resolves on the timeout default.
+fn show_auto_record_prompt(app: &AppHandle) {
+    let title = "Meeting detected";
+    let body = "Start recording this meeting?";
+    #[cfg(target_os = "macos")]
+    if !tauri::is_dev() {
+        eprintln!("auto-record: show via UNUserNotificationCenter (signed bundle path)");
+        macos_un::show_auto_record(app, title, body);
+        return;
+    }
+    // Dev / non-macOS: plugin banner (no buttons). NOTE: from `tauri dev` on
+    // macOS the process isn't a real .app bundle, so this typically posts
+    // nothing visible — the prompt only renders reliably from the built bundle.
+    match app.notification().builder().title(title).body(body).show() {
+        Ok(()) => eprintln!("auto-record: plugin banner posted (may not render in dev)"),
+        Err(e) => eprintln!("auto-record: failed to show prompt notification: {e}"),
+    }
+}
+
 /// Initialize native notification support. On a macOS bundle this installs the
 /// UNUserNotificationCenter delegate (which handles clicks) — MUST be called on
 /// the main thread. In dev / on other platforms it's a no-op (the plugin path
@@ -511,9 +593,10 @@ mod macos_un {
     use objc2::rc::Retained;
     use objc2::runtime::{Bool, NSObject, NSObjectProtocol, ProtocolObject};
     use objc2::{define_class, msg_send, AnyThread};
-    use objc2_foundation::{NSError, NSString};
+    use objc2_foundation::{NSArray, NSError, NSSet, NSString};
     use objc2_user_notifications::{
-        UNAuthorizationOptions, UNMutableNotificationContent, UNNotification,
+        UNAuthorizationOptions, UNMutableNotificationContent, UNNotification, UNNotificationAction,
+        UNNotificationActionOptions, UNNotificationCategory, UNNotificationCategoryOptions,
         UNNotificationPresentationOptions, UNNotificationRequest, UNNotificationResponse,
         UNUserNotificationCenter, UNUserNotificationCenterDelegate,
     };
@@ -544,7 +627,9 @@ mod macos_un {
                 completion.call((opts,));
             }
 
-            // On click, open the deep link carried as the request identifier.
+            // Auto-record action buttons resolve the pending prompt; otherwise
+            // (a meeting-prep body click) open the deep link carried as the
+            // request identifier.
             #[unsafe(method(userNotificationCenter:didReceiveNotificationResponse:withCompletionHandler:))]
             fn did_receive(
                 &self,
@@ -552,6 +637,17 @@ mod macos_un {
                 response: &UNNotificationResponse,
                 completion: &block2::DynBlock<dyn Fn()>,
             ) {
+                let action = response.actionIdentifier().to_string();
+                if action == super::AUTO_RECORD_ACTION_RECORD {
+                    super::deliver_auto_record_decision(true);
+                    completion.call(());
+                    return;
+                }
+                if action == super::AUTO_RECORD_ACTION_DISMISS {
+                    super::deliver_auto_record_decision(false);
+                    completion.call(());
+                    return;
+                }
                 let url = response.notification().request().identifier().to_string();
                 if url.starts_with("http") {
                     let _ = std::process::Command::new("open").arg(&url).spawn();
@@ -584,11 +680,66 @@ mod macos_un {
         // setDelegate stores a weak reference; leak a strong ref so the
         // delegate lives for the whole process.
         std::mem::forget(delegate);
+        register_auto_record_category(&center);
         let handler = RcBlock::new(|_granted: Bool, _err: *mut NSError| {});
         center.requestAuthorizationWithOptions_completionHandler(
             UNAuthorizationOptions::Alert | UNAuthorizationOptions::Sound,
             &handler,
         );
+    }
+
+    /// Register the auto-record category so the prompt notification renders its
+    /// Record / Dismiss buttons. Actions run in the background (no Foreground
+    /// option) — the handler only signals a channel, it doesn't need the app
+    /// frontmost. Dismiss is styled destructive.
+    fn register_auto_record_category(center: &UNUserNotificationCenter) {
+        let record = UNNotificationAction::actionWithIdentifier_title_options(
+            &NSString::from_str(super::AUTO_RECORD_ACTION_RECORD),
+            &NSString::from_str("Record"),
+            UNNotificationActionOptions::empty(),
+        );
+        let dismiss = UNNotificationAction::actionWithIdentifier_title_options(
+            &NSString::from_str(super::AUTO_RECORD_ACTION_DISMISS),
+            &NSString::from_str("Dismiss"),
+            UNNotificationActionOptions::Destructive,
+        );
+        let actions = NSArray::from_retained_slice(&[record, dismiss]);
+        let intents: Retained<NSArray<NSString>> = NSArray::from_slice(&[]);
+        let category =
+            UNNotificationCategory::categoryWithIdentifier_actions_intentIdentifiers_options(
+                &NSString::from_str(super::AUTO_RECORD_CATEGORY),
+                &actions,
+                &intents,
+                UNNotificationCategoryOptions::empty(),
+            );
+        let categories = NSSet::from_retained_slice(&[category]);
+        center.setNotificationCategories(&categories);
+    }
+
+    /// Show the auto-record prompt with action buttons. Mirrors `show` but tags
+    /// the content with the auto-record category so macOS attaches the buttons;
+    /// on UNC failure it falls back to a (button-less) plugin banner.
+    pub fn show_auto_record(app: &AppHandle, title: &str, body: &str) {
+        let center = UNUserNotificationCenter::currentNotificationCenter();
+        let content = UNMutableNotificationContent::new();
+        content.setTitle(&NSString::from_str(title));
+        content.setBody(&NSString::from_str(body));
+        content.setCategoryIdentifier(&NSString::from_str(super::AUTO_RECORD_CATEGORY));
+        // A non-http identifier so the body-click handler's URL guard skips it.
+        let identifier = NSString::from_str(super::AUTO_RECORD_CATEGORY);
+        let request = UNNotificationRequest::requestWithIdentifier_content_trigger(
+            &identifier, &content, None,
+        );
+        let app = app.clone();
+        let title = title.to_string();
+        let body = body.to_string();
+        let handler = RcBlock::new(move |err: *mut NSError| {
+            if let Some(desc) = err_desc(err) {
+                eprintln!("auto-record: UNC unavailable ({desc}); using plugin fallback (no buttons)");
+                let _ = app.notification().builder().title(&title).body(&body).show();
+            }
+        });
+        center.addNotificationRequest_withCompletionHandler(&request, Some(&handler));
     }
 
     pub fn show(app: &AppHandle, title: &str, body: &str, url: &str) {

--- a/src-tauri/src/meeting_notifications.rs
+++ b/src-tauri/src/meeting_notifications.rs
@@ -513,6 +513,82 @@ fn deliver_auto_record_decision(record: bool) {
     }
 }
 
+/// Whether the meeting happening right now is already flagged for server-side
+/// auto-join (an Ariso notetaker will record it), in which case the desktop must
+/// not also record. Only the Ariso backend has a calendar; everything else — and
+/// any network/parse error — returns false so detection proceeds normally.
+pub async fn current_meeting_auto_join_scheduled(app: &AppHandle) -> bool {
+    use crate::commands::{active_backend, api_base_url, get_session_token, http_client};
+    if active_backend(app) != "ariso" {
+        return false;
+    }
+    let Some(token) = get_session_token(app) else {
+        return false;
+    };
+    let now = chrono::Utc::now();
+    let start = (now - chrono::Duration::hours(2)).to_rfc3339();
+    let end = (now + chrono::Duration::hours(2)).to_rfc3339();
+    let result = tokio::time::timeout(HTTP_TIMEOUT, async {
+        http_client()
+            .get(format!("{}/meetings", api_base_url()))
+            .query(&[("startDate", start.as_str()), ("endDate", end.as_str())])
+            .header(AUTHORIZATION, format!("Bearer {token}"))
+            .header(CONTENT_TYPE, "application/json")
+            .send()
+            .await
+            .ok()?
+            .json::<Value>()
+            .await
+            .ok()
+    })
+    .await;
+    match result {
+        Ok(Some(v)) => current_meeting_auto_join_from(&v, now.timestamp_millis()),
+        _ => false,
+    }
+}
+
+/// Pure selector (testable): given the `/meetings` response and the current time
+/// in epoch-ms, return whether the *current* meeting is auto-join-scheduled.
+/// "Current" mirrors the frontend's `pickDefaultMeeting`: a meeting is current
+/// when `start - 5min <= now <= start + 60min`; if several overlap, the latest
+/// start wins (the one you most recently joined).
+fn current_meeting_auto_join_from(resp: &Value, now_ms: i64) -> bool {
+    const FIVE_MIN_MS: i64 = 5 * 60_000;
+    const SIXTY_MIN_MS: i64 = 60 * 60_000;
+    let Some(meetings) = resp.get("meetings").and_then(Value::as_array) else {
+        return false;
+    };
+    let mut current_start = i64::MIN;
+    let mut current_auto_join = false;
+    for m in meetings {
+        let Some(start_str) = m.get("start_at").and_then(Value::as_str) else {
+            continue;
+        };
+        let Ok(start_ms) = chrono::DateTime::parse_from_rfc3339(start_str)
+            .map(|dt| dt.timestamp_millis())
+        else {
+            continue;
+        };
+        let is_current = start_ms - FIVE_MIN_MS <= now_ms && now_ms <= start_ms + SIXTY_MIN_MS;
+        if is_current && start_ms >= current_start {
+            current_start = start_ms;
+            current_auto_join = truthy(m.get("auto_join_scheduled"));
+        }
+    }
+    current_auto_join
+}
+
+/// Lenient truthiness for an API flag that may arrive as a bool, 0/1, or string.
+fn truthy(v: Option<&Value>) -> bool {
+    match v {
+        Some(Value::Bool(b)) => *b,
+        Some(Value::Number(n)) => n.as_i64().map(|i| i != 0).unwrap_or(false),
+        Some(Value::String(s)) => s == "true" || s == "1",
+        _ => false,
+    }
+}
+
 /// Show the auto-record confirm/deny notification and await the user's choice.
 /// Resolves `true` to start recording. Returns `default_record` if the user
 /// doesn't respond within the 10s window — or on a build where the action
@@ -520,7 +596,6 @@ fn deliver_auto_record_decision(record: bool) {
 pub async fn prompt_auto_record(app: &AppHandle, default_record: bool) -> bool {
     let (tx, rx) = oneshot::channel();
     *prompt_slot().lock().unwrap() = Some(tx);
-    eprintln!("auto-record: showing prompt (is_dev={}, default_record={default_record})", tauri::is_dev());
     show_auto_record_prompt(app);
     match tokio::time::timeout(AUTO_RECORD_PROMPT_TIMEOUT, rx).await {
         Ok(Ok(record)) => record,
@@ -542,16 +617,14 @@ fn show_auto_record_prompt(app: &AppHandle) {
     let body = "Start recording this meeting?";
     #[cfg(target_os = "macos")]
     if !tauri::is_dev() {
-        eprintln!("auto-record: show via UNUserNotificationCenter (signed bundle path)");
         macos_un::show_auto_record(app, title, body);
         return;
     }
     // Dev / non-macOS: plugin banner (no buttons). NOTE: from `tauri dev` on
-    // macOS the process isn't a real .app bundle, so this typically posts
-    // nothing visible — the prompt only renders reliably from the built bundle.
-    match app.notification().builder().title(title).body(body).show() {
-        Ok(()) => eprintln!("auto-record: plugin banner posted (may not render in dev)"),
-        Err(e) => eprintln!("auto-record: failed to show prompt notification: {e}"),
+    // macOS the process isn't a real .app bundle, so this may post nothing
+    // visible — the prompt with buttons only renders from the built bundle.
+    if let Err(e) = app.notification().builder().title(title).body(body).show() {
+        eprintln!("auto-record: failed to show prompt notification: {e}");
     }
 }
 
@@ -822,4 +895,80 @@ pub async fn sync_meeting_notifications(app: AppHandle) -> Result<(), String> {
 pub async fn stop_meeting_notifications(app: AppHandle) -> Result<(), String> {
     stop(&app);
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    // 2026-06-16T12:00:00Z in epoch-ms, used as "now" across the cases.
+    const NOW_MS: i64 = 1_781_956_800_000;
+
+    fn at(offset_min: i64) -> String {
+        let dt = chrono::DateTime::from_timestamp_millis(NOW_MS + offset_min * 60_000).unwrap();
+        dt.to_rfc3339()
+    }
+
+    #[test]
+    fn skips_when_current_meeting_is_auto_join_scheduled() {
+        // Started 10 min ago (current), flagged for server-side auto-join.
+        let resp = json!({ "meetings": [
+            { "id": 1, "start_at": at(-10), "auto_join_scheduled": true }
+        ]});
+        assert!(current_meeting_auto_join_from(&resp, NOW_MS));
+    }
+
+    #[test]
+    fn does_not_skip_when_current_meeting_is_not_flagged() {
+        let resp = json!({ "meetings": [
+            { "id": 1, "start_at": at(-10), "auto_join_scheduled": false }
+        ]});
+        assert!(!current_meeting_auto_join_from(&resp, NOW_MS));
+    }
+
+    #[test]
+    fn flag_on_a_non_current_meeting_is_ignored() {
+        // Started 2h ago (well past the +60min current window) — not current.
+        let resp = json!({ "meetings": [
+            { "id": 1, "start_at": at(-120), "auto_join_scheduled": true }
+        ]});
+        assert!(!current_meeting_auto_join_from(&resp, NOW_MS));
+    }
+
+    #[test]
+    fn latest_starting_current_meeting_wins_on_overlap() {
+        // Two overlapping current meetings; the later-starting one (not flagged)
+        // is the active one, mirroring pickDefaultMeeting's tie-break.
+        let resp = json!({ "meetings": [
+            { "id": 1, "start_at": at(-50), "auto_join_scheduled": true },
+            { "id": 2, "start_at": at(-2),  "auto_join_scheduled": false }
+        ]});
+        assert!(!current_meeting_auto_join_from(&resp, NOW_MS));
+    }
+
+    #[test]
+    fn within_five_minute_lead_in_counts_as_current() {
+        // Starts in 3 min — inside the 5-min lead-in, so it's already current.
+        let resp = json!({ "meetings": [
+            { "id": 1, "start_at": at(3), "auto_join_scheduled": true }
+        ]});
+        assert!(current_meeting_auto_join_from(&resp, NOW_MS));
+    }
+
+    #[test]
+    fn truthy_accepts_bool_number_and_string_forms() {
+        assert!(truthy(Some(&json!(true))));
+        assert!(truthy(Some(&json!(1))));
+        assert!(truthy(Some(&json!("true"))));
+        assert!(!truthy(Some(&json!(false))));
+        assert!(!truthy(Some(&json!(0))));
+        assert!(!truthy(None));
+    }
+
+    #[test]
+    fn missing_or_empty_meetings_does_not_skip() {
+        assert!(!current_meeting_auto_join_from(&json!({}), NOW_MS));
+        assert!(!current_meeting_auto_join_from(&json!({ "meetings": [] }), NOW_MS));
+    }
 }

--- a/src-tauri/src/mic_monitor.rs
+++ b/src-tauri/src/mic_monitor.rs
@@ -228,7 +228,6 @@ fn enabled(app: &AppHandle) -> bool {
 /// repeatedly (startup, settings toggle).
 pub async fn sync(app: &AppHandle) {
     let desired = is_supported();
-    eprintln!("mic-monitor: sync() supported(desired)={desired}");
     let mgr = app.state::<MicMonitorManager>();
     let mut guard = mgr.handle.lock().unwrap();
     if !desired {
@@ -249,23 +248,14 @@ pub async fn sync(app: &AppHandle) {
 async fn run_loop(app: AppHandle) {
     let mut machine = Machine::new();
     let mut elapsed: u64 = 0;
-    let mut prev_empty = true;
     loop {
         let external = external_input_pids();
         let recording_active = app
             .state::<crate::recording_state::RecordingState>()
             .is_active();
-        // Log only on edges so the 1Hz poll doesn't spam the terminal.
-        if external.is_empty() != prev_empty {
-            eprintln!(
-                "mic-monitor: external mic pids={external:?} recording_active={recording_active}"
-            );
-            prev_empty = external.is_empty();
-        }
         if let Some(action) = machine.tick(elapsed, &external, recording_active) {
             match action {
                 Action::Start => {
-                    eprintln!("mic-monitor: Action::Start — meeting detected, prompting");
                     // Prompt the user (Record/Dismiss, 10s) before recording.
                     // The default when they don't answer follows the setting:
                     // on → record, off → skip. Spawned so the poll loop keeps
@@ -274,6 +264,14 @@ async fn run_loop(app: AppHandle) {
                     let app2 = app.clone();
                     let default_record = enabled(&app2);
                     tauri::async_runtime::spawn(async move {
+                        // An Ariso notetaker already records meetings flagged for
+                        // server-side auto-join — don't double-record. Skip
+                        // silently: no prompt, no recording.
+                        if crate::meeting_notifications::current_meeting_auto_join_scheduled(&app2)
+                            .await
+                        {
+                            return;
+                        }
                         let record =
                             crate::meeting_notifications::prompt_auto_record(&app2, default_record)
                                 .await;

--- a/src-tauri/src/mic_monitor.rs
+++ b/src-tauri/src/mic_monitor.rs
@@ -209,7 +209,11 @@ impl MicMonitorManager {
     }
 }
 
-/// Whether the user has auto-record enabled (defaults to true).
+/// Whether auto-record is enabled (defaults to true). The monitor now runs
+/// regardless — on detection it always prompts — so this only decides the
+/// no-response default: enabled → start recording when the prompt times out;
+/// disabled → skip. Read fresh per detection so a settings toggle takes effect
+/// without restarting the monitor.
 fn enabled(app: &AppHandle) -> bool {
     use tauri_plugin_store::StoreExt;
     match app.store(SETTINGS_PATH) {
@@ -218,10 +222,13 @@ fn enabled(app: &AppHandle) -> bool {
     }
 }
 
-/// Start the monitor if supported and enabled; otherwise stop it. Safe to call
+/// Start the monitor if the OS supports per-process input detection; otherwise
+/// stop it. The enabled setting no longer gates the monitor (it only sets the
+/// prompt's timeout default), so the prompt fires in both modes. Safe to call
 /// repeatedly (startup, settings toggle).
 pub async fn sync(app: &AppHandle) {
-    let desired = is_supported() && enabled(app);
+    let desired = is_supported();
+    eprintln!("mic-monitor: sync() supported(desired)={desired}");
     let mgr = app.state::<MicMonitorManager>();
     let mut guard = mgr.handle.lock().unwrap();
     if !desired {
@@ -242,20 +249,49 @@ pub async fn sync(app: &AppHandle) {
 async fn run_loop(app: AppHandle) {
     let mut machine = Machine::new();
     let mut elapsed: u64 = 0;
+    let mut prev_empty = true;
     loop {
         let external = external_input_pids();
         let recording_active = app
             .state::<crate::recording_state::RecordingState>()
             .is_active();
+        // Log only on edges so the 1Hz poll doesn't spam the terminal.
+        if external.is_empty() != prev_empty {
+            eprintln!(
+                "mic-monitor: external mic pids={external:?} recording_active={recording_active}"
+            );
+            prev_empty = external.is_empty();
+        }
         if let Some(action) = machine.tick(elapsed, &external, recording_active) {
             match action {
                 Action::Start => {
-                    let app_main = app.clone();
-                    let _ = app.run_on_main_thread(move || {
-                        if let Err(e) =
-                            crate::commands::open_waveform_window(&app_main, None, true)
+                    eprintln!("mic-monitor: Action::Start — meeting detected, prompting");
+                    // Prompt the user (Record/Dismiss, 10s) before recording.
+                    // The default when they don't answer follows the setting:
+                    // on → record, off → skip. Spawned so the poll loop keeps
+                    // running during the prompt; the machine is already in its
+                    // Recording phase so no second prompt fires for this meeting.
+                    let app2 = app.clone();
+                    let default_record = enabled(&app2);
+                    tauri::async_runtime::spawn(async move {
+                        let record =
+                            crate::meeting_notifications::prompt_auto_record(&app2, default_record)
+                                .await;
+                        // A manual recording may have started during the prompt;
+                        // don't stack a second recorder on top of it.
+                        if record
+                            && !app2
+                                .state::<crate::recording_state::RecordingState>()
+                                .is_active()
                         {
-                            eprintln!("mic-monitor: failed to open recorder window: {e}");
+                            let app_main = app2.clone();
+                            let _ = app2.run_on_main_thread(move || {
+                                if let Err(e) =
+                                    crate::commands::open_waveform_window(&app_main, None, true)
+                                {
+                                    eprintln!("mic-monitor: failed to open recorder window: {e}");
+                                }
+                            });
                         }
                     });
                 }

--- a/src/views/WaveformView.test.ts
+++ b/src/views/WaveformView.test.ts
@@ -315,31 +315,35 @@ describe('WaveformView vertical pill', () => {
     vi.useRealTimers();
   });
 
-  it('auto mode with no calendar match shows the confirm overlay', async () => {
+  it('auto mode records immediately with no in-pill confirm overlay', async () => {
+    // Confirmation now happens before the window opens (the notification
+    // prompt), so the pill itself never shows a keep/discard overlay.
     routeQuery = { auto: '1' };
     listScheduledMeetings.mockResolvedValue([]);
     const wrapper = mount(WaveformView);
     await flushPromises();
-    expect(wrapper.find('.confirm').exists()).toBe(true);
-    expect(wrapper.find('.keep-btn').exists()).toBe(true);
+    expect(wrapper.find('.confirm').exists()).toBe(false);
+    expect(startRecording).toHaveBeenCalledWith('mic');
+    expect(wrapper.findAll('.bar')).toHaveLength(3);
     routeQuery = {};
     wrapper.unmount();
   });
 
-  it('discards (does not upload) when stopped while the confirm overlay is unanswered', async () => {
+  it('discards (does not upload) a too-short auto recording on stop', async () => {
+    // Duration defaults to 5s (< the 15s minimum), so an auto recording that
+    // stops almost immediately is dropped rather than uploaded as a stub.
     routeQuery = { auto: '1' };
     listScheduledMeetings.mockResolvedValue([]);
     const wrapper = mount(WaveformView);
     await flushPromises();
-    // Confirm overlay should be showing (local backend, no match).
-    expect(wrapper.find('.confirm').exists()).toBe(true);
     stopRecording.mockResolvedValue(new Blob(['x'], { type: 'audio/mpeg' }));
-    // A native mic-off stop arrives before the user answers.
+    // A native mic-off stop arrives while the recording is still under 15s.
     await eventHandlers['auto-record://stop']?.({});
     await flushPromises();
     // Must NOT have uploaded; must have stopped + closed.
     expect(finalizeRecording).not.toHaveBeenCalled();
     expect(stopRecording).toHaveBeenCalled();
+    expect(closeWin).toHaveBeenCalled();
     routeQuery = {};
     wrapper.unmount();
   });

--- a/src/views/WaveformView.vue
+++ b/src/views/WaveformView.vue
@@ -78,19 +78,6 @@
           </button>
         </div>
 
-        <div v-if="confirmVisible" class="confirm">
-          <button
-            class="ctrl-btn keep-btn"
-            aria-label="Keep recording"
-            @click.stop.prevent="keepRecording"
-          >✓</button>
-          <button
-            class="ctrl-btn discard-btn"
-            aria-label="Discard recording"
-            @click.stop.prevent="discardRecording"
-          >✕</button>
-        </div>
-
         <!-- Tauri only drags when the mousedown target itself carries the
              attribute, so every leaf in the handle needs it. -->
         <div class="drag-handle" data-tauri-drag-region @click.stop>
@@ -155,10 +142,7 @@ const isAuto = route.query.auto === '1';
 // visibility watcher pushes recorder://pill-visible to flip this when the
 // meetings window is minimized or closed mid-recording.
 const pillHidden = ref(route.query.pillHidden === '1');
-const confirmVisible = ref(false);
 const isStopping = ref(false);
-let confirmTimer: ReturnType<typeof setTimeout> | null = null;
-const CONFIRM_TIMEOUT_MS = 60_000;
 // Auto recordings shorter than this are discarded, not uploaded (guards against
 // late mic-on / quick-off races). Manual recordings are never length-gated.
 const MIN_AUTO_DURATION_S = 15;
@@ -303,7 +287,10 @@ async function startRecording() {
   await invoke('set_tray_recording', { isRecording: true, isPaused: false });
 }
 
-// Auto-trigger: resolve calendar association, falling back to a confirm prompt.
+// Auto-trigger: attach to a matching calendar meeting when one is found. The
+// user has already opted in via the pre-recording notification prompt (or
+// auto-record is on), so there's no in-pill confirmation — a no-match recording
+// simply proceeds unattached.
 async function resolveAuto() {
   try {
     if (backend.value?.id === 'ariso') {
@@ -314,45 +301,21 @@ async function resolveAuto() {
       const assoc = resolveAssociation('ariso', meetings, now);
       if (assoc.kind === 'matched') {
         effectiveMeetingId.value = assoc.meetingId ?? null;
-        return;
       }
     }
   } catch (e) {
-    console.error('Auto-trigger match failed; asking for confirmation', e);
+    console.error('Auto-trigger calendar match failed; recording unattached', e);
   }
-  showConfirm();
-}
-
-function showConfirm() {
-  confirmVisible.value = true;
-  // No response within the window → discard (per spec).
-  confirmTimer = setTimeout(() => {
-    confirmTimer = null;
-    void discardRecording();
-  }, CONFIRM_TIMEOUT_MS);
-}
-
-function keepRecording() {
-  if (confirmTimer) {
-    clearTimeout(confirmTimer);
-    confirmTimer = null;
-  }
-  confirmVisible.value = false;
 }
 
 // Discard the in-progress capture without uploading, then close.
 async function discardRecording() {
   if (isStopping.value) return;
   isStopping.value = true;
-  if (confirmTimer) {
-    clearTimeout(confirmTimer);
-    confirmTimer = null;
-  }
   if (closeTimer) {
     clearTimeout(closeTimer);
     closeTimer = null;
   }
-  confirmVisible.value = false;
   if (silenceTimer) {
     clearInterval(silenceTimer);
     silenceTimer = null;
@@ -369,22 +332,15 @@ async function discardRecording() {
 
 async function handleStop() {
   if (isStopping.value) return;
-  // An unanswered confirm overlay means the user never opted in — a stop of any
-  // kind (native mic-off, silence backstop, tray) must discard, not upload.
-  if (confirmVisible.value) {
-    await discardRecording();
-    return;
-  }
+  // Auto recordings that stop almost immediately (late mic-on / quick-off
+  // races) are discarded rather than uploaded as a stub. Manual recordings are
+  // never length-gated.
   if (isAuto && recorder.durationSeconds.value < MIN_AUTO_DURATION_S) {
     await discardRecording();
     return;
   }
   isStopping.value = true;
-  // Tear down the auto-trigger/backstop timers so they can't fire post-stop.
-  if (confirmTimer) {
-    clearTimeout(confirmTimer);
-    confirmTimer = null;
-  }
+  // Tear down the backstop timer so it can't fire post-stop.
   if (silenceTimer) {
     clearInterval(silenceTimer);
     silenceTimer = null;
@@ -566,7 +522,6 @@ onUnmounted(() => {
   unlistenResume?.();
   unlistenStop?.();
   unlistenAutoStop?.();
-  if (confirmTimer) clearTimeout(confirmTimer);
 });
 </script>
 
@@ -721,17 +676,6 @@ html, body {
   border-radius: 50%;
   background: #6b7280;
 }
-
-.confirm {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 6px;
-  margin-top: 7px;
-  flex-shrink: 0;
-}
-.keep-btn { color: #34d399; font-size: 16px; font-weight: 700; }
-.discard-btn { color: #f87171; font-size: 14px; font-weight: 700; }
 
 .status-icon {
   margin-top: 8px;


### PR DESCRIPTION
## What
- Auto-record monitor now runs whenever the OS supports per-process mic detection. On detection it sends a native **Record/Dismiss** notification with a 10s timer; the setting only sets the no-response default (on → record, off → don't).
- Skip silently (no prompt, no recording) when the current meeting is flagged `auto_join_scheduled` — an Ariso notetaker already records it.
- Recorder pill docks to the right edge when the Meetings window is hidden.
- Removed the in-pill confirm overlay (confirmation now happens before recording).

## Test
cargo: 103 passed · vitest: 270 passed · clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)