### PR TITLE
fix: show Play button for local recordings in Transcript tab

### DIFF
--- a/src/views/MeetingDetailView.test.ts
+++ b/src/views/MeetingDetailView.test.ts
@@ -493,12 +493,20 @@ describe('MeetingDetailView audio player', () => {
     expect(wrapper.find('.card-audio .play-btn').exists()).toBe(true);
   });
 
-  it('does not show the audio player for a local recording, even in the Transcript tab', async () => {
+  it('shows the audio player for a local recording in the Transcript tab, like Ariso', async () => {
+    getMeetingAudio.mockResolvedValue(new ArrayBuffer(4));
     const wrapper = await mountWith(detail({ isLocal: true, note: 'hi', hasTranscript: true }));
     const transcriptTab = wrapper.findAll('.seg-btn').find((b) => b.text() === 'Transcript');
     await transcriptTab!.trigger('click');
     await flushPromises();
-    expect(wrapper.find('.card-audio').exists()).toBe(false);
+    expect(wrapper.find('.card-audio .play-btn').exists()).toBe(true);
+
+    // Play routes through the same backend.getMeetingAudio path as Ariso (local
+    // reads read_recording_audio off disk).
+    await wrapper.find('.card-audio .play-btn').trigger('click');
+    await flushPromises();
+    expect(getMeetingAudio).toHaveBeenCalledWith(item);
+    expect(wrapper.find('.card-audio audio').exists()).toBe(true);
   });
 
   it('clicking Play fetches audio through the backend that loaded the detail', async () => {

--- a/src/views/MeetingDetailView.vue
+++ b/src/views/MeetingDetailView.vue
@@ -195,11 +195,14 @@
         </div>
 
         <div v-show="activeTab === 'transcript'" class="tab-pane">
-          <!-- Ariso audio playback sits right under the tabs, surfaced only while the
-               Transcript tab is active (and never for local recordings, whose audio
-               stays on disk); keyed by meeting id so switching selection remounts the
-               player instead of leaking the previous blob URL. -->
-          <div v-if="activeTab === 'transcript' && !detail.isLocal" class="card-audio">
+          <!-- Audio playback sits right under the tabs, surfaced only while the
+               Transcript tab is active; keyed by meeting id so switching selection
+               remounts the player instead of leaking the previous blob URL. Both
+               backends resolve their bytes lazily through loadAudio -> the backend's
+               getMeetingAudio (Ariso fetches /meeting-notes/{id}/audio, local reads
+               read_recording_audio off disk), and the player shows "No audio" when
+               that resolves to null. -->
+          <div v-if="activeTab === 'transcript'" class="card-audio">
             <RecordingAudioPlayer :key="detail.id" :load="loadAudio" />
           </div>
 


### PR DESCRIPTION
## Summary

When using the **local backend**, the Transcript tab now renders the same audio **Play** button as the **Ariso** backend.

The button (`RecordingAudioPlayer`) was gated by `!detail.isLocal` in `MeetingDetailView.vue`, so it only ever showed for Ariso meetings. The rest of the wiring was already backend-agnostic:

- `loadAudio()` delegates to the loading backend's `getMeetingAudio()`.
- `LocalBackend.getMeetingAudio()` already reads the recording's bytes off disk via `read_recording_audio`, returning `null` when `files.hasAudio` is false.
- `RecordingAudioPlayer` already handles a `null` result by showing a disabled **"▶ No audio"** state.

So the only thing suppressing the local Play button was that one condition (plus a now-stale comment). This PR drops the `isLocal` guard and refreshes the comment.

## Changes

- `src/views/MeetingDetailView.vue` — remove `&& !detail.isLocal` from the audio block's `v-if`; update the explanatory comment to cover both backends.
- `src/views/MeetingDetailView.test.ts` — replace the test asserting the old suppressed behavior with one asserting the player now renders for local recordings and that Play routes through `backend.getMeetingAudio`.

## Verification

- `npm run vite:build` — builds clean
- `MeetingDetailView.test.ts` — 36/36 pass

Pre-existing, unrelated failures remain in `LibraryView.test.ts` and `UpdateView.test.ts` (they fail on `main` too); this change adds no net-new failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Audio player functionality is now enabled for local recordings in the Transcript tab. Users can play back local meeting audio directly while reviewing the transcript, providing an integrated experience for simultaneously reviewing both audio and text content. Previously, the audio player was unavailable for local recordings in this tab.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->