### PR TITLE
fix: show Oats in macOS Stage Manager

### DIFF
--- a/src-tauri/src/activation.rs
+++ b/src-tauri/src/activation.rs
@@ -1,0 +1,39 @@
+//! macOS Dock / Stage Manager visibility.
+//!
+//! Oats launches as an Accessory app (`LSUIElement`) so it lives only in the
+//! menu bar — no Dock icon. But macOS Stage Manager only shows apps whose
+//! activation policy is `Regular`, so a pure Accessory app never appears in the
+//! Stage Manager strip on the side. To get both behaviors, the activation
+//! policy tracks the visible windows: `Regular` (Dock icon + Stage Manager)
+//! whenever a real app window is on screen, and back to `Accessory`
+//! (menu-bar-only) once they are all hidden or closed.
+
+/// Windows that must never promote the app to a Dock-visible state: the hidden
+/// bootstrap window and the always-on-top, chrome-less recorder pill.
+#[cfg(target_os = "macos")]
+const UTILITY_WINDOWS: &[&str] = &["main", "waveform"];
+
+/// Recompute the activation policy from the currently-visible windows. Cheap
+/// and idempotent — safe to call on every window focus/close/destroy event.
+#[cfg(target_os = "macos")]
+pub fn refresh(app: &tauri::AppHandle) {
+    use tauri::{ActivationPolicy, Manager};
+
+    let has_real_window = app.webview_windows().iter().any(|(label, win)| {
+        !UTILITY_WINDOWS.contains(&label.as_str()) && win.is_visible().unwrap_or(false)
+    });
+
+    let policy = if has_real_window {
+        ActivationPolicy::Regular
+    } else {
+        ActivationPolicy::Accessory
+    };
+
+    if let Err(e) = app.set_activation_policy(policy) {
+        eprintln!("Failed to set activation policy: {e}");
+    }
+}
+
+/// No-op on non-macOS platforms; the Dock / Stage Manager have no equivalent.
+#[cfg(not(target_os = "macos"))]
+pub fn refresh(_app: &tauri::AppHandle) {}

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,6 +1,7 @@
 // Prevents additional console window on Windows in release
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
+mod activation;
 mod audio_capture;
 mod commands;
 mod meeting_notifications;
@@ -220,6 +221,9 @@ fn main() {
                 if let tauri::WindowEvent::CloseRequested { api, .. } = event {
                     api.prevent_close();
                     let _ = settings_clone.hide();
+                    // Settings hides rather than closes, so the global
+                    // Destroyed hook never fires — demote here once it's gone.
+                    activation::refresh(&settings_clone.app_handle());
                 }
             });
 
@@ -276,14 +280,29 @@ fn main() {
         .build(tauri::generate_context!())
         .expect("error while running tauri application")
         .run(|_app, _event| {
-            // macOS: clicking the Dock icon re-activates the app (Reopen).
-            // Surface the meetings window — every other window is a hidden
-            // utility (bootstrap, settings) or transient (recorder pill).
             #[cfg(target_os = "macos")]
-            if let tauri::RunEvent::Reopen { .. } = _event {
-                if let Err(e) = commands::open_library_window(_app) {
-                    eprintln!("Failed to open meetings window on dock reopen: {e}");
+            match &_event {
+                // Clicking the Dock icon re-activates the app (Reopen).
+                // Surface the meetings window — every other window is a hidden
+                // utility (bootstrap, settings) or transient (recorder pill).
+                tauri::RunEvent::Reopen { .. } => {
+                    if let Err(e) = commands::open_library_window(_app) {
+                        eprintln!("Failed to open meetings window on dock reopen: {e}");
+                    }
                 }
+                // Keep the Dock / Stage Manager presence in sync with the
+                // visible windows: promote to Regular while a real window is up,
+                // demote to Accessory once they're all gone. Focused covers
+                // show()/set_focus(); Destroyed covers transient closes.
+                tauri::RunEvent::WindowEvent { event, .. } => {
+                    if matches!(
+                        event,
+                        tauri::WindowEvent::Focused(_) | tauri::WindowEvent::Destroyed
+                    ) {
+                        activation::refresh(_app);
+                    }
+                }
+                _ => {}
             }
         });
 }


### PR DESCRIPTION
## Problem
Oats doesn't appear in the macOS Stage Manager strip, unlike other apps.

## Cause
The app runs as an `LSUIElement` (Accessory) app so it stays menu-bar-only with no Dock icon. macOS Stage Manager only lists apps with the `Regular` activation policy, which always carries a Dock icon — so an Accessory app is excluded.

## Fix
Track the activation policy against visible windows:
- **Regular** (Dock icon + Stage Manager) while any real window is open
- **Accessory** (menu-bar-only) once all are closed

The hidden bootstrap window (`main`) and the always-on-top recorder pill (`waveform`) don't count. New `activation.rs` recomputes the policy on window `Focused`/`Destroyed` (global run-event hook) and when Settings hides.

Manually tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS app behavior when toggling window visibility and focus states to ensure proper system-level window management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->