### PR TITLE
Local-backend generation progress + retry

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -737,6 +737,27 @@ pub fn list_local_recordings() -> Result<Vec<crate::storage::RecordingSummary>, 
     crate::storage::list_recordings(&root)
 }
 
+/// Lightweight status for a single local recording, used by the detail panel's
+/// generation poller. Reads only that recording's `meta.json` and probes its
+/// two artifact files, deriving the AI-notes state the list summary omits.
+#[tauri::command]
+pub fn local_recording_status(
+    id: String,
+) -> Result<crate::storage::RecordingStatusView, String> {
+    crate::storage::validate_recording_id(&id)?;
+    let dir = recording_dir(&id)?;
+    let meta = crate::storage::read_meta(&dir)?;
+    let has_note = dir.join("ari-note.md").is_file();
+    let has_transcript = dir.join("transcript.md").is_file();
+    let notes_status = crate::storage::derive_notes_status(has_note, meta.notes_error.as_deref());
+    Ok(crate::storage::RecordingStatusView {
+        status: meta.status,
+        has_transcript,
+        has_note,
+        notes_status,
+    })
+}
+
 /// Buffer a stopped Ariso recording's mp3 + metadata on disk before the upload
 /// attempt, keyed by its ISO `created_at`. Returns the sanitized id.
 #[tauri::command]
@@ -1354,6 +1375,57 @@ mod tests {
         unsafe {
             std::env::remove_var("ARISO_ROOT");
         }
+    }
+
+    #[test]
+    fn local_recording_status_reports_derived_notes_status() {
+        // SAFETY: command tests run with --test-threads=1 (see plan conventions),
+        // so the process-wide ARISO_ROOT mutation below has no concurrent writer.
+        let tmp = tempfile::tempdir().unwrap();
+        unsafe { std::env::set_var("ARISO_ROOT", tmp.path()); }
+
+        let id = "2026-06-02T14-30-05Z";
+        let dir = crate::storage::create_recording_dir(tmp.path(), id).unwrap();
+        let mut meta = crate::storage::RecordingMeta {
+            id: id.into(),
+            title: "T".into(),
+            created_at: "2026-06-02T14:30:05Z".into(),
+            duration_seconds: 5,
+            status: crate::storage::RecordingStatus::Done,
+            language: None,
+            participants: vec![],
+            model_version: None,
+            error: None,
+            notes_error: None,
+        };
+        crate::storage::write_meta(&dir, &meta).unwrap();
+        std::fs::write(dir.join("transcript.md"), b"t").unwrap();
+
+        // Transcript present, note absent, no error -> notes pending.
+        let view = local_recording_status(id.to_string()).unwrap();
+        assert_eq!(view.status, crate::storage::RecordingStatus::Done);
+        assert!(view.has_transcript);
+        assert!(!view.has_note);
+        assert_eq!(view.notes_status, crate::storage::NotesStatus::Pending);
+
+        // Record a notes failure -> notes failed.
+        meta.notes_error = Some("boom".into());
+        crate::storage::write_meta(&dir, &meta).unwrap();
+        let view = local_recording_status(id.to_string()).unwrap();
+        assert_eq!(view.notes_status, crate::storage::NotesStatus::Failed);
+
+        // Write the note file -> notes ready (note presence wins over the error).
+        std::fs::write(dir.join("ari-note.md"), b"n").unwrap();
+        let view = local_recording_status(id.to_string()).unwrap();
+        assert!(view.has_note);
+        assert_eq!(view.notes_status, crate::storage::NotesStatus::Ready);
+
+        unsafe { std::env::remove_var("ARISO_ROOT"); }
+    }
+
+    #[test]
+    fn local_recording_status_rejects_bad_id() {
+        assert!(local_recording_status("../escape".to_string()).is_err());
     }
 }
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -110,6 +110,7 @@ fn main() {
             commands::put_presigned,
             commands::get_desktop_config,
             commands::list_local_recordings,
+            commands::local_recording_status,
             commands::create_library_window,
             commands::get_active_recording_meeting_id,
             commands::read_recording_audio,

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -128,6 +128,8 @@ fn main() {
             commands::fetch_meeting_audio,
             commands::share_text_native,
             transcribe::local_finalize_recording,
+            transcribe::retry_local_transcription,
+            transcribe::retry_local_notes,
             model_manager::local_model_status,
             model_manager::download_local_stt,
             model_manager::download_local_llm,

--- a/src-tauri/src/storage.rs
+++ b/src-tauri/src/storage.rs
@@ -16,6 +16,31 @@ pub enum RecordingStatus {
     Failed,
 }
 
+/// AI-notes generation state, derived from on-disk artifacts. Notes run as a
+/// best-effort background task after the transcript completes, so the
+/// recording's own `RecordingStatus` stays `Done` regardless; this captures
+/// whether the note itself succeeded, is still pending, or failed.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub enum NotesStatus {
+    Pending,
+    Ready,
+    Failed,
+}
+
+/// Classify AI-notes generation from the note file's presence and any recorded
+/// `notes_error`. A present `ari-note.md` always means success (a stale error
+/// from a prior attempt is ignored).
+pub fn derive_notes_status(has_note: bool, notes_error: Option<&str>) -> NotesStatus {
+    if has_note {
+        NotesStatus::Ready
+    } else if notes_error.is_some() {
+        NotesStatus::Failed
+    } else {
+        NotesStatus::Pending
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct Participant {
     pub id: u32,
@@ -64,6 +89,18 @@ pub struct RecordingSummary {
     pub has_note: bool,
     /// Whether `transcript.md` exists in the recording's directory.
     pub has_transcript: bool,
+}
+
+/// Lightweight per-recording status for the detail panel's generation poller.
+/// Cheaper than `list_recordings` (no directory scan) and carries the derived
+/// `notes_status` the list summary omits.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct RecordingStatusView {
+    pub status: RecordingStatus,
+    pub has_transcript: bool,
+    pub has_note: bool,
+    pub notes_status: NotesStatus,
 }
 
 /// Metadata persisted next to a buffered pending upload (`<id>.json`), so a
@@ -263,6 +300,22 @@ pub fn format_hms(secs: f64) -> String {
     let m = (total % 3600) / 60;
     let s = total % 60;
     format!("{h:02}:{m:02}:{s:02}")
+}
+
+/// Reject recording ids that could escape the recordings dir. Ids are normally
+/// sanitized timestamps (e.g. `2026-06-02T14-30-05Z`); this mirrors the guard
+/// in `commands::recording_dir` so retry/status commands can validate ids that
+/// arrive from the frontend.
+pub fn validate_recording_id(id: &str) -> Result<(), String> {
+    if id.is_empty()
+        || id.contains('/')
+        || id.contains('\\')
+        || id.contains(':')
+        || id.contains("..")
+    {
+        return Err(format!("invalid recording id: {id}"));
+    }
+    Ok(())
 }
 
 pub fn create_recording_dir(root: &Path, id: &str) -> Result<PathBuf, String> {
@@ -659,6 +712,37 @@ mod tests {
         write_pending_audio(root, &pmeta("2026-06-12T09:00:00Z"), b"toolong").unwrap();
         let keys = vec!["2026-06-12T09:00:00Z".to_string()];
         assert!(combine_pending_audio(root, &keys, 3).is_err());
+    }
+
+    #[test]
+    fn derive_notes_status_ready_when_note_present() {
+        assert_eq!(derive_notes_status(true, None), NotesStatus::Ready);
+        // A present note wins even if a stale error lingers.
+        assert_eq!(derive_notes_status(true, Some("boom")), NotesStatus::Ready);
+    }
+
+    #[test]
+    fn derive_notes_status_failed_when_error_and_no_note() {
+        assert_eq!(derive_notes_status(false, Some("boom")), NotesStatus::Failed);
+    }
+
+    #[test]
+    fn derive_notes_status_pending_when_no_note_no_error() {
+        assert_eq!(derive_notes_status(false, None), NotesStatus::Pending);
+    }
+
+    #[test]
+    fn validate_recording_id_accepts_sanitized_timestamp() {
+        assert!(validate_recording_id("2026-06-02T14-30-05Z").is_ok());
+    }
+
+    #[test]
+    fn validate_recording_id_rejects_traversal() {
+        assert!(validate_recording_id("").is_err());
+        assert!(validate_recording_id("../etc").is_err());
+        assert!(validate_recording_id("a/b").is_err());
+        assert!(validate_recording_id("a\\b").is_err());
+        assert!(validate_recording_id("C:foo").is_err());
     }
 
     #[test]

--- a/src-tauri/src/transcribe.rs
+++ b/src-tauri/src/transcribe.rs
@@ -200,6 +200,61 @@ pub async fn finalize_core(
     }
 }
 
+/// Re-run the full pipeline (transcription + notes) for an existing recording,
+/// reusing its saved `recording.mp3`. `finalize_core` derives the recording's
+/// dir from `created_at`, which equals the existing folder id, so it rewrites
+/// in place and resets `status`/`error`/`notes_error`. Returns the result plus
+/// the detached notes `JoinHandle` (tests await it; the command drops it).
+pub async fn retry_transcription_core(
+    root: &Path,
+    id: &str,
+) -> Result<(FinalizeResult, JoinHandle<()>), String> {
+    storage::validate_recording_id(id)?;
+    let dir = storage::recordings_dir(root).join(id);
+    let meta = storage::read_meta(&dir)?;
+    let audio = std::fs::read(dir.join("recording.mp3"))
+        .map_err(|e| format!("read recording audio: {e}"))?;
+    finalize_core(root, audio, meta.title, meta.created_at, meta.duration_seconds).await
+}
+
+/// Regenerate AI notes for a recording from its existing `transcript.md`,
+/// without re-running STT. Clears any prior `notes_error` first so the poller
+/// sees a "pending" state immediately, then spawns `process_notes` detached
+/// (it writes `ari-note.md` or a fresh `notes_error`). Returns the handle so
+/// tests can await completion; the command drops it.
+pub async fn retry_notes_core(root: &Path, id: &str) -> Result<JoinHandle<()>, String> {
+    storage::validate_recording_id(id)?;
+    let dir = storage::recordings_dir(root).join(id);
+    if !dir.join("transcript.md").is_file() {
+        return Err("no transcript available to generate notes".to_string());
+    }
+    let mut meta = storage::read_meta(&dir)?;
+    meta.notes_error = None;
+    storage::write_meta(&dir, &meta)?;
+    let models = storage::models_dir(root);
+    Ok(tokio::spawn(process_notes(dir, models, meta)))
+}
+
+/// Retry transcription (and notes) for a failed local recording.
+#[tauri::command]
+pub async fn retry_local_transcription(id: String) -> Result<FinalizeResult, String> {
+    let root = storage::ariso_root()?;
+    // Drop the notes JoinHandle: notes are best-effort and write their outcome
+    // to meta.json directly, matching `local_finalize_recording`.
+    retry_transcription_core(&root, &id)
+        .await
+        .map(|(res, _notes)| res)
+}
+
+/// Retry only AI-notes generation for a recording whose transcript exists.
+#[tauri::command]
+pub async fn retry_local_notes(id: String) -> Result<(), String> {
+    let root = storage::ariso_root()?;
+    // Drop the JoinHandle: the detached task writes its outcome to disk; the
+    // frontend observes completion via `local_recording_status` polling.
+    retry_notes_core(&root, &id).await.map(|_handle| ())
+}
+
 #[tauri::command]
 pub async fn local_finalize_recording(
     audio: Vec<u8>,
@@ -364,5 +419,110 @@ mod tests {
         let meta = crate::storage::read_meta(&dir).unwrap();
         assert_eq!(meta.status, RecordingStatus::Done);
         assert!(meta.notes_error.is_some());
+    }
+
+    #[tokio::test]
+    async fn retry_transcription_reruns_failed_recording_to_done() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        // Seed a previously-failed recording: audio on disk, meta=failed.
+        let id = "2026-06-02T14-30-05Z";
+        let dir = storage::create_recording_dir(root, id).unwrap();
+        std::fs::write(dir.join("recording.mp3"), b"audio").unwrap();
+        let meta = RecordingMeta {
+            id: id.into(),
+            title: "T".into(),
+            created_at: "2026-06-02T14:30:05Z".into(),
+            duration_seconds: 5,
+            status: RecordingStatus::Failed,
+            language: None,
+            participants: vec![],
+            model_version: None,
+            error: Some("old failure".into()),
+            notes_error: None,
+        };
+        storage::write_meta(&dir, &meta).unwrap();
+
+        // Stub: notes subcommand prints markdown; otherwise transcript JSON.
+        let json = r#"{"language":"en","durationSeconds":5.0,"participants":[{"id":0,"label":"Speaker 1"}],"segments":[{"speaker":0,"text":"hi","start":0.0,"end":1.0}]}"#;
+        let body = format!(
+            "if [ \"$1\" = notes ]; then echo '# Notes'; exit 0; fi\ncat <<'EOF'\n{json}\nEOF"
+        );
+        let stub = write_stub(tmp.path(), &body);
+        unsafe { std::env::set_var("ARISO_STT_BIN", &stub); }
+
+        let (res, notes_handle) = retry_transcription_core(root, id).await.unwrap();
+        notes_handle.await.unwrap();
+        unsafe { std::env::remove_var("ARISO_STT_BIN"); }
+
+        assert_eq!(res.status, RecordingStatus::Done);
+        assert!(dir.join("transcript.md").exists());
+        let meta = read_meta(&dir).unwrap();
+        assert_eq!(meta.status, RecordingStatus::Done);
+        assert!(meta.error.is_none(), "prior transcription error must be cleared");
+    }
+
+    #[tokio::test]
+    async fn retry_transcription_errors_when_audio_missing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        let id = "2026-06-02T14-30-05Z";
+        let dir = storage::create_recording_dir(root, id).unwrap();
+        // meta but no recording.mp3
+        let meta = RecordingMeta {
+            id: id.into(), title: "T".into(), created_at: "2026-06-02T14:30:05Z".into(),
+            duration_seconds: 5, status: RecordingStatus::Failed, language: None,
+            participants: vec![], model_version: None, error: None, notes_error: None,
+        };
+        storage::write_meta(&dir, &meta).unwrap();
+
+        let err = retry_transcription_core(root, id).await.unwrap_err();
+        assert!(err.contains("recording audio"), "got: {err}");
+    }
+
+    #[tokio::test]
+    async fn retry_notes_regenerates_from_existing_transcript() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        let id = "2026-06-02T14-30-05Z";
+        let dir = storage::create_recording_dir(root, id).unwrap();
+        std::fs::write(dir.join("transcript.md"), b"# Transcript\nhi").unwrap();
+        let meta = RecordingMeta {
+            id: id.into(), title: "T".into(), created_at: "2026-06-02T14:30:05Z".into(),
+            duration_seconds: 5, status: RecordingStatus::Done, language: None,
+            participants: vec![], model_version: None, error: None,
+            notes_error: Some("prior notes failure".into()),
+        };
+        storage::write_meta(&dir, &meta).unwrap();
+
+        // Stub: notes subcommand succeeds.
+        let body = "if [ \"$1\" = notes ]; then echo '# Notes'; echo '- point'; exit 0; fi\nexit 1";
+        let stub = write_stub(tmp.path(), body);
+        unsafe { std::env::set_var("ARISO_STT_BIN", &stub); }
+
+        let handle = retry_notes_core(root, id).await.unwrap();
+        handle.await.unwrap();
+        unsafe { std::env::remove_var("ARISO_STT_BIN"); }
+
+        let notes = std::fs::read_to_string(dir.join("ari-note.md")).unwrap();
+        assert!(notes.contains("# Notes"), "got: {notes}");
+        assert!(read_meta(&dir).unwrap().notes_error.is_none(), "notes_error must be cleared");
+    }
+
+    #[tokio::test]
+    async fn retry_notes_errors_without_transcript() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        let id = "2026-06-02T14-30-05Z";
+        let dir = storage::create_recording_dir(root, id).unwrap();
+        let meta = RecordingMeta {
+            id: id.into(), title: "T".into(), created_at: "2026-06-02T14:30:05Z".into(),
+            duration_seconds: 5, status: RecordingStatus::Done, language: None,
+            participants: vec![], model_version: None, error: None, notes_error: None,
+        };
+        storage::write_meta(&dir, &meta).unwrap();
+
+        let err = retry_notes_core(root, id).await.unwrap_err();
+        assert!(err.contains("transcript"), "got: {err}");
     }
 }

--- a/src-tauri/src/transcribe.rs
+++ b/src-tauri/src/transcribe.rs
@@ -212,6 +212,13 @@ pub async fn retry_transcription_core(
     storage::validate_recording_id(id)?;
     let dir = storage::recordings_dir(root).join(id);
     let meta = storage::read_meta(&dir)?;
+    let derived_id = storage::sanitize_iso_to_id(&meta.created_at);
+    if meta.id != id || derived_id != id {
+        return Err(format!(
+            "recording metadata/id mismatch: requested={id}, meta.id={}, derived={derived_id}",
+            meta.id
+        ));
+    }
     let audio = std::fs::read(dir.join("recording.mp3"))
         .map_err(|e| format!("read recording audio: {e}"))?;
     finalize_core(root, audio, meta.title, meta.created_at, meta.duration_seconds).await

--- a/src/composables/useLocalRecordingProgress.test.ts
+++ b/src/composables/useLocalRecordingProgress.test.ts
@@ -1,0 +1,128 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const recordingStatus = vi.fn();
+const retryTranscription = vi.fn();
+const retryNotes = vi.fn();
+
+vi.mock('../tauri', () => ({
+  local: {
+    recordingStatus: (id: string) => recordingStatus(id),
+    retryTranscription: (id: string) => retryTranscription(id),
+    retryNotes: (id: string) => retryNotes(id),
+  },
+}));
+
+import { deriveStage, useLocalRecordingProgress } from './useLocalRecordingProgress';
+import type { RecordingStatusView } from '../tauri';
+
+function view(over: Partial<RecordingStatusView> = {}): RecordingStatusView {
+  return { status: 'done', hasTranscript: false, hasNote: false, notesStatus: 'pending', ...over };
+}
+
+describe('deriveStage', () => {
+  it('returns idle for null', () => {
+    expect(deriveStage(null)).toBe('idle');
+  });
+  it('maps recording/transcribing to transcribing', () => {
+    expect(deriveStage(view({ status: 'recording' }))).toBe('transcribing');
+    expect(deriveStage(view({ status: 'transcribing' }))).toBe('transcribing');
+  });
+  it('maps failed status to transcript-failed', () => {
+    expect(deriveStage(view({ status: 'failed' }))).toBe('transcript-failed');
+  });
+  it('maps done+notes pending to notes-pending', () => {
+    expect(deriveStage(view({ status: 'done', hasTranscript: true, notesStatus: 'pending' }))).toBe('notes-pending');
+  });
+  it('maps done+notes failed to notes-failed', () => {
+    expect(deriveStage(view({ status: 'done', hasTranscript: true, notesStatus: 'failed' }))).toBe('notes-failed');
+  });
+  it('maps done+note ready to ready', () => {
+    expect(deriveStage(view({ status: 'done', hasTranscript: true, hasNote: true, notesStatus: 'ready' }))).toBe('ready');
+  });
+});
+
+describe('useLocalRecordingProgress polling', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('polls until terminal and exposes the derived stage', async () => {
+    recordingStatus
+      .mockResolvedValueOnce(view({ status: 'transcribing' }))
+      .mockResolvedValueOnce(view({ status: 'done', hasTranscript: true, notesStatus: 'pending' }))
+      .mockResolvedValueOnce(view({ status: 'done', hasTranscript: true, hasNote: true, notesStatus: 'ready' }));
+
+    const p = useLocalRecordingProgress(() => 'rec-1');
+    p.begin();
+
+    await vi.advanceTimersByTimeAsync(0);
+    expect(p.stage.value).toBe('transcribing');
+
+    await vi.advanceTimersByTimeAsync(2000);
+    expect(p.stage.value).toBe('notes-pending');
+    expect(p.hasTranscript.value).toBe(true);
+
+    await vi.advanceTimersByTimeAsync(2000);
+    expect(p.stage.value).toBe('ready');
+    expect(p.hasNote.value).toBe(true);
+
+    // Terminal: no further polls scheduled.
+    const calls = recordingStatus.mock.calls.length;
+    await vi.advanceTimersByTimeAsync(4000);
+    expect(recordingStatus.mock.calls.length).toBe(calls);
+  });
+
+  it('stops polling at a failed stage', async () => {
+    recordingStatus.mockResolvedValue(view({ status: 'failed' }));
+    const p = useLocalRecordingProgress(() => 'rec-1');
+    p.begin();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(p.stage.value).toBe('transcript-failed');
+    const calls = recordingStatus.mock.calls.length;
+    await vi.advanceTimersByTimeAsync(4000);
+    expect(recordingStatus.mock.calls.length).toBe(calls);
+  });
+
+  it('retryTranscription optimistically shows transcribing, calls the binding, and resumes polling', async () => {
+    recordingStatus.mockResolvedValue(view({ status: 'transcribing' }));
+    retryTranscription.mockResolvedValue({ backend: 'local', id: 'rec-1', title: 'T', status: 'done' });
+    const p = useLocalRecordingProgress(() => 'rec-1');
+
+    void p.retryTranscription();
+    // Optimistic state is set synchronously before any await resolves.
+    expect(p.stage.value).toBe('transcribing');
+    await vi.advanceTimersByTimeAsync(0);
+    expect(retryTranscription).toHaveBeenCalledWith('rec-1');
+    expect(recordingStatus).toHaveBeenCalledWith('rec-1');
+  });
+
+  it('retryNotes optimistically shows notes-pending and calls the binding', async () => {
+    recordingStatus.mockResolvedValue(view({ status: 'done', hasTranscript: true, notesStatus: 'pending' }));
+    retryNotes.mockResolvedValue(undefined);
+    const p = useLocalRecordingProgress(() => 'rec-1');
+
+    void p.retryNotes();
+    expect(p.stage.value).toBe('notes-pending');
+    await vi.advanceTimersByTimeAsync(0);
+    expect(retryNotes).toHaveBeenCalledWith('rec-1');
+  });
+
+  it('reset clears state and stops polling', async () => {
+    recordingStatus.mockResolvedValue(view({ status: 'transcribing' }));
+    const p = useLocalRecordingProgress(() => 'rec-1');
+    p.begin();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(p.stage.value).toBe('transcribing');
+
+    p.reset();
+    expect(p.stage.value).toBe('idle');
+    const calls = recordingStatus.mock.calls.length;
+    await vi.advanceTimersByTimeAsync(4000);
+    expect(recordingStatus.mock.calls.length).toBe(calls);
+  });
+});

--- a/src/composables/useLocalRecordingProgress.test.ts
+++ b/src/composables/useLocalRecordingProgress.test.ts
@@ -112,6 +112,29 @@ describe('useLocalRecordingProgress polling', () => {
     expect(retryNotes).toHaveBeenCalledWith('rec-1');
   });
 
+  it('does not poll until the retry binding resolves (no stale-terminal regression)', async () => {
+    let resolveRetry: (() => void) | null = null;
+    retryTranscription.mockImplementation(
+      () => new Promise<void>((resolve) => { resolveRetry = () => resolve(); })
+    );
+    // If a poll DID run before the retry resolved, it would read this terminal view.
+    recordingStatus.mockResolvedValue(view({ status: 'failed' }));
+
+    const p = useLocalRecordingProgress(() => 'rec-1');
+    void p.retryTranscription();
+
+    // Optimistic stage is shown and no poll has happened while the RPC is in flight.
+    expect(p.stage.value).toBe('transcribing');
+    await vi.advanceTimersByTimeAsync(2000);
+    expect(recordingStatus).not.toHaveBeenCalled();
+    expect(p.stage.value).toBe('transcribing');
+
+    // Once the RPC resolves, polling starts.
+    resolveRetry!();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(recordingStatus).toHaveBeenCalledWith('rec-1');
+  });
+
   it('reset clears state and stops polling', async () => {
     recordingStatus.mockResolvedValue(view({ status: 'transcribing' }));
     const p = useLocalRecordingProgress(() => 'rec-1');

--- a/src/composables/useLocalRecordingProgress.ts
+++ b/src/composables/useLocalRecordingProgress.ts
@@ -66,17 +66,25 @@ export function useLocalRecordingProgress(getId: () => string | null): LocalReco
   async function loop(my: number): Promise<void> {
     const id = getId();
     if (!id || my !== token) return;
+    let shouldContinue = false;
     try {
       const s = await local.recordingStatus(id);
       if (my !== token) return;
       status.value = s;
+      shouldContinue = stage.value === 'transcribing' || stage.value === 'notes-pending';
     } catch (e) {
       if (my !== token) return;
       console.error('local recording status poll failed', e);
+      // Keep retrying if we don't have an initial snapshot yet, so a transient
+      // error doesn't permanently hide in-flight generation progress.
+      shouldContinue =
+        status.value == null ||
+        stage.value === 'transcribing' ||
+        stage.value === 'notes-pending';
     }
     if (my !== token) return;
     // Keep polling only while there is still work in flight.
-    if (stage.value === 'transcribing' || stage.value === 'notes-pending') {
+    if (shouldContinue) {
       timer = setTimeout(() => void loop(my), POLL_MS);
     }
   }

--- a/src/composables/useLocalRecordingProgress.ts
+++ b/src/composables/useLocalRecordingProgress.ts
@@ -1,0 +1,136 @@
+import { ref, computed, onUnmounted, type Ref, type ComputedRef } from 'vue';
+import { local, type RecordingStatusView } from '../tauri';
+
+/** Stages of the local generation pipeline, surfaced to the detail panel. */
+export type LocalProgressStage =
+  | 'idle'
+  | 'transcribing'
+  | 'transcript-failed'
+  | 'notes-pending'
+  | 'notes-failed'
+  | 'ready';
+
+/** Derive the UI stage from a recording's status view. A present note ('ready')
+ *  always wins; a `failed` recording status means transcription failed. */
+export function deriveStage(s: RecordingStatusView | null): LocalProgressStage {
+  if (!s) return 'idle';
+  if (s.status === 'failed') return 'transcript-failed';
+  if (s.status === 'recording' || s.status === 'transcribing') return 'transcribing';
+  // status === 'done'
+  if (s.hasNote || s.notesStatus === 'ready') return 'ready';
+  if (s.notesStatus === 'failed') return 'notes-failed';
+  return 'notes-pending';
+}
+
+const POLL_MS = 2000;
+
+export interface LocalRecordingProgress {
+  status: Ref<RecordingStatusView | null>;
+  stage: ComputedRef<LocalProgressStage>;
+  hasTranscript: ComputedRef<boolean>;
+  hasNote: ComputedRef<boolean>;
+  retrying: Ref<boolean>;
+  /** Start (or restart) polling for the current id. */
+  begin: () => void;
+  /** Stop polling and clear status (used when switching away / to non-local). */
+  reset: () => void;
+  /** Stop polling, keeping the last status. */
+  stop: () => void;
+  retryTranscription: () => Promise<void>;
+  retryNotes: () => Promise<void>;
+}
+
+/**
+ * Polls `local.recordingStatus(id)` every 2s while the recording is still
+ * generating (transcribing or notes-pending) and stops at any terminal stage
+ * (ready / failed). `getId` is read on each tick so the caller can repoint it.
+ * Retries set an optimistic status, resume polling, then fire the binding.
+ */
+export function useLocalRecordingProgress(getId: () => string | null): LocalRecordingProgress {
+  const status = ref<RecordingStatusView | null>(null);
+  const retrying = ref(false);
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  let token = 0;
+
+  const stage = computed(() => deriveStage(status.value));
+  const hasTranscript = computed(() => !!status.value?.hasTranscript);
+  const hasNote = computed(() => !!status.value?.hasNote);
+
+  function clearTimer(): void {
+    if (timer) {
+      clearTimeout(timer);
+      timer = null;
+    }
+  }
+
+  async function loop(my: number): Promise<void> {
+    const id = getId();
+    if (!id || my !== token) return;
+    try {
+      const s = await local.recordingStatus(id);
+      if (my !== token) return;
+      status.value = s;
+    } catch (e) {
+      if (my !== token) return;
+      console.error('local recording status poll failed', e);
+    }
+    if (my !== token) return;
+    // Keep polling only while there is still work in flight.
+    if (stage.value === 'transcribing' || stage.value === 'notes-pending') {
+      timer = setTimeout(() => void loop(my), POLL_MS);
+    }
+  }
+
+  function begin(): void {
+    clearTimer();
+    const my = ++token;
+    void loop(my);
+  }
+
+  function reset(): void {
+    token++;
+    clearTimer();
+    status.value = null;
+  }
+
+  function stop(): void {
+    token++;
+    clearTimer();
+  }
+
+  async function retryTranscription(): Promise<void> {
+    const id = getId();
+    if (!id || retrying.value) return;
+    retrying.value = true;
+    // Optimistic: show "Generating Transcript" immediately, before the (long)
+    // command awaits STT. Polling independently observes completion.
+    status.value = { status: 'transcribing', hasTranscript: false, hasNote: false, notesStatus: 'pending' };
+    begin();
+    try {
+      await local.retryTranscription(id);
+    } catch (e) {
+      console.error('retry transcription failed', e);
+    } finally {
+      retrying.value = false;
+    }
+  }
+
+  async function retryNotes(): Promise<void> {
+    const id = getId();
+    if (!id || retrying.value) return;
+    retrying.value = true;
+    status.value = { status: 'done', hasTranscript: true, hasNote: false, notesStatus: 'pending' };
+    begin();
+    try {
+      await local.retryNotes(id);
+    } catch (e) {
+      console.error('retry notes failed', e);
+    } finally {
+      retrying.value = false;
+    }
+  }
+
+  onUnmounted(stop);
+
+  return { status, stage, hasTranscript, hasNote, retrying, begin, reset, stop, retryTranscription, retryNotes };
+}

--- a/src/composables/useLocalRecordingProgress.ts
+++ b/src/composables/useLocalRecordingProgress.ts
@@ -102,10 +102,10 @@ export function useLocalRecordingProgress(getId: () => string | null): LocalReco
     const id = getId();
     if (!id || retrying.value) return;
     retrying.value = true;
-    // Optimistic: show "Generating Transcript" immediately, before the (long)
-    // command awaits STT. Polling independently observes completion.
+    // Optimistic: show "Generating Transcript" immediately. Poll only AFTER the
+    // retry RPC resolves — until then the backend still reports the prior
+    // terminal state, and a poll would clobber the optimistic stage and stop.
     status.value = { status: 'transcribing', hasTranscript: false, hasNote: false, notesStatus: 'pending' };
-    begin();
     try {
       await local.retryTranscription(id);
     } catch (e) {
@@ -113,14 +113,17 @@ export function useLocalRecordingProgress(getId: () => string | null): LocalReco
     } finally {
       retrying.value = false;
     }
+    begin();
   }
 
   async function retryNotes(): Promise<void> {
     const id = getId();
     if (!id || retrying.value) return;
     retrying.value = true;
+    // Optimistic: show "Generating AI Notes" immediately. Poll only AFTER the
+    // retry RPC resolves (it clears notes_error), so the first poll reflects the
+    // regenerating state instead of the prior failure.
     status.value = { status: 'done', hasTranscript: true, hasNote: false, notesStatus: 'pending' };
-    begin();
     try {
       await local.retryNotes(id);
     } catch (e) {
@@ -128,6 +131,7 @@ export function useLocalRecordingProgress(getId: () => string | null): LocalReco
     } finally {
       retrying.value = false;
     }
+    begin();
   }
 
   onUnmounted(stop);

--- a/src/tauri.ts
+++ b/src/tauri.ts
@@ -174,6 +174,17 @@ export interface RecordingSummary {
   hasTranscript: boolean;
 }
 
+export type NotesStatus = 'pending' | 'ready' | 'failed';
+
+/** Mirrors the Rust `RecordingStatusView`. Drives the detail panel's local
+ *  generation poller (tab enable/disable + the inline status chip). */
+export interface RecordingStatusView {
+  status: RecordingSummary['status'];
+  hasTranscript: boolean;
+  hasNote: boolean;
+  notesStatus: NotesStatus;
+}
+
 export interface LocalFinalizeResult {
   backend: 'local';
   id: string;
@@ -204,6 +215,18 @@ export const local = {
   },
   listRecordings(): Promise<RecordingSummary[]> {
     return invoke<RecordingSummary[]>('list_local_recordings');
+  },
+  /** Cheap single-recording status for the detail panel's generation poller. */
+  recordingStatus(id: string): Promise<RecordingStatusView> {
+    return invoke<RecordingStatusView>('local_recording_status', { id });
+  },
+  /** Re-run transcription (and notes) for a failed recording from saved audio. */
+  retryTranscription(id: string): Promise<LocalFinalizeResult> {
+    return invoke<LocalFinalizeResult>('retry_local_transcription', { id });
+  },
+  /** Regenerate AI notes from the existing transcript (no STT re-run). */
+  retryNotes(id: string): Promise<void> {
+    return invoke('retry_local_notes', { id });
   },
   readRecordingAudio(id: string): Promise<ArrayBuffer> {
     return invoke<ArrayBuffer>('read_recording_audio', { id });

--- a/src/views/MeetingDetailView.test.ts
+++ b/src/views/MeetingDetailView.test.ts
@@ -12,6 +12,10 @@ const notesCanEdit = vi.fn(() => false);
 const loadNote = vi.fn();
 const saveNote = vi.fn();
 const shareTextNative = vi.fn();
+const recordingStatus = vi.fn();
+const readRecordingFile = vi.fn();
+const retryTranscription = vi.fn();
+const retryNotes = vi.fn();
 
 vi.mock('../composables/useBackend', () => ({
   getActiveBackend: () => activeBackend(),
@@ -29,6 +33,12 @@ vi.mock('../tauri', () => ({
   shareTextNative: (text: string, anchor: unknown) => shareTextNative(text, anchor),
   getDesktopConfig: () =>
     Promise.resolve({ webAppBaseUrl: 'https://app.test', pusherKey: '', pusherCluster: '' }),
+  local: {
+    recordingStatus: (id: string) => recordingStatus(id),
+    readRecordingFile: (id: string, kind: string) => readRecordingFile(id, kind),
+    retryTranscription: (id: string) => retryTranscription(id),
+    retryNotes: (id: string) => retryNotes(id),
+  },
 }));
 
 import MeetingDetailView from './MeetingDetailView.vue';
@@ -68,6 +78,15 @@ beforeEach(() => {
   notesCanEdit.mockReturnValue(false);
   loadNote.mockResolvedValue({ content: '', title: '' });
   saveNote.mockResolvedValue(undefined);
+  recordingStatus.mockResolvedValue({
+    status: 'done',
+    hasTranscript: false,
+    hasNote: false,
+    notesStatus: 'ready',
+  });
+  readRecordingFile.mockResolvedValue(null);
+  retryTranscription.mockResolvedValue({ backend: 'local', id: '7', title: 'T', status: 'done' });
+  retryNotes.mockResolvedValue(undefined);
 });
 
 describe('MeetingDetailView inline title editing', () => {
@@ -548,5 +567,98 @@ describe('MeetingDetailView AI Assessment tab', () => {
     const wrapper = await mountWith(detail({ score: 3, rationale: 'Mixed' }));
     expect(wrapper.find('.score-circle').isVisible()).toBe(true);
     expect(wrapper.find('.score-circle').text()).toBe('3');
+  });
+});
+
+describe('MeetingDetailView local generation progress', () => {
+  const localItem: MeetingListItem = {
+    id: '7',
+    title: 'Rec',
+    timestamp: '2026-06-02T10:00:00Z',
+    files: { hasAudio: true, hasNote: false, hasTranscript: false },
+  };
+
+  async function mountLocal(d: MeetingDetail) {
+    getMeetingDetail.mockResolvedValue(d);
+    const wrapper = mount(MeetingDetailView, { props: { item: localItem } });
+    await flushPromises();
+    return wrapper;
+  }
+
+  it('shows AI Notes + Transcript buttons (disabled) while transcribing, with a "Generating Transcript" chip', async () => {
+    recordingStatus.mockResolvedValue({
+      status: 'transcribing', hasTranscript: false, hasNote: false, notesStatus: 'pending',
+    });
+    const wrapper = await mountLocal(detail({ isLocal: true }));
+
+    const labels = wrapper.findAll('.seg-btn').map((b) => b.text());
+    expect(labels).toContain('AI Notes');
+    expect(labels).toContain('Transcript');
+
+    const aiNotes = wrapper.findAll('.seg-btn').find((b) => b.text() === 'AI Notes')!;
+    const transcript = wrapper.findAll('.seg-btn').find((b) => b.text() === 'Transcript')!;
+    expect(aiNotes.attributes('disabled')).toBeDefined();
+    expect(transcript.attributes('disabled')).toBeDefined();
+
+    expect(wrapper.find('.tab-status-label').text()).toBe('Generating Transcript');
+    expect(wrapper.find('.tab-status .spinner').exists()).toBe(true);
+    expect(wrapper.find('.tab-retry').exists()).toBe(false);
+  });
+
+  it('shows "Generating AI Notes" with the Transcript tab enabled once the transcript is ready', async () => {
+    recordingStatus.mockResolvedValue({
+      status: 'done', hasTranscript: true, hasNote: false, notesStatus: 'pending',
+    });
+    readRecordingFile.mockResolvedValue('# Transcript\nhi');
+    const wrapper = await mountLocal(detail({ isLocal: true }));
+    await flushPromises();
+
+    const transcript = wrapper.findAll('.seg-btn').find((b) => b.text() === 'Transcript')!;
+    expect(transcript.attributes('disabled')).toBeUndefined();
+    const aiNotes = wrapper.findAll('.seg-btn').find((b) => b.text() === 'AI Notes')!;
+    expect(aiNotes.attributes('disabled')).toBeDefined();
+    expect(wrapper.find('.tab-status-label').text()).toBe('Generating AI Notes');
+  });
+
+  it('shows a Retry button on AI-notes failure and calls retryNotes', async () => {
+    recordingStatus.mockResolvedValue({
+      status: 'done', hasTranscript: true, hasNote: false, notesStatus: 'failed',
+    });
+    const wrapper = await mountLocal(detail({ isLocal: true, hasTranscript: true }));
+    await flushPromises();
+
+    expect(wrapper.find('.tab-status-label').text()).toBe('AI Notes failed');
+    const retry = wrapper.find('.tab-retry');
+    expect(retry.exists()).toBe(true);
+
+    await retry.trigger('click');
+    await flushPromises();
+    expect(retryNotes).toHaveBeenCalledWith('7');
+  });
+
+  it('shows a Retry button on transcript failure and calls retryTranscription', async () => {
+    recordingStatus.mockResolvedValue({
+      status: 'failed', hasTranscript: false, hasNote: false, notesStatus: 'pending',
+    });
+    const wrapper = await mountLocal(detail({ isLocal: true }));
+    await flushPromises();
+
+    expect(wrapper.find('.tab-status-label').text()).toBe('Transcript failed');
+    await wrapper.find('.tab-retry').trigger('click');
+    await flushPromises();
+    expect(retryTranscription).toHaveBeenCalledWith('7');
+  });
+
+  it('hides the chip and enables both tabs once notes are ready', async () => {
+    recordingStatus.mockResolvedValue({
+      status: 'done', hasTranscript: true, hasNote: true, notesStatus: 'ready',
+    });
+    readRecordingFile.mockResolvedValue('AI body');
+    const wrapper = await mountLocal(detail({ isLocal: true, note: 'AI body', hasTranscript: true }));
+    await flushPromises();
+
+    expect(wrapper.find('.tab-status').exists()).toBe(false);
+    const aiNotes = wrapper.findAll('.seg-btn').find((b) => b.text() === 'AI Notes')!;
+    expect(aiNotes.attributes('disabled')).toBeUndefined();
   });
 });

--- a/src/views/MeetingDetailView.vue
+++ b/src/views/MeetingDetailView.vue
@@ -89,7 +89,7 @@
 
       <div v-else class="divider" />
 
-      <!-- Tabs + Chat -->
+      <!-- Tabs + generation status -->
       <div v-if="availableTabs.length" class="card-tabs">
         <div class="segment">
           <button
@@ -98,10 +98,23 @@
             class="seg-btn"
             :class="{ 'seg-btn--active': activeTab === t.key }"
             type="button"
-            @click="activeTab = t.key"
+            :disabled="t.disabled"
+            @click="t.disabled || (activeTab = t.key)"
           >{{ t.label }}</button>
         </div>
-        <!-- add chat with meeting button later -->
+        <div v-if="showStatusChip" class="tab-status">
+          <span v-if="statusGenerating" class="spinner spinner--sm" />
+          <span class="tab-status-label" :class="{ 'tab-status-label--err': !statusGenerating }">
+            {{ statusLabel }}
+          </span>
+          <button
+            v-if="!statusGenerating"
+            class="tab-retry"
+            type="button"
+            :disabled="progress.retrying.value"
+            @click="onRetry"
+          >Retry</button>
+        </div>
       </div>
 
       <!-- Content -->
@@ -260,7 +273,8 @@ import MeetingNotesEditor from './MeetingNotesEditor.vue';
 import RecordingAudioPlayer from './RecordingAudioPlayer.vue';
 import ShareMeetingPopover from './ShareMeetingPopover.vue';
 import { composeLocalShareText } from './meetingShareText';
-import { shareTextNative } from '../tauri';
+import { shareTextNative, local } from '../tauri';
+import { useLocalRecordingProgress } from '../composables/useLocalRecordingProgress';
 
 const props = defineProps<{ item: MeetingListItem | null }>();
 const emit = defineEmits<{
@@ -378,6 +392,71 @@ const notesPlaceholder = computed(() =>
 // the other backend.
 let detailBackend: Backend | null = null;
 
+// Local recordings generate their transcript + AI notes asynchronously after
+// recording stops. This poller drives the inline status chip and tab enabling.
+const progress = useLocalRecordingProgress(() => (detail.value?.isLocal ? detail.value.id : null));
+
+const showStatusChip = computed(
+  () =>
+    !!detail.value?.isLocal &&
+    ['transcribing', 'notes-pending', 'transcript-failed', 'notes-failed'].includes(progress.stage.value)
+);
+const statusGenerating = computed(
+  () => progress.stage.value === 'transcribing' || progress.stage.value === 'notes-pending'
+);
+const statusLabel = computed(() => {
+  switch (progress.stage.value) {
+    case 'transcribing':
+      return 'Generating Transcript';
+    case 'notes-pending':
+      return 'Generating AI Notes';
+    case 'transcript-failed':
+      return 'Transcript failed';
+    case 'notes-failed':
+      return 'AI Notes failed';
+    default:
+      return '';
+  }
+});
+function onRetry(): void {
+  if (progress.stage.value === 'transcript-failed') void progress.retryTranscription();
+  else if (progress.stage.value === 'notes-failed') void progress.retryNotes();
+}
+
+// When the poller reports a newly-ready artifact, read it into `detail` so the
+// now-enabled tab renders its content. Guarded by reqId so a meeting switch
+// mid-read drops the stale result.
+async function reloadLocalArtifact(kind: 'note' | 'transcript'): Promise<void> {
+  const d = detail.value;
+  if (!d?.isLocal) return;
+  const my = reqId;
+  try {
+    const text = await local.readRecordingFile(d.id, kind);
+    if (my !== reqId || !detail.value) return;
+    if (kind === 'transcript') {
+      detail.value.transcript = text ?? undefined;
+      detail.value.hasTranscript = !!text;
+    } else {
+      detail.value.note = text ?? undefined;
+    }
+  } catch (e) {
+    console.error('reload local artifact failed', e);
+  }
+}
+
+watch(
+  () => progress.hasTranscript.value,
+  (now, prev) => {
+    if (now && !prev && detail.value?.isLocal) void reloadLocalArtifact('transcript');
+  }
+);
+watch(
+  () => progress.hasNote.value,
+  (now, prev) => {
+    if (now && !prev && detail.value?.isLocal) void reloadLocalArtifact('note');
+  }
+);
+
 // Lazy audio loader pinned to the backend that loaded the detail (a Settings
 // backend flip mid-view must not route the fetch through the other backend).
 function loadAudio(): Promise<ArrayBuffer | null> {
@@ -403,6 +482,7 @@ async function load(item: MeetingListItem | null): Promise<void> {
   transcript.value = null;
   transcriptLoaded.value = false;
   loadingTranscript.value = false;
+  progress.reset();
   individualNote.value = null;
   individualNoteLoaded.value = false;
   loadingIndividualNote.value = false;
@@ -430,6 +510,7 @@ async function load(item: MeetingListItem | null): Promise<void> {
     if (activeTab.value === 'mynote') {
       await loadIndividualNote();
     }
+    if (d.isLocal) progress.begin();
   } catch (e) {
     if (my !== reqId) return;
     console.error('Failed to load meeting detail', e);
@@ -574,14 +655,25 @@ function firstTabFor(d: MeetingDetail, item: MeetingListItem): 'note' | 'transcr
   return 'note';
 }
 
-// Tabs appear only when their content exists: AI Notes (generated/shared
-// meeting notes), Transcript, My Notes (the user's editable note), then
-// AI Assessment (score, rationale, coaching) when the meeting has one.
-const availableTabs = computed<{ key: 'note' | 'transcript' | 'mynote' | 'assessment'; label: string }[]>(() => {
+// Tabs appear when their content exists. For local recordings the AI Notes and
+// Transcript tabs are always present (disabled until their content is ready) so
+// the row stays stable while generation runs; the inline status chip reports
+// progress. Ariso meetings keep the content-gated behavior.
+const availableTabs = computed<
+  { key: 'note' | 'transcript' | 'mynote' | 'assessment'; label: string; disabled?: boolean }[]
+>(() => {
   const d = detail.value;
   if (!d) return [];
-  const out: { key: 'note' | 'transcript' | 'mynote' | 'assessment'; label: string }[] = [];
-  if (notesPresent(d)) out.push({ key: 'note', label: "AI Notes" });
+  const out: { key: 'note' | 'transcript' | 'mynote' | 'assessment'; label: string; disabled?: boolean }[] = [];
+  if (d.isLocal) {
+    out.push({ key: 'note', label: 'AI Notes', disabled: !d.note });
+    out.push({ key: 'transcript', label: 'Transcript', disabled: !d.hasTranscript });
+    if ((props.item && notesPersistence.canEdit(props.item)) || d.hasIndividualNote) {
+      out.push({ key: 'mynote', label: 'My Notes' });
+    }
+    return out;
+  }
+  if (notesPresent(d)) out.push({ key: 'note', label: 'AI Notes' });
   if (d.hasTranscript) out.push({ key: 'transcript', label: 'Transcript' });
   if ((props.item && notesPersistence.canEdit(props.item)) || d.hasIndividualNote) {
     out.push({ key: 'mynote', label: 'My Notes' });
@@ -899,6 +991,17 @@ const durationLabel = computed<string | null>(() => {
   font-family: inherit; font-size: 14px; font-weight: 600; cursor: pointer; white-space: nowrap;
 }
 .btn-chat:hover { background: #1a1a1a; }
+.tab-status { margin-left: auto; display: flex; align-items: center; gap: 8px; font-size: 13px; color: #6f6f6f; }
+.tab-status-label { white-space: nowrap; }
+.tab-status-label--err { color: #dc2626; }
+.tab-retry {
+  height: 28px; padding: 0 12px;
+  background: #fff; border: 1px solid #d6d6d6; border-radius: 8px; box-shadow: 2px 2px 0 #e7e5e2;
+  font-family: inherit; font-size: 13px; font-weight: 600; color: #1a1a1a; cursor: pointer;
+}
+.tab-retry:hover:not(:disabled) { background: #fbfbfb; }
+.tab-retry:disabled { opacity: 0.6; cursor: default; }
+.spinner--sm { width: 14px; height: 14px; }
 
 /* Content */
 .card-content { flex: 1; min-height: 0; overflow-y: auto; padding: 8px 24px 24px; }


### PR DESCRIPTION
## Summary
- Local recordings now keep the **AI Notes** and **Transcript** tab buttons visible in the detail panel after recording finishes (disabled until ready), with a right-aligned inline status chip: **Generating Transcript** → **Generating AI Notes**, and **X failed + Retry** on failure.
- Tabs enable as each artifact lands; a frontend poller (`useLocalRecordingProgress`) drives it via a new cheap `local_recording_status` command (no Rust events exist).
- Failed-stage-only retry: transcript failure re-runs STT+notes from saved audio; notes failure regenerates notes from the existing transcript (`retry_local_transcription` / `retry_local_notes`).

## Test Plan
- [x] Rust suite: `cargo test ... -- --test-threads=1` (119 pass)
- [x] Frontend: `npm test` (327 pass; 7 failures pre-existing in LibraryView/UpdateView, untouched by this branch)
- [x] `npm run vite:build` passes
- [ ] Manual: record locally, open mid-generation, watch chip transition + tabs enable; exercise a failure → Retry

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added retry flows for failed local transcription and AI notes generation
  * Introduced per-recording progress polling with live status indicators (transcribing, notes pending, ready, and failure states)
  * Added an on-screen status chip with contextual “Retry” actions and automatic polling resume after retries
  * Updated meeting detail tabs to remain visible while disabling/enabling transcript and AI Notes based on generated content
* **Tests**
  * Added unit/component coverage for progress derivation, polling behavior, retries, and invalid recording IDs
<!-- end of auto-generated comment: release notes by coderabbit.ai -->