### PR TITLE
fix: show Google avatar in Settings account row

### DIFF
--- a/src/views/SettingsView.test.ts
+++ b/src/views/SettingsView.test.ts
@@ -9,6 +9,15 @@ const hasPromptedLocalModels = vi.fn(() => Promise.resolve(false));
 const setPromptedLocalModels = vi.fn((_v: unknown) => Promise.resolve());
 const downloadStt = vi.fn(() => Promise.resolve());
 const downloadLlm = vi.fn(() => Promise.resolve());
+const checkSession = vi.fn((): Promise<unknown> => Promise.resolve(null));
+const apiRequest = vi.fn(
+  (
+    _method: string,
+    _path: string,
+    _body?: unknown
+  ): Promise<{ status: number; data: unknown }> =>
+    Promise.resolve({ status: 200, data: {} })
+);
 
 // Capture event listeners by name so tests can fire them.
 const listeners = new Map<string, (e: { payload: unknown }) => void>();
@@ -25,11 +34,14 @@ vi.mock('@tauri-apps/api/event', () => ({
 vi.mock('../tauri', () => ({
   AUTH_SIGNED_IN_EVENT: 'auth://signed-in',
   auth: {
-    checkSession: () => Promise.resolve(null),
+    checkSession: () => checkSession(),
     googleSignIn: vi.fn(),
     signOut: vi.fn(),
   },
-  api: { request: vi.fn(() => Promise.resolve({ status: 200, data: {} })) },
+  api: {
+    request: (method: string, path: string, body?: unknown) =>
+      apiRequest(method, path, body),
+  },
   updater: {
     getState: () =>
       Promise.resolve({
@@ -82,6 +94,12 @@ beforeEach(() => {
   vi.clearAllMocks();
   listeners.clear();
   getAllWebviewWindows.mockResolvedValue([]);
+  // clearAllMocks keeps the last-set implementation, so restore the signed-out
+  // defaults for every test; the avatar suite overrides these explicitly.
+  checkSession.mockResolvedValue(null);
+  apiRequest.mockImplementation(() =>
+    Promise.resolve({ status: 200, data: {} })
+  );
 });
 
 function fireRecordingState(active: boolean) {
@@ -225,5 +243,113 @@ describe('SettingsView first-time local models prompt', () => {
 
     expect(wrapper.find('.download-confirm').exists()).toBe(false);
     expect(downloadStt).not.toHaveBeenCalled();
+  });
+});
+
+describe('SettingsView account avatar', () => {
+  // The component preloads the avatar through a detached `new Image()` before
+  // binding it to the <img>. Stub Image so tests control load success/failure.
+  let imageShouldFail = false;
+  class FakeImage {
+    referrerPolicy = '';
+    onload: (() => void) | null = null;
+    onerror: (() => void) | null = null;
+    set src(_v: string) {
+      queueMicrotask(() => {
+        if (imageShouldFail) this.onerror?.();
+        else this.onload?.();
+      });
+    }
+  }
+  beforeEach(() => {
+    imageShouldFail = false;
+    vi.stubGlobal('Image', FakeImage);
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  // Sign the user in and route the two profile calls fetchUserProfile makes.
+  function mockSignedIn(avatar: string | null) {
+    checkSession.mockResolvedValue({ token: 'session' });
+    apiRequest.mockImplementation((_method: string, path: string) => {
+      if (path === '/auth/me') {
+        return Promise.resolve({
+          status: 200,
+          data: { full_name: 'Ada Lovelace', email: 'ada@example.com' },
+        });
+      }
+      if (path === '/users/google-avatar') {
+        return Promise.resolve({
+          status: 200,
+          data: { avatar, connected: avatar != null },
+        });
+      }
+      return Promise.resolve({ status: 200, data: {} });
+    });
+  }
+
+  it('renders the Google avatar image when one is available', async () => {
+    mockSignedIn('https://lh3.googleusercontent.com/a/photo.png');
+    const wrapper = mount(SettingsView);
+    await flushPromises();
+
+    const img = wrapper.find('img.avatar');
+    expect(img.exists()).toBe(true);
+    expect(img.attributes('src')).toBe(
+      'https://lh3.googleusercontent.com/a/photo.png'
+    );
+    // The initials circle should not also render.
+    expect(wrapper.find('div.avatar').exists()).toBe(false);
+  });
+
+  it('falls back to the initials circle when there is no Google avatar', async () => {
+    mockSignedIn(null);
+    const wrapper = mount(SettingsView);
+    await flushPromises();
+
+    expect(wrapper.find('img.avatar').exists()).toBe(false);
+    const initialsCircle = wrapper.find('div.avatar');
+    expect(initialsCircle.exists()).toBe(true);
+    expect(initialsCircle.text()).toBe('AD');
+  });
+
+  it('still shows initials when the avatar request fails', async () => {
+    checkSession.mockResolvedValue({ token: 'session' });
+    apiRequest.mockImplementation((_method: string, path: string) => {
+      if (path === '/auth/me') {
+        return Promise.resolve({
+          status: 200,
+          data: { full_name: 'Ada Lovelace', email: 'ada@example.com' },
+        });
+      }
+      if (path === '/users/google-avatar') {
+        return Promise.reject(new Error('network'));
+      }
+      return Promise.resolve({ status: 200, data: {} });
+    });
+    const wrapper = mount(SettingsView);
+    await flushPromises();
+
+    expect(wrapper.find('img.avatar').exists()).toBe(false);
+    expect(wrapper.find('div.avatar').text()).toBe('AD');
+    // The avatar failure must not wipe out the name/email that loaded first.
+    expect(wrapper.text()).toContain('Ada Lovelace');
+    expect(wrapper.text()).toContain('ada@example.com');
+  });
+
+  it('falls back to initials when the avatar image never loads', async () => {
+    imageShouldFail = true;
+    mockSignedIn('https://lh3.googleusercontent.com/a/photo.png');
+    vi.useFakeTimers();
+    try {
+      const wrapper = mount(SettingsView);
+      // Drives onMounted, the profile fetch, and the preload retry backoff.
+      await vi.runAllTimersAsync();
+      expect(wrapper.find('img.avatar').exists()).toBe(false);
+      expect(wrapper.find('div.avatar').text()).toBe('AD');
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/src/views/SettingsView.vue
+++ b/src/views/SettingsView.vue
@@ -143,7 +143,15 @@
       <h2 class="section-title">Account</h2>
       <div class="card">
         <div v-if="isSignedIn" class="account-info">
-          <div class="avatar">{{ initials }}</div>
+          <img
+            v-if="avatarUrl"
+            class="avatar"
+            :src="avatarUrl"
+            :alt="displayName || email"
+            referrerpolicy="no-referrer"
+            @error="avatarUrl = ''"
+          />
+          <div v-else class="avatar">{{ initials }}</div>
           <div class="account-details">
             <span class="account-name">{{ displayName }}</span>
             <span class="account-email">{{ email }}</span>
@@ -346,6 +354,7 @@ const isSigningIn = ref(false);
 const errorMessage = ref('');
 const displayName = ref('');
 const email = ref('');
+const avatarUrl = ref('');
 const micEnabled = ref(true);
 const systemAudioEnabled = ref(true);
 const autoRecordEnabled = ref(true);
@@ -722,6 +731,44 @@ async function fetchUserProfile() {
   } catch {
     // profile fetch failed — leave fields empty
   }
+  // Avatar is fetched separately and is non-critical: a failure here must not
+  // disturb the name/email above, and the UI falls back to initials.
+  try {
+    const res = await api.request('GET', '/users/google-avatar');
+    const data = res.data as { avatar?: string | null };
+    // Preload before binding to the <img>: WKWebView drops the very first
+    // request for a freshly-rendered <img> during the post-sign-in churn and
+    // never retries it, leaving a broken "?". Loading it through a detached
+    // Image first (which is not affected) warms the cache, so the bound <img>
+    // resolves instantly. Falls back to initials if it truly can't load.
+    avatarUrl.value = data.avatar ? await preloadAvatar(data.avatar) : '';
+  } catch {
+    avatarUrl.value = '';
+  }
+}
+
+// Resolves to `url` once it loads in a detached Image (retrying a few times for
+// transient webview failures), or to '' so the caller falls back to initials.
+function preloadAvatar(url: string): Promise<string> {
+  return new Promise((resolve) => {
+    const MAX_ATTEMPTS = 4;
+    let attempts = 0;
+    const attempt = () => {
+      const img = new Image();
+      img.referrerPolicy = 'no-referrer';
+      img.onload = () => resolve(url);
+      img.onerror = () => {
+        attempts += 1;
+        if (attempts >= MAX_ATTEMPTS) {
+          resolve('');
+        } else {
+          setTimeout(attempt, 300 * attempts);
+        }
+      };
+      img.src = url;
+    };
+    attempt();
+  });
 }
 
 let unlistenSignInPrompt: UnlistenFn | null = null;
@@ -741,11 +788,13 @@ async function refreshSignedInAccount() {
     } else {
       displayName.value = '';
       email.value = '';
+      avatarUrl.value = '';
     }
   } catch (e) {
     isSignedIn.value = false;
     displayName.value = '';
     email.value = '';
+    avatarUrl.value = '';
     console.warn('Failed to refresh signed-in account', e);
   }
 }
@@ -866,6 +915,7 @@ async function handleSignOut() {
   isSignedIn.value = false;
   displayName.value = '';
   email.value = '';
+  avatarUrl.value = '';
   void emitNotificationsSync().catch((err) => {
     console.warn('Failed to sync notifications after sign-out', err);
   });
@@ -971,6 +1021,8 @@ async function handleSignOut() {
   font-size: 13px;
   font-weight: 600;
   color: white;
+  flex-shrink: 0;
+  object-fit: cover;
 }
 
 .account-details {


### PR DESCRIPTION
## Problem
After signing in with Google, the Settings account row showed only the user's initials (e.g. "SH") instead of their Google profile photo.

## Fix
- `fetchUserProfile` now also calls `GET /users/google-avatar` and renders the returned photo, falling back to the initials circle when there is none.
- The photo is **preloaded through a detached `Image()` before binding it to the `<img>`**. WKWebView drops the very first request for a freshly-rendered `<img>` during the post-sign-in window churn and never retries it on its own, leaving a broken-image "?". Preloading (which the detached Image isn't subject to) warms the shared cache, so the bound `<img>` resolves instantly. An `@error` handler keeps the initials fallback as a final safety net.
- The avatar fetch is isolated in its own try/catch so it can never disturb the name/email that load first.

## Notes
- Depends on the backend `GET /users/google-avatar` endpoint (already deployed), which returns the Google photo specifically when Google is connected.
- Verified live in the desktop app: the photo renders (`naturalWidth: 96`) after a fresh load; initials show only when no loadable avatar exists.

## Tests
`SettingsView.test.ts` — 15/15 pass, including new cases: avatar renders when available, falls back to initials when absent, when the request fails, and when the image never loads (preload retries exhausted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)