### PR TITLE
chore: add Dependabot version updates for npm, cargo, and actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,3 +33,8 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
+    groups:
+      github-actions-minor-patch:
+        update-types:
+          - minor
+          - patch

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,35 @@
+# Dependabot version updates — keeps dependencies current proactively.
+# Security updates (vuln fixes) are configured separately in repo settings.
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+version: 2
+updates:
+  # Frontend (Vue / Vite) npm packages
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    groups:
+      npm-minor-patch:
+        update-types:
+          - minor
+          - patch
+
+  # Tauri / Rust crates
+  - package-ecosystem: cargo
+    directory: /src-tauri
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    groups:
+      cargo-minor-patch:
+        update-types:
+          - minor
+          - patch
+
+  # GitHub Actions used in workflows
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5


### PR DESCRIPTION
## What

Adds `.github/dependabot.yml` to enable **Dependabot version updates** — proactive weekly PRs that keep dependencies current. This is separate from security (vulnerability) updates, which are already enabled in repo settings.

## Ecosystems covered

| Ecosystem | Directory | Schedule | PR limit |
|---|---|---|---|
| `npm` (Vue/Vite frontend) | `/` | weekly | 10 |
| `cargo` (Tauri/Rust crates) | `/src-tauri` | weekly | 10 |
| `github-actions` (workflows) | `/` | weekly | 5 |

Minor/patch updates are grouped per ecosystem to reduce PR noise; majors come as individual PRs.

## Part of a broader security pass

Alongside this, the following were enabled in repo settings: secret scanning + push protection, CodeQL default-setup code scanning, Dependabot security updates, and branch protection on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured automated dependency management to ensure systematic updates across npm packages, Rust crates, and GitHub Actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->