### PR TITLE
fix: lazy-load router views to isolate import failures

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -3,24 +3,20 @@ import { setupPluginListeners } from 'tauri-plugin-mcp';
 import { createApp } from 'vue';
 import { createRouter, createWebHashHistory } from 'vue-router';
 import App from './App.vue';
-import WaveformView from './views/WaveformView.vue';
-import SettingsView from './views/SettingsView.vue';
-import UpdateView from './views/UpdateView.vue';
-import BootstrapView from './views/BootstrapView.vue';
-import MeetingPickerView from './views/MeetingPickerView.vue';
-import LibraryView from './views/LibraryView.vue';
-import OnboardingView from './views/OnboardingView.vue';
 
+// Routes are lazy-loaded so each window only fetches the view it renders, and a
+// broken import in one view stays contained to its own route instead of taking
+// down the whole app.
 const router = createRouter({
   history: createWebHashHistory(),
   routes: [
-    { path: '/', name: 'Bootstrap', component: BootstrapView },
-    { path: '/onboarding', name: 'Onboarding', component: OnboardingView },
-    { path: '/waveform', name: 'Waveform', component: WaveformView },
-    { path: '/settings', name: 'Settings', component: SettingsView },
-    { path: '/update', name: 'Update', component: UpdateView },
-    { path: '/meeting-picker', name: 'MeetingPicker', component: MeetingPickerView },
-    { path: '/library', name: 'Library', component: LibraryView },
+    { path: '/', name: 'Bootstrap', component: () => import('./views/BootstrapView.vue') },
+    { path: '/onboarding', name: 'Onboarding', component: () => import('./views/OnboardingView.vue') },
+    { path: '/waveform', name: 'Waveform', component: () => import('./views/WaveformView.vue') },
+    { path: '/settings', name: 'Settings', component: () => import('./views/SettingsView.vue') },
+    { path: '/update', name: 'Update', component: () => import('./views/UpdateView.vue') },
+    { path: '/meeting-picker', name: 'MeetingPicker', component: () => import('./views/MeetingPickerView.vue') },
+    { path: '/library', name: 'Library', component: () => import('./views/LibraryView.vue') },
   ],
 });
 


### PR DESCRIPTION
## Problem

`src/main.ts` statically imported every view component into the router. Because all views share one module graph, a single unresolvable import in *any* view took down the *entire* app — every Tauri window (settings, library, etc.) rendered blank with no JS bridge, not just the affected route.

This was hit in practice when `@heroicons/vue` was absent from `node_modules`: the failed import in `UpdateView.vue` blanked all windows, even though no other view depends on heroicons.

## Fix

Convert all routes to dynamic `import()`. Each Tauri window loads a single route, so now it only fetches the view it actually renders, and a broken import stays contained to its own route instead of cascading to the whole app.

Side benefit: views are code-split into separate chunks (confirmed in the build output).

## Testing

- `npm run vite:build` succeeds; each view emits its own chunk.
- `npm test`: no new failures introduced (the 7 pre-existing `UpdateView`/update-snapshot failures are present on `main` as well, unrelated to this change).
- Manually verified via the MCP server that the settings and meetings (library) windows open and render correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Optimized route loading to improve initial application startup time. Routes now load on-demand when accessed, reducing upfront resource consumption.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->