### PR TITLE
fix: UI tweaks — title width, transcript scrollbar, hide local front-matter

### DIFF
--- a/src/utils/markdown.test.ts
+++ b/src/utils/markdown.test.ts
@@ -1,5 +1,31 @@
 import { describe, it, expect } from 'vitest';
-import { renderMarkdown } from './markdown';
+import { renderMarkdown, stripFrontmatter } from './markdown';
+
+describe('stripFrontmatter', () => {
+  it('strips a leading YAML front-matter block', () => {
+    const src = '---\ntitle: "My meeting"\ndate: "2026-06-18"\n---\n\n**Speaker 1** [0:00]\nHello';
+    expect(stripFrontmatter(src)).toBe('**Speaker 1** [0:00]\nHello');
+  });
+
+  it('handles CRLF line endings', () => {
+    const src = '---\r\ntitle: "x"\r\n---\r\n\r\nBody';
+    expect(stripFrontmatter(src)).toBe('Body');
+  });
+
+  it('leaves content without front-matter unchanged', () => {
+    const src = '# Notes\n- a point';
+    expect(stripFrontmatter(src)).toBe(src);
+  });
+
+  it('does not strip a `---` that is not at the very start', () => {
+    const src = 'Intro\n\n---\ntitle: x\n---\n';
+    expect(stripFrontmatter(src)).toBe(src);
+  });
+
+  it('returns empty input unchanged', () => {
+    expect(stripFrontmatter('')).toBe('');
+  });
+});
 
 describe('renderMarkdown task lists', () => {
   it('renders `- [ ]` as a disabled unchecked checkbox', () => {

--- a/src/utils/markdown.ts
+++ b/src/utils/markdown.ts
@@ -38,6 +38,18 @@ function renderInline(text: string): string {
   return out;
 }
 
+// Strip a leading YAML front-matter block (`---` … `---`) if the string opens
+// with one. Local recordings persist note/transcript markdown with metadata
+// front-matter (title/date/duration/participants) that's useful in the exported
+// file on disk but is noise when rendering in-app, so callers strip it for
+// display only. Returns the input unchanged when there's no leading block.
+export function stripFrontmatter(src: string): string {
+  if (!src) return src;
+  const normalized = src.replace(/\r\n/g, '\n');
+  const match = normalized.match(/^---\n[\s\S]*?\n---[ \t]*(?:\n|$)/);
+  return match ? normalized.slice(match[0].length).replace(/^\n+/, '') : src;
+}
+
 /** Render a Markdown string to a sanitized HTML string. */
 export function renderMarkdown(src: string): string {
   if (!src) return '';

--- a/src/views/MeetingDetailView.vue
+++ b/src/views/MeetingDetailView.vue
@@ -136,7 +136,7 @@
 
         <div v-show="activeTab === 'note'" class="tab-pane">
           <!-- Local note -->
-          <div v-if="detail.isLocal && detail.note" class="md" v-html="renderMarkdown(detail.note)" />
+          <div v-if="detail.isLocal && detail.note" class="md" v-html="renderMarkdown(stripFrontmatter(detail.note))" />
 
           <!-- Ariso rich content -->
           <template v-if="!detail.isLocal">
@@ -272,7 +272,7 @@
 
 <script setup lang="ts">
 import { ref, computed, watch, nextTick, onBeforeUnmount } from 'vue';
-import { renderMarkdown } from '../utils/markdown';
+import { renderMarkdown, stripFrontmatter } from '../utils/markdown';
 import type { TranscriptChunk } from '../composables/useMeetingApi';
 import { useMeetingNotesPersistence } from '../composables/useMeetingNotesPersistence';
 import {
@@ -649,9 +649,11 @@ function commitNoteTitle(): void {
 // Local recordings carry their transcript as markdown on the detail; Ariso
 // loads structured chunks lazily into `transcript`. The Transcript tab renders
 // whichever is present.
-const transcriptMarkdown = computed<string | null>(() =>
-  detail.value?.isLocal ? detail.value?.transcript ?? null : null
-);
+const transcriptMarkdown = computed<string | null>(() => {
+  if (!detail.value?.isLocal) return null;
+  const md = detail.value?.transcript;
+  return md ? stripFrontmatter(md) : null;
+});
 const transcriptChunks = computed<TranscriptChunk[] | null>(() => {
   if (detail.value?.isLocal) return null;
   return Array.isArray(transcript.value) ? transcript.value : null;
@@ -973,7 +975,7 @@ const durationLabel = computed<string | null>(() => {
 
 /* Header */
 .card-head { display: flex; align-items: flex-start; justify-content: space-between; gap: 12px; padding: 22px 24px 12px; border-bottom: 1px solid #e5e6e3; }
-.head-titles { min-width: 0; }
+.head-titles { flex: 1; min-width: 0; }
 .head-title { margin: 0; font-size: 22px; font-weight: 700; line-height: 1.2; color: #1c1c1c; }
 .head-title--editable { cursor: text; }
 .head-title--input {
@@ -1065,6 +1067,8 @@ const durationLabel = computed<string | null>(() => {
 
 /* Content */
 .card-content { flex: 1; min-height: 0; overflow-y: auto; padding: 8px 24px 24px; }
+.card-content::-webkit-scrollbar { width: 6px; }
+.card-content::-webkit-scrollbar-thumb { background: #d6d6d6; border-radius: 3px; }
 .tab-pane { min-height: 100%; }
 .tab-pane--editor { display: flex; flex-direction: column; }
 .notes-head { margin-bottom: 14px; }


### PR DESCRIPTION
Three small UI fixes in `MeetingDetailView`:

- **Editable title** — `head-titles` now flex-grows so the rename input fills the row up to the actions, instead of a fixed ~321px box.
- **Transcript scrollbar** — `card-content` uses the same narrow 6px rounded scrollbar as the sidebar.
- **Local front-matter** — strip the YAML `--- title: … ---` block from local transcript and AI-note markdown on display (on-disk files keep it). New `stripFrontmatter` helper + tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Meeting notes and transcripts now automatically remove unnecessary metadata formatting before display, resulting in a cleaner, more focused reading experience.

* **Style**
  * Improved header layout and scrollbar styling in the meeting detail view for enhanced visual presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->