### PR TITLE
fix(tray): keep Meetings menu item visible while recording

### DIFF
--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -305,6 +305,7 @@ pub fn build_recording_menu(app: &AppHandle, is_paused: bool) -> tauri::Result<t
     };
     let stop = MenuItemBuilder::with_id("stop_recording", "Stop Recording").build(app)?;
     let settings = MenuItemBuilder::with_id("settings", "Settings...").build(app)?;
+    let library = MenuItemBuilder::with_id("library", "Meetings...").build(app)?;
     let check_updates = MenuItemBuilder::with_id("check_updates", "Check for Updates…").build(app)?;
 
     // Quit is intentionally omitted while recording to prevent
@@ -314,6 +315,7 @@ pub fn build_recording_menu(app: &AppHandle, is_paused: bool) -> tauri::Result<t
         .item(&stop)
         .separator()
         .item(&settings)
+        .item(&library)
         .item(&check_updates)
         .build()
 }


### PR DESCRIPTION
## Problem
The **Meetings...** tray menu item disappeared whenever a recording was in progress.

## Cause
The tray swaps to `build_recording_menu` during recording, which omitted the `"library"` (Meetings...) item that `build_idle_menu` includes.

## Fix
Add the Meetings item to `build_recording_menu`, ordered to match the idle menu (Settings → Meetings → Check for Updates). The `"library"` handler is already registered globally, so it opens the Meetings window during recording with no extra wiring.

Verified with `cargo build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added a "Meetings..." menu option to the recording tray menu. Users can now quickly access and browse their meeting library directly during active recordings without needing to stop or pause the session.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->