### PR TITLE
chore: update release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   release-please:
-    runs-on: [self-hosted, macOS, ARM64]
+    runs-on: macos-15
     permissions:
       contents: write
       pull-requests: write
@@ -51,7 +51,7 @@ jobs:
   sync-lock:
     needs: release-please
     if: ${{ needs.release-please.outputs.prs_created == 'true' }}
-    runs-on: [self-hosted, macOS, ARM64]
+    runs-on: macos-15
     permissions:
       contents: write
     steps:
@@ -224,7 +224,7 @@ jobs:
   publish:
     name: Generate manifest and publish artifacts to R2
     needs: [release-please, release]
-    runs-on: [self-hosted, macOS, ARM64]
+    runs-on: macos-15
     # The R2 credentials live in the `release` environment alongside the Apple
     # signing secrets (see README → Signing & Notarization).
     environment: release


### PR DESCRIPTION
<!--
Thanks for contributing to oats! A few quick things before you open this PR.
See CONTRIBUTING.md for the full guide.
-->

## What does this PR do?

<!-- A short summary of the change and the problem it solves. Link any related issue, e.g. "Closes #123". -->

## Type of change
- [x] `docs:` / `chore:` / `refactor:` — no user-facing release

## How was this tested?

<!-- Did you run the frontend tests (`npm test`)? Test manually with which backend (Ariso / Local)? On what macOS version? -->

## Screenshots / recordings

<!-- For any UI change, drop a before/after screenshot or short clip here. -->

## Checklist

- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I ran `npm test` and the suite passes
- [x] I tested the change in the app (note which backend above)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD infrastructure to use GitHub-hosted runners instead of self-hosted resources, improving workflow reliability and maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->