### PR TITLE
Regenerate notes button on the AI Notes tab (local)

### DIFF
--- a/src-tauri/src/transcribe.rs
+++ b/src-tauri/src/transcribe.rs
@@ -225,10 +225,17 @@ pub async fn retry_transcription_core(
 }
 
 /// Regenerate AI notes for a recording from its existing `transcript.md`,
-/// without re-running STT. Clears any prior `notes_error` first so the poller
-/// sees a "pending" state immediately, then spawns `process_notes` detached
-/// (it writes `ari-note.md` or a fresh `notes_error`). Returns the handle so
-/// tests can await completion; the command drops it.
+/// without re-running STT. Clears any prior `notes_error` and removes any
+/// existing `ari-note.md` first — readiness is signaled by that file's
+/// presence, so leaving a stale note in place would make the poller report the
+/// recording as "ready" the instant polling resumes, finishing the regeneration
+/// silently in the background. Removing it makes the regeneration observable
+/// (`hasNote` false → generating → true when the new note lands). Then spawns
+/// `process_notes` detached (it writes `ari-note.md` or a fresh `notes_error`).
+/// Returns the handle so tests can await completion; the command drops it.
+///
+/// Trade-off: a failed regeneration leaves the recording note-less (surfaced as
+/// "AI Notes failed" with a Retry), since the prior note is not restored.
 pub async fn retry_notes_core(root: &Path, id: &str) -> Result<JoinHandle<()>, String> {
     storage::validate_recording_id(id)?;
     let dir = storage::recordings_dir(root).join(id);
@@ -238,6 +245,13 @@ pub async fn retry_notes_core(root: &Path, id: &str) -> Result<JoinHandle<()>, S
     let mut meta = storage::read_meta(&dir)?;
     meta.notes_error = None;
     storage::write_meta(&dir, &meta)?;
+    // Clear the stale note so regeneration is observable (see doc comment).
+    // A missing file is fine — only surface real removal errors.
+    match std::fs::remove_file(dir.join("ari-note.md")) {
+        Ok(()) => {}
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+        Err(e) => return Err(format!("remove stale note: {e}")),
+    }
     let models = storage::models_dir(root);
     Ok(tokio::spawn(process_notes(dir, models, meta)))
 }
@@ -514,6 +528,43 @@ mod tests {
         let notes = std::fs::read_to_string(dir.join("ari-note.md")).unwrap();
         assert!(notes.contains("# Notes"), "got: {notes}");
         assert!(read_meta(&dir).unwrap().notes_error.is_none(), "notes_error must be cleared");
+    }
+
+    #[tokio::test]
+    async fn retry_notes_removes_stale_note_so_regeneration_is_observable() {
+        // Regenerate precondition: a note already exists. The readiness signal is
+        // `ari-note.md`'s presence, so retry must remove the stale note up front —
+        // otherwise the poller would instantly report the old note as "ready" and
+        // the regeneration would finish in the background, never surfacing.
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        let id = "2026-06-02T14-30-05Z";
+        let dir = storage::create_recording_dir(root, id).unwrap();
+        std::fs::write(dir.join("transcript.md"), b"# Transcript\nhi").unwrap();
+        std::fs::write(dir.join("ari-note.md"), b"# Old note").unwrap();
+        let meta = RecordingMeta {
+            id: id.into(), title: "T".into(), created_at: "2026-06-02T14:30:05Z".into(),
+            duration_seconds: 5, status: RecordingStatus::Done, language: None,
+            participants: vec![], model_version: None, error: None, notes_error: None,
+        };
+        storage::write_meta(&dir, &meta).unwrap();
+
+        // Notes regeneration fails: with the stale note cleared up front, the
+        // recording is observably note-less afterwards (rather than still showing
+        // the old note), which is what lets the poller track regeneration.
+        let body = "if [ \"$1\" = notes ]; then echo 'boom' >&2; exit 1; fi\nexit 1";
+        let stub = write_stub(tmp.path(), body);
+        unsafe { std::env::set_var("ARISO_STT_BIN", &stub); }
+
+        let handle = retry_notes_core(root, id).await.unwrap();
+        handle.await.unwrap();
+        unsafe { std::env::remove_var("ARISO_STT_BIN"); }
+
+        assert!(
+            !dir.join("ari-note.md").exists(),
+            "stale note must be removed so regeneration is observable"
+        );
+        assert!(read_meta(&dir).unwrap().notes_error.is_some());
     }
 
     #[tokio::test]

--- a/src/views/MeetingDetailView.test.ts
+++ b/src/views/MeetingDetailView.test.ts
@@ -661,4 +661,48 @@ describe('MeetingDetailView local generation progress', () => {
     const aiNotes = wrapper.findAll('.seg-btn').find((b) => b.text() === 'AI Notes')!;
     expect(aiNotes.attributes('disabled')).toBeUndefined();
   });
+
+  it('shows a Regenerate notes button when local AI Notes are ready and clicking it calls retryNotes', async () => {
+    recordingStatus.mockResolvedValue({
+      status: 'done', hasTranscript: true, hasNote: true, notesStatus: 'ready',
+    });
+    readRecordingFile.mockResolvedValue('AI body');
+    const wrapper = await mountLocal(detail({ isLocal: true, note: 'AI body', hasTranscript: true }));
+    await flushPromises();
+
+    // AI Notes is the default active tab (note present), so the button shows.
+    const regen = wrapper.find('.tab-regen');
+    expect(regen.exists()).toBe(true);
+    expect(regen.text()).toContain('Regenerate notes');
+
+    await regen.trigger('click');
+    await flushPromises();
+    expect(retryNotes).toHaveBeenCalledWith('7');
+  });
+
+  it('does not show the Regenerate notes button when no AI note exists yet', async () => {
+    recordingStatus.mockResolvedValue({
+      status: 'done', hasTranscript: true, hasNote: false, notesStatus: 'pending',
+    });
+    const wrapper = await mountLocal(detail({ isLocal: true, hasTranscript: true }));
+    await flushPromises();
+    expect(wrapper.find('.tab-regen').exists()).toBe(false);
+  });
+
+  it('does not show the Regenerate notes button for an Ariso meeting', async () => {
+    const wrapper = await mountLocal(detail({ isLocal: false, digest: 'A digest' }));
+    await flushPromises();
+    expect(wrapper.find('.tab-regen').exists()).toBe(false);
+  });
+
+  it('hides the Regenerate notes button while notes are regenerating, showing the chip instead', async () => {
+    recordingStatus.mockResolvedValue({
+      status: 'done', hasTranscript: true, hasNote: false, notesStatus: 'pending',
+    });
+    const wrapper = await mountLocal(detail({ isLocal: true, note: 'Old body', hasTranscript: true }));
+    await flushPromises();
+    // A note exists (old body) but notes are generating -> chip owns the row.
+    expect(wrapper.find('.tab-status-label').text()).toBe('Generating AI Notes');
+    expect(wrapper.find('.tab-regen').exists()).toBe(false);
+  });
 });

--- a/src/views/MeetingDetailView.vue
+++ b/src/views/MeetingDetailView.vue
@@ -115,6 +115,16 @@
             @click="onRetry"
           >Retry</button>
         </div>
+        <button
+          v-if="showRegenerate"
+          class="tab-regen"
+          type="button"
+          title="Regenerate AI Notes from the transcript"
+          @click="onRegenerate"
+        >
+          <svg viewBox="0 0 24 24" class="ic"><path d="M21 12a9 9 0 1 1-2.64-6.36" /><path d="M21 3v6h-6" /></svg>
+          Regenerate notes
+        </button>
       </div>
 
       <!-- Content -->
@@ -421,6 +431,22 @@ const statusLabel = computed(() => {
 function onRetry(): void {
   if (progress.stage.value === 'transcript-failed') void progress.retryTranscription();
   else if (progress.stage.value === 'notes-failed') void progress.retryNotes();
+}
+
+// Local AI Notes can be regenerated from the transcript on demand. Shown only on
+// the AI Notes tab once a note already exists and nothing is in flight (the
+// status chip owns the row's right slot while generating/failed). Clicking
+// reuses the notes-retry path, which re-runs generation from transcript.md.
+const showRegenerate = computed(
+  () =>
+    !!detail.value?.isLocal &&
+    activeTab.value === 'note' &&
+    !!detail.value?.note &&
+    !!detail.value?.hasTranscript &&
+    !showStatusChip.value
+);
+function onRegenerate(): void {
+  void progress.retryNotes();
 }
 
 // When the poller reports a newly-ready artifact, read it into `detail` so the
@@ -1002,6 +1028,14 @@ const durationLabel = computed<string | null>(() => {
 .tab-retry:hover:not(:disabled) { background: #fbfbfb; }
 .tab-retry:disabled { opacity: 0.6; cursor: default; }
 .spinner--sm { width: 14px; height: 14px; }
+.tab-regen {
+  margin-left: auto; display: inline-flex; align-items: center; gap: 6px;
+  height: 28px; padding: 0 12px;
+  background: #fff; border: 1px solid #d6d6d6; border-radius: 8px; box-shadow: 2px 2px 0 #e7e5e2;
+  font-family: inherit; font-size: 13px; font-weight: 600; color: #1a1a1a; cursor: pointer;
+}
+.tab-regen:hover { background: #fbfbfb; }
+.tab-regen .ic { width: 15px; height: 15px; }
 
 /* Content */
 .card-content { flex: 1; min-height: 0; overflow-y: auto; padding: 8px 24px 24px; }


### PR DESCRIPTION

<img width="896" height="595" alt="Screenshot 2026-06-17 at 23 56 01" src="https://github.com/user-attachments/assets/9cc360de-4a63-47ee-bcca-f038a84fc77f" />


## Summary
- On the local backend, when the **AI Notes** tab is active and a note already exists, a right-aligned **⟳ Regenerate notes** button appears on the same row as the AI Notes / Transcript / My Notes tabs.
- Clicking it regenerates the AI Notes from the existing transcript (reuses the `retry_local_notes` path added in #100). While running, the existing "Generating AI Notes" chip takes the row's right slot (button hidden); the refreshed note loads in when done.

## Test Plan
- [x] `npx vitest run src/views/MeetingDetailView.test.ts` (40 pass; 4 new)
- [x] `npm run vite:build` passes
- [x] Manual: local recording with notes → AI Notes tab → click Regenerate → chip shows, note refreshes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "Regenerate notes" button for local meetings with existing AI notes. Users can now regenerate meeting notes directly from the meeting interface. The button is hidden for non-local meetings or while regeneration is in progress.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->