### PR TITLE
doc: add Homebrew install instructions with tap-trust step

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,21 @@ You decide where the work happens:
 
 > **Requires Apple Silicon (M-series) and macOS 14 or later.**
 
+### 🍺 Homebrew
+
+```bash
+# Add the tap (the cask lives in this repo, so point Homebrew at it directly)
+brew tap ariso-ai/oats https://github.com/ariso-ai/oats
+
+# Trust the cask, then install
+brew trust --cask ariso-ai/oats/oats
+brew install --cask oats
+```
+
+> Homebrew 6.0 introduced [tap trust](https://docs.brew.sh/Tap-Trust): third-party taps must be explicitly trusted before they install. The `brew trust` step grants that once — without it you'll see `Refusing to load cask … from untrusted tap`.
+
+### 📦 Direct download
+
 1. Download the latest `oats.dmg` from the [**Releases page**](https://github.com/ariso-ai/oats/releases/latest).
 2. Open the DMG and drag **oats** into your Applications folder.
 3. Launch it from Applications. oats lives in your menu bar — look for the <img src="src/assets/oats-dark.png" alt="oats icon" width="16" height="16" valign="middle" /> icon.


### PR DESCRIPTION
## What

Adds a **🍺 Homebrew** subsection to the README Install section documenting the full install flow:

```bash
brew tap ariso-ai/oats https://github.com/ariso-ai/oats
brew trust --cask ariso-ai/oats/oats
brew install --cask oats
```

## Why

A user hit:

```
Error: Refusing to load cask ariso-ai/oats/oats from untrusted tap ariso-ai/oats.
```

This is not a defect in our cask. [Homebrew 6.0.0](https://docs.brew.sh/Tap-Trust) (June 2026) added **tap trust**, which now requires every third-party tap to be explicitly trusted before Homebrew evaluates its Ruby. Our cask lives in this repo (`Casks/oats.rb`) tapped via a custom remote, so users must `brew tap` it by URL and `brew trust` it once before installing.

## Notes

- Reordered the section so Homebrew comes first, with Direct download (DMG) below — both kept.
- Verified locally: per-cask trust resolves the error and `brew info --cask oats` loads cleanly afterward.
- Longer-term, submitting to official homebrew-cask would drop the `brew trust` step, but our `version :latest` + `sha256 :no_check` cask isn't eligible as-is. Out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Homebrew installation method to the installation guide, including steps for adding the tap, trusting the cask, and installing via Homebrew, with relevant explanatory notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->