### PR TITLE
fix: run release-publish.sh with modern bash on hosted runner

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -257,6 +257,13 @@ jobs:
             echo "RELEASE_BODY_EOF"
           } >> "$GITHUB_OUTPUT"
 
+      # release-publish.sh uses `mapfile`, a bash 4.0+ builtin. The hosted
+      # macos-15 runner's system bash is 3.2, so install a modern bash from
+      # Homebrew and run the script with it explicitly (the next step's full
+      # path overrides the script's `#!/usr/bin/env bash` shebang).
+      - name: Install modern bash
+        run: brew install bash
+
       - name: Generate manifest and publish artifacts to R2
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
@@ -267,7 +274,7 @@ jobs:
           RELEASE_TAG: ${{ needs.release-please.outputs.tag_name }}
           RELEASE_BODY: ${{ steps.rel.outputs.body }}
           RELEASE_NAME: ${{ steps.rel.outputs.name }}
-        run: .github/scripts/release-publish.sh
+        run: /opt/homebrew/bin/bash .github/scripts/release-publish.sh
 
       - name: Add R2 download link to GitHub Release
         uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65  # v2.6.2


### PR DESCRIPTION
## Problem

The `release` workflow's `publish` job failed with:

```
.github/scripts/release-publish.sh: line 63: mapfile: command not found
sort: stdout: Broken pipe
```

(see the [failed run](https://github.com/ariso-ai/oats/actions/runs/27765223050/job/82152763810))

`release-publish.sh` uses `mapfile`, a **bash 4.0+** builtin. The `publish` job runs on the GitHub-hosted `macos-15` runner, whose system bash is **3.2.57** — so `mapfile` doesn't exist. (The `sort: stdout: Broken pipe` is just downstream fallout: when the `mapfile` builtin failed, the reader end of the `< <(... | sort)` process substitution closed and `sort` got SIGPIPE.)

This surfaced when the `publish` job moved to the hosted runner; previously it ran on the self-hosted runner, which had a Homebrew bash 4+.

## Fix

Install a modern bash from Homebrew and run the script with it explicitly:

- Added an `Install modern bash` step (`brew install bash`).
- Changed the publish step to `run: /opt/homebrew/bin/bash .github/scripts/release-publish.sh`. Invoking the file as an argument to bash overrides its `#!/usr/bin/env bash` shebang, so it runs under bash 5.x regardless of PATH ordering.

`/opt/homebrew/bin/bash` is the correct path for the Apple Silicon `macos-15` runner. The publish script itself is unchanged.

Fixes #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow to improve build process stability and compatibility across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->