### PR TITLE
Revert "Merge pull request #88 from ariso-ai/feat/skip-dmg-compose"

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -165,7 +165,12 @@ jobs:
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
-        run: npm run tauri:build -- -- --features prod-api
+        run: npm run tauri:build -- --bundles app -- --features prod-api
+
+      # Tauri does not expose Finder icon size for DMGs, so compose the DMG
+      # after the signed app bundle exists and persist the smaller bowl layout.
+      - name: Compose DMG layout
+        run: npm run dmg:compose
 
       # Hand the bundler outputs to the publish job. Paths share the common
       # ancestor bundle/, so the artifact preserves the macos/ and dmg/

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -172,6 +172,30 @@ jobs:
       - name: Compose DMG layout
         run: npm run dmg:compose
 
+      # The custom composer writes Finder metadata after Tauri signs the .app,
+      # so sign the final DMG before it becomes the public release artifact.
+      - name: Sign composed DMG
+        env:
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${APPLE_SIGNING_IDENTITY}" ]]; then
+            echo "APPLE_SIGNING_IDENTITY is required to sign the composed DMG." >&2
+            exit 1
+          fi
+
+          DMG_DIR="src-tauri/target/release/bundle/dmg"
+          DMG_COUNT="$(find "${DMG_DIR}" -maxdepth 1 -type f -name '*.dmg' | wc -l | tr -d ' ')"
+          if [[ "${DMG_COUNT}" != "1" ]]; then
+            echo "Expected exactly 1 DMG in ${DMG_DIR}, found ${DMG_COUNT}." >&2
+            find "${DMG_DIR}" -maxdepth 1 -type f -name '*.dmg' -print >&2
+            exit 1
+          fi
+
+          DMG="$(find "${DMG_DIR}" -maxdepth 1 -type f -name '*.dmg' -print)"
+          codesign --force --sign "${APPLE_SIGNING_IDENTITY}" --timestamp "${DMG}"
+          codesign --verify --verbose=4 "${DMG}"
+
       # Hand the bundler outputs to the publish job. Paths share the common
       # ancestor bundle/, so the artifact preserves the macos/ and dmg/
       # subdirectories that release-publish.sh expects. The DMG and tarball are


### PR DESCRIPTION
don't skip dmg compose

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved the macOS release build workflow to package the app bundle more reliably, then compose the DMG explicitly in a separate step.
  * Added automated verification and signing for the composed DMG, ensuring exactly one expected DMG is produced before codesigning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->