### PR TITLE
chore: make repo vibe-coder-ready for Claude Code

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
+  "name": "oats",
+  "owner": { "name": "ariso-ai" },
+  "metadata": {
+    "description": "oats codebase skills for Claude Code — Vue, Tauri, architecture, and MCP-driven debugging."
+  },
+  "plugins": [
+    {
+      "name": "oats-skills",
+      "source": "./",
+      "description": "Vue, Tauri, architecture, and MCP-debugging skills tailored to the oats desktop app."
+    }
+  ]
+}

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -3,13 +3,13 @@
   "name": "oats",
   "owner": { "name": "ariso-ai" },
   "metadata": {
-    "description": "oats codebase skills for Claude Code — Vue, Tauri, architecture, and MCP-driven debugging."
+    "description": "oats codebase skills for Claude Code — Vue, Tauri, architecture, security, and MCP-driven debugging."
   },
   "plugins": [
     {
       "name": "oats-skills",
       "source": "./",
-      "description": "Vue, Tauri, architecture, and MCP-debugging skills tailored to the oats desktop app."
+      "description": "Vue, Tauri, architecture, security, and MCP-debugging skills tailored to the oats desktop app."
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "oats-skills",
-  "description": "Vue, Tauri, architecture, and MCP-debugging skills tailored to the oats desktop app.",
+  "description": "Vue, Tauri, architecture, security, and MCP-debugging skills tailored to the oats desktop app.",
   "author": { "name": "ariso-ai" },
   "homepage": "https://github.com/ariso-ai/oats",
   "license": "MIT",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "oats-skills",
+  "description": "Vue, Tauri, architecture, and MCP-debugging skills tailored to the oats desktop app.",
+  "author": { "name": "ariso-ai" },
+  "homepage": "https://github.com/ariso-ai/oats",
+  "license": "MIT",
+  "skills": "./.claude/skills"
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "extraKnownMarketplaces": {
+    "claude-plugins-official": {
+      "source": { "source": "github", "repo": "anthropics/claude-plugins-official" }
+    }
+  },
+  "enabledPlugins": ["superpowers@claude-plugins-official"]
+}

--- a/.claude/skills/oats-architecture/SKILL.md
+++ b/.claude/skills/oats-architecture/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: oats-architecture
+description: Use to orient in the oats codebase or plan cross-cutting features — the cloud-vs-offline backend split, the speech-to-text pipeline, window topology, and where specs live.
+---
+
+# oats Architecture Map
+
+oats is a macOS menu-bar meeting recorder/notetaker: hit record, get a transcript and
+notes. Tauri v2 (Rust) + Vue 3 (TypeScript). Apple Silicon only.
+
+## Two backends, one app
+
+The defining design choice is a **backend abstraction** (`src/composables/useBackend.ts`
+on the frontend; STT/storage modules on the Rust side):
+
+- ☁️ **Cloud (Ariso)** — sign in; transcription and notes run on Ariso's servers.
+- 🔒 **Offline (local)** — flip a switch; recording, transcription, speaker labels, and
+  notes all run on-device, nothing leaves the Mac.
+
+When designing a feature, ask which backend(s) it touches and keep the abstraction intact —
+don't hardcode cloud-only or local-only paths into shared code.
+
+## Speech-to-text pipeline
+
+Local transcription uses **`ariso-stt`**, a Swift/MLX speech engine shipped as a sidecar
+binary (`src-tauri/binaries/ariso-stt-aarch64-apple-darwin`, plus `mlx-swift_Cmlx.bundle`).
+Rust side: `audio_capture.rs` (Core Audio process taps for system audio + mic),
+`transcribe.rs`, `model_manager.rs` (model download/management), `storage.rs` (recordings
++ meeting data on disk under `~/.ariso`).
+
+## Window topology
+
+All windows load one Vue bundle and render a hash route (`src/main.ts`):
+- `main` (`/`) — **headless** BootstrapView; runs sync/startup logic, intentionally blank.
+- `settings` (`/settings`) — the settings window (pre-created hidden at startup).
+- `library` (`/library`) — titled **"Meetings"**; the main user-facing window
+  (created on demand, destroyed on close).
+- plus `waveform`, `update`, `meeting-picker`, `onboarding`, `oauth`.
+
+The tray (`tray.rs`, `tray_meeting.rs`) and recorder pill (`recorder_pill.rs`) are the
+menu-bar surface.
+
+## Where things live
+
+- Frontend: `src/` (`views/`, `composables/`, `tauri.ts`) — see `oats-vue`.
+- Backend: `src-tauri/src/` — see `oats-tauri`.
+- **Design specs: `docs/superpowers/specs/`** (`YYYY-MM-DD-<topic>-design.md`). Read
+  recent specs before a related feature; write a new one (via the brainstorming workflow)
+  before non-trivial work.
+
+For runtime inspection of any window, use `oats-debugging`.

--- a/.claude/skills/oats-debugging/SKILL.md
+++ b/.claude/skills/oats-debugging/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: oats-debugging
+description: Use when reproducing or diagnosing runtime behavior in the running oats desktop app — driving and inspecting its windows via the oats-desktop MCP server (execute JS, read DOM, invoke backend commands). Pairs with systematic-debugging.
+---
+
+# Debugging the running oats app via MCP
+
+oats ships a Tauri MCP server (`tauri-plugin-mcp`) that lets you drive the live app —
+list windows, screenshot, execute JS in a webview, and call backend commands. Use it to
+verify a fix in the real app, not just in unit tests. Pair this with superpowers'
+`systematic-debugging` for the methodology.
+
+## Enable the server
+
+It is registered in `.mcp.json` as **`oats-desktop`** but disabled by default in
+`.claude/settings.local.json` (`disabledMcpjsonServers`). Remove it from that list (or
+approve the server when prompted) to use it. The app must be launched with the MCP
+feature:
+
+```
+npm run tauri:dev:debug      # = tauri dev --features mcp
+```
+
+Run it in the **background with the sandbox disabled** (cargo must compile and the GUI /
+network must spawn). It's a never-exiting dev server — don't wait on it to "finish".
+
+## Windows (what you'll see)
+
+Routes live in `src/main.ts`. See `oats-architecture` for the full map. Quick version:
+- `settings` — the settings window (pre-created hidden).
+- `library` — titled **"Meetings"**; the main user-facing window.
+- `main` — **headless/blank** BootstrapView; a blank screenshot of it is expected.
+
+## execute_js gotchas (these will bite you)
+
+- **Hidden WKWebViews are JS-suspended on macOS** — `execute_js` times out until the
+  window is **shown and focused**. Show the window first.
+- **Backend bridge**: `window.__TAURI__` is **not** exposed (the app uses ESM
+  `@tauri-apps/api`). Call commands via
+  `window.__TAURI_INTERNALS__.invoke('cmd_name', args)`.
+- **No top-level `await`** — make the last expression a promise; the tool resolves it.
+- A blank window with no JS bridge usually means the **Vue bundle failed to load** —
+  check the vite dev log for an unresolved import (the router statically imports every
+  view, so one bad import breaks the whole graph).
+
+## Typical loop
+
+1. Launch `tauri:dev:debug` in the background.
+2. List windows; `show` the target window before any `execute_js`.
+3. Inspect via JS / screenshot; reproduce the issue.
+4. Drive the backend with `__TAURI_INTERNALS__.invoke(...)` to isolate frontend vs Rust.
+5. Once root cause is found, fix per `oats-vue` / `oats-tauri` and re-verify here.

--- a/.claude/skills/oats-security/SKILL.md
+++ b/.claude/skills/oats-security/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: oats-security
+description: Use when changing oats code that touches auth/OAuth, session tokens, the capabilities allowlist, a Tauri invoke command, file paths, URL/deep-link opening, the sidecar, network calls, or the offline-mode privacy guarantee. Encodes this app's real attack surface and a pre-PR review checklist.
+---
+
+# oats Security Review
+
+oats records meetings (highly sensitive audio + transcripts), holds an auth session, and
+runs a native sidecar — so changes near the surfaces below deserve a deliberate security
+pass. Use this alongside superpowers' `requesting-code-review` and the built-in
+`/security-review` command. **Default to suspicion**: if a change touches a surface here,
+walk its checklist before opening the PR.
+
+## The attack surfaces (where they live)
+
+1. **Tauri `invoke` boundary** — every `#[tauri::command]` in `src-tauri/src/commands.rs`
+   is reachable from any loaded webview (incl. the external OAuth page). Treat command
+   arguments as **untrusted input**.
+2. **File paths from the frontend** — commands like `read_recording_audio` /
+   note read-write take a path/id and hit `std::fs::read` / `read_to_string` /
+   `create_dir_all`. **Path-traversal risk**: a malicious id (`../../`) could escape
+   `~/.ariso/recordings/`. Confirm ids are validated and paths are built from
+   `storage::recordings_dir(...)`, never concatenated from caller-supplied absolute paths.
+3. **Auth / OAuth** — `auth.googleSignIn` → `/oauth2/prepare-state` (CSRF state),
+   an `oauth` **external** webview (`WebviewUrl::External`), result delivered via the
+   `oauth-result` event. Verify: state is generated server-side and checked; the external
+   window is scoped to the expected origin; the returned `sessionToken` is never logged or
+   emitted to other windows.
+4. **Session token storage** — tokens/Bearer creds back the `http_client()`
+   (`AUTHORIZATION` header). The `@tauri-apps/plugin-store` (`settings.json`) is
+   **plaintext on disk** — fine for prefs (`backend`, `onboarded`), **not** for secrets.
+   Confirm no token/secret is written to plugin-store; secrets belong in the OS keychain
+   or backend-managed session.
+5. **Capabilities allowlist** — `src-tauri/capabilities/default.json` is least-privilege
+   and should stay that way. Note the scoped `opener:allow-open-url` (only
+   `x-apple.systempreferences:*`). **Don't broaden a permission or add a window** without
+   justifying it; never add a wildcard URL/open scope.
+6. **URL / deep-link opening** — `app.opener().open_url(...)` and notification deep links
+   (`meeting_notifications.rs` carries a URL as the request id). Only open URLs whose
+   **origin you control** (the `web.ari.ariso.ai` web app). Validate scheme + host before
+   opening anything derived from server data or a notification payload.
+7. **Sidecar execution** — `ariso-stt` is spawned with `--audio <path>` etc. It uses
+   `Command::new` + `.arg(...)` (no shell), so keep it that way — **never** route sidecar
+   args through a shell string or interpolate untrusted data into one.
+8. **Network / API base** — `DEFAULT_API_BASE_URL` is compiled per feature; release builds
+   **intentionally ignore env overrides** (`ARISO_DESKTOP_API_BASE_URL`). Don't add a
+   runtime override path that would let an attacker repoint the API. Keep `https://` in
+   non-local builds; `http://localhost` is dev-only.
+9. **Updater** — R2-hosted, signature-verified with the public key. Updates must stay
+   **signature-verified**; never disable the pubkey check or pull updates over plain HTTP.
+10. **Offline-mode privacy invariant** — when the Local backend is selected, **nothing
+    leaves the machine**. Any new network call (`reqwest`, telemetry, fetch) on a
+    code path reachable in Local mode breaks the product's core promise. Gate network I/O
+    behind the cloud backend explicitly.
+11. **Sensitive data in logs** — transcripts, audio paths, tokens, and meeting content
+    must not land in stdout/stderr/log files. The sidecar contract is "stdout = result,
+    stderr = logs" — keep secrets out of both.
+
+## Pre-PR checklist
+
+For a change touching any surface above, confirm:
+
+- [ ] New/changed `invoke` command validates and bounds every argument (esp. paths/ids).
+- [ ] No secret (token, key) written to plugin-store or any plaintext file; none logged.
+- [ ] No capability/permission/window added or widened without a written reason; no
+      wildcard URL open scope.
+- [ ] Any opened URL/deep link is origin- and scheme-checked against a trusted host.
+- [ ] No new network call reachable in Local (offline) mode.
+- [ ] Sidecar args stay argv-based (no shell), no untrusted interpolation.
+- [ ] Updater signature verification and HTTPS endpoints untouched.
+- [ ] Ran `/security-review` (or requested review) on the diff.
+
+When this surfaces a real finding, fix it via `oats-tauri` (backend) / `oats-vue`
+(frontend) and re-verify. For runtime reproduction, use `oats-debugging`.

--- a/.claude/skills/oats-tauri/SKILL.md
+++ b/.claude/skills/oats-tauri/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: oats-tauri
+description: Use when changing oats backend — Rust commands in src-tauri, the invoke contract, capabilities/permissions, Tauri plugins, multi-window, or running the cargo test suite. Includes the macOS build/test workarounds.
+---
+
+# oats Backend (Tauri v2) Conventions
+
+The backend is Rust in `src-tauri/`, exposing commands the Vue frontend calls via
+`invoke`. Tauri v2, Apple-Silicon macOS only.
+
+## Layout (`src-tauri/src/`)
+
+- `main.rs` — app setup, plugin registration, tray, window creation, `invoke_handler`.
+- `commands.rs` — the bulk of `#[tauri::command]` functions (the frontend API surface).
+- Domain modules: `audio_capture.rs`, `transcribe.rs`, `model_manager.rs`,
+  `storage.rs`, `recording_state.rs`, `mic_monitor.rs`, `meeting_notifications.rs`,
+  `recorder_pill.rs`, `tray.rs` / `tray_meeting.rs`, `update_manager.rs`.
+
+## The invoke contract
+
+Frontend → backend goes through typed wrappers in `src/tauri.ts`
+(`import { invoke } from '@tauri-apps/api/core'`). To add a command:
+1. Write `#[tauri::command] async fn foo(...)` in `commands.rs` (or a domain module).
+2. Register it in the `invoke_handler![...]` in `main.rs`.
+3. Add a typed wrapper in `src/tauri.ts`; call that from views/composables.
+
+## Capabilities & permissions
+
+`src-tauri/capabilities/default.json` is the allowlist — it names the **windows**
+(`main`, `waveform`, `settings`, `oauth`, `update`, `library`, `onboarding`) and the
+**permissions** they get (`core:window:*`, `store:default`, `opener:default`,
+`notification:default`, `updater:default`, plus a scoped `opener:allow-open-url` for
+`x-apple.systempreferences:*`). A new window or plugin capability must be added here or
+calls are rejected at runtime.
+
+## Plugins in use
+
+`@tauri-apps/plugin-store` (persisted settings), `plugin-updater` (R2-hosted auto-update,
+configured under `plugins.updater` in `tauri.conf.json`), `plugin-notification`,
+`plugin-opener`. The `tauri-plugin-mcp` server is gated behind `--features mcp` — see
+`oats-debugging`.
+
+## Run / build
+
+- `npm run tauri:dev` — run the app.
+- `npm run tauri:dev:debug` — run with the MCP server (`--features mcp`).
+- `npm run tauri:build` — bundle. **Exits non-zero on the updater signing step
+  (`TAURI_SIGNING_PRIVATE_KEY` missing) but the `.app` is already built** at
+  `src-tauri/target/release/bundle/macos/oats.app` and is fully usable.
+
+## Testing the Rust suite (macOS workarounds — important)
+
+Default `cargo test` fails on this platform two ways. Full green command:
+
+```
+DYLD_LIBRARY_PATH="/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift-5.5/macosx" \
+  cargo test --manifest-path src-tauri/Cargo.toml -- --test-threads=1
+```
+
+- `DYLD_LIBRARY_PATH` fixes a missing `libswift_Concurrency.dylib` SIGABRT. A benign
+  `objc[...] Class ... implemented in both` warning still prints.
+- `--test-threads=1` avoids a pre-existing isolation flake (some `rename_local_recording*`
+  / `finalize*` tests mutate process-wide state and collide in parallel).
+
+### Fresh git worktree bootstrap
+
+A fresh worktree is missing `.gitignore`d build inputs; bootstrap before building/testing:
+1. **Sidecar binaries** (`src-tauri/binaries/` is gitignored) — copy from the primary
+   checkout: `cp -R <primary>/src-tauri/binaries/{ariso-stt-aarch64-apple-darwin,mlx-swift_Cmlx.bundle} src-tauri/binaries/`.
+2. `npm ci` (repo uses npm + `package-lock.json`).
+3. `npm run vite:build` once — `generate_context!` needs `dist/` to exist.
+
+## macOS permission (TCC) testing
+
+Test TCC grants (system-audio etc.) on the **bundled app** (stable id `ai.ariso.desktop`),
+not the adhoc-signed `tauri:dev` binary (unstable identity across rebuilds). System-audio
+capture (Core Audio process taps) prompts on **capture start** and the grant lands under
+"System Audio Recording Only" in Privacy → Screen & System Audio Recording. Reset a grant
+with `tccutil reset ScreenCapture ai.ariso.desktop`; a leftover broad Screen Recording
+grant silently satisfies the tap and suppresses the narrow prompt.
+
+For frontend conventions see `oats-vue`; for the big picture see `oats-architecture`;
+for driving the running app see `oats-debugging`.

--- a/.claude/skills/oats-vue/SKILL.md
+++ b/.claude/skills/oats-vue/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: oats-vue
+description: Use when building or changing oats frontend UI — Vue 3 components, views, composables, routing, Tailwind, or the TipTap notes editor. Encodes this repo's frontend conventions.
+---
+
+# oats Frontend (Vue 3) Conventions
+
+The frontend is Vue 3 + TypeScript + Vite, styled with Tailwind v4. Entry is
+`src/main.ts`; the single root is `src/App.vue` (just `<RouterView/>`).
+
+## Layout
+
+- `src/main.ts` — app bootstrap **and the router**. Every window loads the same bundle
+  and renders a route via `createWebHashHistory`. Add a view by importing it here and
+  adding a `routes` entry. The router statically imports every view, so **one broken
+  import breaks the whole app graph** (blank windows).
+- `src/views/` — one `.vue` per screen (`SettingsView`, `LibraryView`,
+  `MeetingDetailView`, `RecorderStrip`, `WaveformView`, …). Co-located `*.test.ts` use
+  Vitest + `@vue/test-utils`. Pure helpers also live here as plain `.ts` + tests
+  (e.g. `waveformBars.ts`, `meetingShareText.ts`).
+- `src/composables/` — reusable reactive logic (`useBackend`, `useRecorder`,
+  `useMeetingApi`, `usePendingUploads`, `useAutoRecord`, …). Prefer extracting logic
+  into a composable with its own `*.test.ts` over fattening a view.
+- `src/tauri.ts` — typed wrappers around backend `invoke` calls (`auth`, `api`,
+  `getDesktopConfig`, …). **Call the backend through helpers here**, not raw `invoke`
+  scattered in components. See `oats-tauri` for the invoke ↔ Rust contract.
+
+## Conventions
+
+- **`<script setup lang="ts">` + Composition API** everywhere. No Options API, no Vuex —
+  state lives in composables and `@tauri-apps/plugin-store`.
+- **Tailwind v4** via `@tailwindcss/vite` (config-light; utilities in templates). Global
+  CSS in `src/assets/main.css`.
+- **Routing is window-driven**: the Rust side opens a window pointed at a hash route
+  (e.g. `/#/settings`, `/#/library`). A new screen = a new route here + a Rust window
+  opener. See `oats-architecture` for the window topology.
+- **Notes editor** uses TipTap (`@tiptap/vue-3`, StarterKit, task-list, typography,
+  `tiptap-markdown`) — see `MeetingNotesEditor.vue` / `MeetingDetailView.vue`.
+- **Icons**: `@heroicons/vue`.
+
+## Testing
+
+`npm test` runs Vitest (jsdom). Write a co-located `*.test.ts` for every new view,
+component, or composable. Mock `@tauri-apps/api` invoke calls — don't hit the backend in
+unit tests. Frontend tests are independent of the Rust suite.
+
+When the change spans the Rust boundary, also read `oats-tauri`. For runtime debugging in
+the real window, use `oats-debugging`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,8 @@ conventions, not generic framework docs):
 - **`oats-vue`** — any frontend change (views, composables, routing, Tailwind, TipTap).
 - **`oats-tauri`** — any Rust/Tauri change, the invoke contract, capabilities, and the
   macOS build/test workarounds.
+- **`oats-security`** — changes touching auth, tokens, capabilities, invoke commands,
+  file paths, URL/deep-link opening, the sidecar, or the offline-mode privacy guarantee.
 - **`oats-debugging`** — drive/inspect the running app via the `oats-desktop` MCP server.
 
 ## Recommended workflow
@@ -56,6 +58,6 @@ A fresh git worktree needs bootstrapping first (sidecar binaries, `npm ci`,
 - `settings.json` — shared: registers the official marketplace, auto-enables superpowers.
 - `settings.local.json` — personal overrides (not your concern when shared); it disables
   the `oats-desktop` MCP server by default — `oats-debugging` explains enabling it.
-- `skills/` — the four oats skills above (auto-discovered; also packaged as the
+- `skills/` — the five oats skills above (auto-discovered; also packaged as the
   `oats-skills` plugin via `.claude-plugin/`).
 - `commands/` — repo slash commands (e.g. `apply-coderabbit`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,61 @@
+# oats — working with Claude Code
+
+oats is a macOS menu-bar meeting recorder/notetaker: hit record, get a transcript and
+notes. **Tauri v2 (Rust) + Vue 3 (TypeScript)**, Apple Silicon only. It runs either in
+the cloud (Ariso) or fully offline on-device.
+
+This repo is set up so Claude Code is productive on clone. When you trust the folder you
+get the **superpowers** plugin (brainstorming, plans, TDD, systematic debugging) plus
+this repo's own skills.
+
+## Use the skills
+
+Invoke these before working in the matching area (they encode this codebase's real
+conventions, not generic framework docs):
+
+- **`oats-architecture`** — orient first: cloud-vs-offline backend split, the `ariso-stt`
+  speech pipeline, window topology, where specs live.
+- **`oats-vue`** — any frontend change (views, composables, routing, Tailwind, TipTap).
+- **`oats-tauri`** — any Rust/Tauri change, the invoke contract, capabilities, and the
+  macOS build/test workarounds.
+- **`oats-debugging`** — drive/inspect the running app via the `oats-desktop` MCP server.
+
+## Recommended workflow
+
+For features: `brainstorming → writing-plans → subagent-driven-development →
+verification-before-completion`. For bugs: `systematic-debugging → test-driven-development
+→ verification-before-completion`. Design specs live in `docs/superpowers/specs/`.
+
+## Commands
+
+```bash
+npm run tauri:dev          # run the app
+npm run tauri:dev:debug    # run with the MCP server (--features mcp)
+npm run tauri:build        # bundle (exits non-zero on the updater signing step,
+                           # but src-tauri/target/release/bundle/macos/oats.app is built)
+npm test                   # frontend unit tests (Vitest)
+
+# Rust tests need two macOS workarounds (see oats-tauri for why):
+DYLD_LIBRARY_PATH="/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift-5.5/macosx" \
+  cargo test --manifest-path src-tauri/Cargo.toml -- --test-threads=1
+```
+
+A fresh git worktree needs bootstrapping first (sidecar binaries, `npm ci`,
+`npm run vite:build`) — see `oats-tauri`.
+
+## Layout
+
+- `src/` — Vue frontend. `main.ts` (bootstrap + router), `views/`, `composables/`,
+  `tauri.ts` (typed `invoke` wrappers).
+- `src-tauri/src/` — Rust backend. `commands.rs` (the frontend API), `main.rs` (setup +
+  `invoke_handler`), domain modules, `capabilities/` (permission allowlist).
+- `docs/superpowers/specs/` — design specs.
+
+## `.claude/` directory
+
+- `settings.json` — shared: registers the official marketplace, auto-enables superpowers.
+- `settings.local.json` — personal overrides (not your concern when shared); it disables
+  the `oats-desktop` MCP server by default — `oats-debugging` explains enabling it.
+- `skills/` — the four oats skills above (auto-discovered; also packaged as the
+  `oats-skills` plugin via `.claude-plugin/`).
+- `commands/` — repo slash commands (e.g. `apply-coderabbit`).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,7 +46,7 @@ in `.claude/` and `.claude-plugin/`.
 - [Rust](https://rustup.rs/) toolchain
 - Node.js + npm
 - From the monorepo root: `npm install`
-- `DEEPGRAM_API_KEY` in `.env` — must have **Member** role or higher (required for `/v1/auth/grant` token provisioning)
+- [Xcode](https://apps.apple.com/app/xcode/id497799835) (full install, not just Command Line Tools) — `xcodebuild` is required to compile the sidecar's MLX Metal shaders (`mlx-swift_Cmlx.bundle`); `swift build` alone cannot
 - **Apple Silicon, macOS 14+** (required to build and run the on-device Local backend sidecar)
 
 ## Development scripts

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,7 @@ Much of oats was built with [Claude Code](https://claude.com/claude-code) and th
 
 - [Code of conduct](#code-of-conduct)
 - [Ways to contribute](#ways-to-contribute)
+- [Working with Claude Code](#working-with-claude-code)
 - [Prerequisites](#prerequisites)
 - [Development scripts](#development-scripts)
 - [API build targets vs. transcription backend](#api-build-targets-vs-transcription-backend)
@@ -31,6 +32,14 @@ Be kind, be constructive, and assume good intent. We want oats to be a welcoming
 - 🐛 **Report bugs** — open an [issue](https://github.com/ariso-ai/oats/issues) with steps to reproduce, your macOS version, and which transcription backend you were using.
 - 💡 **Suggest features** — open an issue describing the problem you'd like solved.
 - 🔧 **Send pull requests** — fix a bug, improve docs, or build a feature. See [Submitting changes](#submitting-changes).
+
+## Working with Claude Code
+
+This repo is set up for [Claude Code](https://claude.com/claude-code). On clone, trust
+the folder and you get the **superpowers** plugin plus four repo-specific skills
+(`oats-architecture`, `oats-vue`, `oats-tauri`, `oats-debugging`) that encode our
+conventions. See [`CLAUDE.md`](CLAUDE.md) for the full guide. Plugin/skill config lives
+in `.claude/` and `.claude-plugin/`.
 
 ## Prerequisites
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,10 +36,10 @@ Be kind, be constructive, and assume good intent. We want oats to be a welcoming
 ## Working with Claude Code
 
 This repo is set up for [Claude Code](https://claude.com/claude-code). On clone, trust
-the folder and you get the **superpowers** plugin plus four repo-specific skills
-(`oats-architecture`, `oats-vue`, `oats-tauri`, `oats-debugging`) that encode our
-conventions. See [`CLAUDE.md`](CLAUDE.md) for the full guide. Plugin/skill config lives
-in `.claude/` and `.claude-plugin/`.
+the folder and you get the **superpowers** plugin plus five repo-specific skills
+(`oats-architecture`, `oats-vue`, `oats-tauri`, `oats-security`, `oats-debugging`) that
+encode our conventions. See [`CLAUDE.md`](CLAUDE.md) for the full guide. Plugin/skill
+config lives in `.claude/` and `.claude-plugin/`.
 
 ## Prerequisites
 

--- a/docs/superpowers/specs/2026-06-18-vibe-coder-claude-setup-design.md
+++ b/docs/superpowers/specs/2026-06-18-vibe-coder-claude-setup-design.md
@@ -1,0 +1,170 @@
+# Vibe-Coder-Ready `.claude` Setup — Design
+
+**Date:** 2026-06-18
+**Status:** Approved for planning
+**Topic:** Make the oats repo ready for "vibe coders" — a contributor who clones the
+repo, opens Claude Code, and is productive immediately.
+
+## Goal
+
+When someone clones `oats` and opens Claude Code, the environment should bootstrap
+itself: the superpowers plugin becomes available, and this repo's own Vue / Tauri /
+architecture / debugging knowledge is loaded as skills — with no manual setup beyond
+trusting the folder.
+
+Delivery mechanism (decided): **marketplace + auto-enable**. We reference the
+superpowers plugin from the official marketplace and ship our own domain skills as a
+local plugin that the repo itself serves as a marketplace.
+
+## Non-Goals
+
+- Re-vendoring superpowers (we reference it, we don't copy it).
+- Auto-enabling agent-skills or rust-analyzer-lsp (keep the shared config minimal —
+  superpowers only). Contributors can opt in personally via `settings.local.json`.
+- Changing application code. This is purely tooling/docs.
+
+## Directory Layout (committed)
+
+```
+.claude/
+  settings.json            NEW  shared: known marketplaces + enabled plugins
+  settings.local.json      KEEP personal overrides (disables oats-desktop MCP, etc.)
+  commands/apply-coderabbit.md  KEEP
+.claude-plugin/
+  marketplace.json         NEW  declares the "oats" marketplace (this repo)
+  plugin.json              NEW  the "oats-skills" local plugin manifest
+skills/                    NEW  our own domain skills
+  oats-vue/SKILL.md
+  oats-tauri/SKILL.md
+  oats-architecture/SKILL.md
+  oats-debugging/SKILL.md
+CLAUDE.md                  NEW  root orientation: run/build/test + skill pointers
+```
+
+## Components
+
+### 1. `.claude/settings.json` (shared, committed)
+
+Registers the official marketplace and auto-enables superpowers. Minimal by decision.
+
+```jsonc
+{
+  "extraKnownMarketplaces": {
+    "claude-plugins-official": {
+      "source": { "source": "github", "repo": "anthropics/claude-plugins-official" }
+    }
+  },
+  "enabledPlugins": ["superpowers@claude-plugins-official"]
+}
+```
+
+On first open the cloner trusts the folder, Claude Code registers the marketplace and
+prompts to enable superpowers. Our own skills load from the repo-local plugin with no
+network dependency. `settings.local.json` stays untouched and personal.
+
+### 2. `.claude-plugin/marketplace.json` + `plugin.json` (repo-as-marketplace)
+
+The repo doubles as a single-plugin marketplace named `oats`, exposing one plugin,
+`oats-skills`, sourced from `./`. `plugin.json` points `skills` at `./skills`.
+
+```jsonc
+// .claude-plugin/marketplace.json
+{
+  "name": "oats",
+  "owner": { "name": "ariso-ai" },
+  "metadata": { "description": "oats domain skills for Claude Code" },
+  "plugins": [
+    { "name": "oats-skills", "source": "./",
+      "description": "Vue, Tauri, architecture, and MCP-debugging skills for the oats codebase" }
+  ]
+}
+```
+
+```jsonc
+// .claude-plugin/plugin.json
+{
+  "name": "oats-skills",
+  "description": "Vue, Tauri, architecture, and MCP-debugging skills for the oats codebase",
+  "author": { "name": "ariso-ai" },
+  "homepage": "https://github.com/ariso-ai/oats",
+  "license": "MIT",
+  "skills": "./skills"
+}
+```
+
+Note: project-local `skills/` are auto-discovered by Claude Code when the folder is
+trusted, so the skills work even if a contributor never formally installs the plugin.
+The marketplace/plugin manifests make the set installable/named and future-proof.
+
+### 3. Skills (the real value — encode THIS codebase's conventions)
+
+Each skill is one `SKILL.md` with YAML frontmatter (`name`, `description`) and a body
+scoped to oats specifics, not generic framework docs.
+
+- **`oats-vue`** — Vue 3 `<script setup>` + Composition API; Tailwind v4 via
+  `@tailwindcss/vite`; `vue-router` across the multi-window UI; composables pattern
+  (`src/composables`); TipTap editor (`@tiptap/vue-3`) usage; where views live
+  (`src/views`). When to use: any frontend change.
+
+- **`oats-tauri`** — Tauri v2 `invoke` ↔ Rust command layer (`src-tauri/src`);
+  capabilities/permissions (`src-tauri/capabilities`); plugins in use (store, updater,
+  notification, opener); multi-window topology (settings / library=Meetings / main);
+  run/build commands; and the **test workaround** (`DYLD_LIBRARY_PATH` +
+  `--test-threads=1`) plus fresh-worktree build prerequisites (copy
+  `src-tauri/binaries`, `npm ci`, `vite:build`). When to use: any Rust/Tauri change or
+  running the cargo suite.
+
+- **`oats-architecture`** — the map: cloud (Ariso) vs offline backend abstraction;
+  the `ariso-stt` Swift/MLX speech pipeline; high-level data flow; macOS TCC/permission
+  testing gotcha (test on the bundle `ai.ariso.desktop`, not the adhoc dev binary);
+  where specs live (`docs/superpowers/specs/`). When to use: orienting in the codebase
+  or cross-cutting features.
+
+- **`oats-debugging`** — drive and inspect the running app via the `oats-desktop` MCP
+  server for debugging tasks: enabling the server (it is disabled in
+  `settings.local.json` by default), launching the app, the window names
+  (settings / library / main, main is headless), `show` before `execute_js`, and using
+  `__TAURI_INTERNALS__.invoke`. Pairs with superpowers' `systematic-debugging`. When to
+  use: reproducing/diagnosing runtime behavior in the desktop app.
+
+### 4. `CLAUDE.md` (root) — the front door
+
+Short orientation, not a manual:
+- What oats is (one paragraph).
+- Recommended workflow: `brainstorming → writing-plans → subagent-driven-development
+  → verification-before-completion`.
+- One-liners: `npm run tauri:dev`, `npm run tauri:build`, `npm test`, and the cargo
+  test invocation with the `DYLD_LIBRARY_PATH` workaround.
+- Directory map (`src/` frontend, `src-tauri/` backend, `docs/superpowers/specs/`).
+- Explicit pointers: "use the `oats-vue` / `oats-tauri` / `oats-architecture` /
+  `oats-debugging` skills."
+
+CONTRIBUTING.md gets a short "Working with Claude Code" subsection linking to CLAUDE.md.
+
+## Data Flow (bootstrap)
+
+```
+clone repo → open Claude Code → trust folder
+  → settings.json registers claude-plugins-official marketplace
+  → prompt to enable superpowers@claude-plugins-official
+  → skills/ auto-discovered (oats-vue, oats-tauri, oats-architecture, oats-debugging)
+  → CLAUDE.md loaded as project context
+contributor is productive with zero extra setup
+```
+
+## Testing / Verification
+
+- `settings.json`, `marketplace.json`, `plugin.json` are valid JSON.
+- Each `SKILL.md` has valid frontmatter and is discoverable via the Skill tool.
+- Sanity-check in this worktree that the skills appear and CLAUDE.md loads.
+- Verify referenced commands/paths exist (e.g. `src-tauri/capabilities`,
+  `src/composables`, the test workaround actually runs green).
+
+## Risks / Open Questions
+
+- Self-referencing marketplace source for the repo-local plugin: project-local
+  `skills/` are auto-discovered regardless, so the plugin manifest is additive insurance
+  rather than load-bearing. If the marketplace self-reference proves unsupported, the
+  skills still work via auto-discovery.
+- Skills must stay accurate as the codebase evolves; keep them terse and pointer-heavy
+  rather than duplicating code that will drift.


### PR DESCRIPTION
## Summary

Sets up the repo so a contributor who clones it and opens Claude Code is productive immediately — the **superpowers** plugin plus repo-specific skills load on trust, with no manual install step.

## Changes

- **`.claude/settings.json`** (shared) — registers the official marketplace and auto-enables `superpowers@claude-plugins-official`.
- **`.claude-plugin/{marketplace,plugin}.json`** — package the repo's own skills as the installable `oats-skills` plugin.
- **`.claude/skills/`** — five skills encoding this codebase's actual conventions:
  - `oats-architecture` — cloud-vs-offline backend split, `ariso-stt` pipeline, window topology, spec locations.
  - `oats-vue` — Vue 3 `<script setup>`, composables, hash-route-per-window, Tailwind v4, TipTap.
  - `oats-tauri` — invoke↔Rust contract, capabilities, plugins, and the macOS build/test workarounds.
  - `oats-security` — triggers on this app's real attack surfaces (invoke boundary, frontend-supplied file paths, OAuth/token handling, the capabilities allowlist, URL/deep-link opening, sidecar execution, network/API base, the updater, and the offline-mode privacy invariant) with a pre-PR checklist.
  - `oats-debugging` — driving the live app via the `oats-desktop` MCP server.
- **`CLAUDE.md`** — front door (what oats is, recommended workflow, commands, layout, skill pointers).
- **`CONTRIBUTING.md`** — adds a "Working with Claude Code" section + TOC entry, and adds **Xcode** to Prerequisites (needed for the sidecar's MLX Metal shaders).
- **`docs/superpowers/specs/2026-06-18-vibe-coder-claude-setup-design.md`** — design spec.

## How it manages `.claude/`

- Shared (`settings.json`) vs. personal (`settings.local.json`) split.
- References upstream superpowers via the marketplace rather than vendoring it; owns domain knowledge as in-repo skills.
- Skills live in `.claude/skills/` (auto-discovered on trust) and are also packaged as a named, installable plugin.

## Notes

No application code touched — docs/tooling only, so existing tests are unaffected. All JSON validated; all skills load (confirmed in-session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Claude Code marketplace/plugin configuration and settings to enable repo-local skills and the official Superpowers plugin.

* **Documentation**
  * Added/expanded Claude Code skill guides for frontend (Vue), backend (Tauri), system architecture, and running-app MCP debugging.
  * Added a security pre-PR checklist skill guide.
  * Introduced `CLAUDE.md` onboarding plus updates to contributor guidance and a “Vibe-Coder-Ready” setup/design spec.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->