### PR TITLE
Refine recording UX in the Meetings window

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -574,7 +574,10 @@ pub(crate) fn open_waveform_window(
         .title("")
         // Fixed size: room for the expanded pill plus its CSS shadow. The pill
         // itself is anchored to the bottom and grows upward within this window.
-        .inner_size(92.0, 284.0)
+        .inner_size(
+            crate::recorder_pill::PILL_W,
+            crate::recorder_pill::PILL_H,
+        )
         // Born visible even when the library's embedded strip is the real UI:
         // WebKit won't resolve getUserMedia for a hidden window, so the pill
         // must stay on screen until capture starts. The visibility watcher
@@ -592,23 +595,12 @@ pub(crate) fn open_waveform_window(
         .map_err(|e| e.to_string())?;
 
     // When the pill is the visible recording UI (the meetings window is hidden,
-    // minimized, or closed), dock it to the right edge of the primary screen,
-    // vertically centered, rather than leaving it at the OS default spot. When
-    // the meetings window owns the UI the pill is painted-empty, so its position
-    // doesn't matter.
+    // minimized, or closed), dock it to the right edge of the primary screen
+    // rather than leaving it at the OS default spot. When the meetings window
+    // owns the UI the pill is painted-empty, so its position doesn't matter —
+    // the watcher re-docks it later if the meetings window is minimized.
     if !pill_hidden {
-        if let Ok(Some(monitor)) = win.primary_monitor() {
-            let scale = monitor.scale_factor();
-            let msize = monitor.size();
-            let mpos = monitor.position();
-            // Window outer size is the fixed inner size (no decorations).
-            let win_w = (92.0 * scale).round() as i32;
-            let win_h = (284.0 * scale).round() as i32;
-            let margin = (16.0 * scale).round() as i32;
-            let x = mpos.x + msize.width as i32 - win_w - margin;
-            let y = mpos.y + (msize.height as i32 - win_h) / 2;
-            let _ = win.set_position(tauri::PhysicalPosition::new(x, y));
-        }
+        crate::recorder_pill::dock_to_right_edge(&win);
     }
 
     let source = if auto {

--- a/src-tauri/src/recorder_pill.rs
+++ b/src-tauri/src/recorder_pill.rs
@@ -6,9 +6,45 @@
 //! closed. Tauri emits no minimize/restore events, so a watcher task polls
 //! and exits once the waveform window is gone.
 
-use tauri::{AppHandle, Emitter, Manager};
+use tauri::{AppHandle, Emitter, Manager, PhysicalPosition, WebviewWindow};
 
 const POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(200);
+
+/// Pill ("waveform") window size in CSS px — must match the `inner_size` used
+/// when the window is built (see `open_waveform_window`). Kept here so the
+/// right-edge docking math and the window dimensions stay in sync.
+pub(crate) const PILL_W: f64 = 92.0;
+pub(crate) const PILL_H: f64 = 284.0;
+/// Gap from the screen's right edge, in CSS px.
+const PILL_MARGIN: f64 = 16.0;
+
+/// Physical-pixel top-left for the pill docked to a monitor's right edge,
+/// vertically centered. Pure so the edge math is unit-tested without a window.
+fn pill_dock_position(monitor_pos: (i32, i32), monitor_size: (u32, u32), scale: f64) -> (i32, i32) {
+    let win_w = (PILL_W * scale).round() as i32;
+    let win_h = (PILL_H * scale).round() as i32;
+    let margin = (PILL_MARGIN * scale).round() as i32;
+    let x = monitor_pos.0 + monitor_size.0 as i32 - win_w - margin;
+    let y = monitor_pos.1 + (monitor_size.1 as i32 - win_h) / 2;
+    (x, y)
+}
+
+/// Dock the pill to the right edge of the primary screen, vertically centered,
+/// rather than wherever the OS first placed it (≈ mid-screen). Called both when
+/// the pill is born as the visible UI and each time the watcher reveals it
+/// (e.g. the meetings window was minimized mid-recording).
+pub(crate) fn dock_to_right_edge(win: &WebviewWindow) {
+    if let Ok(Some(monitor)) = win.primary_monitor() {
+        let msize = monitor.size();
+        let mpos = monitor.position();
+        let (x, y) = pill_dock_position(
+            (mpos.x, mpos.y),
+            (msize.width, msize.height),
+            monitor.scale_factor(),
+        );
+        let _ = win.set_position(PhysicalPosition::new(x, y));
+    }
+}
 
 /// The pill is the fallback recording UI: visible only while the library
 /// window (hosting the embedded recorder strip) is absent or minimized.
@@ -67,6 +103,10 @@ pub(crate) fn spawn_watcher(app: &AppHandle) {
             let visible = wave.is_visible().unwrap_or(desired);
             match visibility_action(desired, capture, visible) {
                 Some(true) => {
+                    // Re-dock to the right edge before revealing: the pill was
+                    // born at the OS default spot when the meetings window owned
+                    // the UI, so show it docked rather than mid-screen.
+                    dock_to_right_edge(&wave);
                     let _ = wave.show();
                 }
                 Some(false) => {
@@ -116,5 +156,23 @@ mod tests {
         assert_eq!(visibility_action(true, true, true), None);
         assert_eq!(visibility_action(false, true, false), None);
         assert_eq!(visibility_action(false, false, false), None);
+    }
+
+    #[test]
+    fn docks_against_the_monitor_right_edge_vertically_centered() {
+        // 1920x1080 primary monitor at the origin, no HiDPI scaling.
+        let (x, y) = pill_dock_position((0, 0), (1920, 1080), 1.0);
+        assert_eq!(x, 1920 - PILL_W as i32 - PILL_MARGIN as i32); // 16px gap from the right
+        assert_eq!(y, (1080 - PILL_H as i32) / 2); // vertically centered
+    }
+
+    #[test]
+    fn dock_position_respects_scale_and_monitor_offset() {
+        // A 2x monitor positioned to the right of a primary one (offset origin).
+        let (x, y) = pill_dock_position((1920, 0), (2560, 1440), 2.0);
+        let win_w = (PILL_W * 2.0) as i32;
+        let margin = (PILL_MARGIN * 2.0) as i32;
+        assert_eq!(x, 1920 + 2560 - win_w - margin);
+        assert_eq!(y, (1440 - (PILL_H * 2.0) as i32) / 2);
     }
 }

--- a/src/views/LibraryView.test.ts
+++ b/src/views/LibraryView.test.ts
@@ -512,29 +512,57 @@ describe('LibraryView', () => {
     expect(invoke).toHaveBeenCalledWith('start_recording_window', {});
   });
 
-  it('hides the sidebar and disables the Start button while a recording (waveform window) is active', async () => {
+  it('hides the sidebar for an active recording (waveform window) without disabling Start on its own', async () => {
     listMeetings.mockResolvedValue([]);
     getAllWebviewWindows.mockResolvedValue([{ label: 'waveform' }]);
     const wrapper = mount(LibraryView);
     await flushPromises();
-    // The sidebar collapses, but the titlebar Start button stays — disabled, so
-    // a second recording can't be started over the live one.
+    // The sidebar collapses for the recording session…
     expect(wrapper.find('.sidebar').exists()).toBe(false);
+    // …but the Start button is disabled only by the docked recorder strip, not
+    // by the mere presence of the recorder window (which can't be reset here).
     const btn = wrapper.find('.add-btn');
     expect(btn.exists()).toBe(true);
-    expect(btn.attributes('disabled')).toBeDefined();
+    expect(btn.attributes('disabled')).toBeUndefined();
   });
 
-  it('hides the sidebar and disables the Start button immediately after clicking it', async () => {
+  it('hides the sidebar immediately after clicking Start, leaving the button usable', async () => {
     listMeetings.mockResolvedValue([]);
     const wrapper = mount(LibraryView);
     await flushPromises();
     expect(wrapper.find('.sidebar').exists()).toBe(true);
-    expect(wrapper.find('.add-btn').attributes('disabled')).toBeUndefined();
     await wrapper.find('.add-btn').trigger('click');
     await flushPromises();
+    // Sidebar collapses right away; the button stays enabled until the strip
+    // docks (a redundant click merely refocuses the recorder window).
     expect(wrapper.find('.sidebar').exists()).toBe(false);
-    expect(wrapper.find('.add-btn').attributes('disabled')).toBeDefined();
+    expect(wrapper.find('.add-btn').attributes('disabled')).toBeUndefined();
+  });
+
+  // Regression: stopping a recording from the in-library strip leaves the
+  // window focused, so no focus event fires to reset the internal `recording`
+  // flag. The Start button must NOT stay stuck disabled — disabling is driven
+  // by the docked strip's presence, not by that flag.
+  it('keeps the Start button usable after a recording ends without a refocus', async () => {
+    listMeetings.mockResolvedValue([item({ id: 'a', title: 'Standup' })]);
+    const wrapper = mountWithDetailStub();
+    await flushPromises();
+    await wrapper.find('.add-btn').trigger('click');
+    await flushPromises();
+
+    // Recording runs, then stops — the strip relays a 'recording' then 'closed'
+    // heartbeat. No window 'focus' event is dispatched (the strip was in-window).
+    emitEvent('recorder://state', localRecorderState());
+    await flushPromises();
+    emitEvent('recorder://state', localRecorderState({ phase: 'closed' }));
+    await flushPromises();
+
+    const btn = wrapper.find('.add-btn');
+    expect(btn.attributes('disabled')).toBeUndefined();
+    invoke.mockClear();
+    await btn.trigger('click');
+    await flushPromises();
+    expect(invoke).toHaveBeenCalledWith('start_recording_window', {});
   });
 
   it('reloads meetings when the window regains focus (recorder finished)', async () => {

--- a/src/views/LibraryView.test.ts
+++ b/src/views/LibraryView.test.ts
@@ -923,6 +923,26 @@ describe('LibraryView', () => {
     expect(wrapper.find('.add-btn').attributes('disabled')).toBeDefined();
   });
 
+  // Clicking the floating recorder pill emits `recording://reveal`; the open
+  // library must jump back to the recording meeting (re-docking the strip).
+  it('re-selects the recording meeting on a reveal event (recording pill clicked)', async () => {
+    listMeetings.mockResolvedValue([item({ id: 'a', title: 'Standup' })]);
+    const wrapper = mountWithDetailStub();
+    await flushPromises();
+    emitEvent('recorder://state', localRecorderState());
+    await flushPromises();
+    // Navigate off the recording (14:30) onto Standup (10:00).
+    await wrapper.findAll('.meeting-item')[0].trigger('click');
+    await flushPromises();
+    expect(wrapper.find('.strip').exists()).toBe(false);
+
+    emitEvent('recording://reveal', {});
+    await flushPromises();
+
+    expect(wrapper.find('.strip').exists()).toBe(true);
+    expect(wrapper.find('.add-btn--recording').exists()).toBe(false);
+  });
+
   // Req 2: closing the detail pane mid-recording also surfaces the indicator.
   it('shows the "Recording" indicator after the detail pane is closed mid-recording', async () => {
     listMeetings.mockResolvedValue([item({ id: 'a', title: 'Standup' })]);

--- a/src/views/LibraryView.test.ts
+++ b/src/views/LibraryView.test.ts
@@ -89,6 +89,18 @@ function item(over: Record<string, unknown>) {
   };
 }
 
+// MeetingDetailView mounts a TipTap editor jsdom can't fully host; stub it to a
+// lightweight placeholder when a test only cares about the surrounding Library
+// chrome (selection, the recorder strip, the titlebar button).
+const detailStub = {
+  name: 'MeetingDetailView',
+  emits: ['close', 'title-updated'],
+  template: '<div class="detail-stub"><button class="btn-close" @click="$emit(\'close\')">x</button></div>',
+};
+function mountWithDetailStub() {
+  return mount(LibraryView, { global: { stubs: { MeetingDetailView: detailStub } } });
+}
+
 // Auto-unmount between tests so each component's window 'focus' listener is
 // removed — otherwise a dispatched focus event would also fire stale listeners.
 enableAutoUnmount(afterEach);
@@ -500,22 +512,29 @@ describe('LibraryView', () => {
     expect(invoke).toHaveBeenCalledWith('start_recording_window', {});
   });
 
-  it('hides the sidebar (and add button) while a recording (waveform window) is active', async () => {
+  it('hides the sidebar and disables the Start button while a recording (waveform window) is active', async () => {
     listMeetings.mockResolvedValue([]);
     getAllWebviewWindows.mockResolvedValue([{ label: 'waveform' }]);
     const wrapper = mount(LibraryView);
     await flushPromises();
-    expect(wrapper.find('.add-btn').exists()).toBe(false);
+    // The sidebar collapses, but the titlebar Start button stays — disabled, so
+    // a second recording can't be started over the live one.
+    expect(wrapper.find('.sidebar').exists()).toBe(false);
+    const btn = wrapper.find('.add-btn');
+    expect(btn.exists()).toBe(true);
+    expect(btn.attributes('disabled')).toBeDefined();
   });
 
-  it('hides the sidebar immediately after clicking the add button', async () => {
+  it('hides the sidebar and disables the Start button immediately after clicking it', async () => {
     listMeetings.mockResolvedValue([]);
     const wrapper = mount(LibraryView);
     await flushPromises();
-    expect(wrapper.find('.add-btn').exists()).toBe(true);
+    expect(wrapper.find('.sidebar').exists()).toBe(true);
+    expect(wrapper.find('.add-btn').attributes('disabled')).toBeUndefined();
     await wrapper.find('.add-btn').trigger('click');
     await flushPromises();
-    expect(wrapper.find('.add-btn').exists()).toBe(false);
+    expect(wrapper.find('.sidebar').exists()).toBe(false);
+    expect(wrapper.find('.add-btn').attributes('disabled')).toBeDefined();
   });
 
   it('reloads meetings when the window regains focus (recorder finished)', async () => {
@@ -840,6 +859,84 @@ describe('LibraryView', () => {
     expect(rows[0].attributes('aria-pressed')).toBe('true');
     expect(wrapper.find('.strip').exists()).toBe(false);
     expect(rows[1].find('.mi-rec-dot').exists()).toBe(true);
+  });
+
+  // Req 1: the floating recorder is docked in the detail pane → the titlebar
+  // keeps the Start button but disables it so a second recording can't begin.
+  it('disables the Start button while the recorder strip is docked in the detail pane', async () => {
+    listMeetings.mockResolvedValue([item({ id: 'a', title: 'Standup' })]);
+    const wrapper = mountWithDetailStub();
+    await flushPromises();
+    emitEvent('recorder://state', localRecorderState());
+    await flushPromises();
+
+    expect(wrapper.find('.strip').exists()).toBe(true);
+    const btn = wrapper.find('.add-btn');
+    expect(btn.exists()).toBe(true);
+    expect(btn.text()).toContain('Start recording');
+    expect(btn.attributes('disabled')).toBeDefined();
+    expect(wrapper.find('.add-btn--recording').exists()).toBe(false);
+  });
+
+  // Req 2: recording continues but its meeting is no longer shown (the user
+  // navigated to another meeting) → the Start button becomes a "Recording"
+  // indicator.
+  it('swaps the Start button for a "Recording" indicator when the recording is off-screen', async () => {
+    listMeetings.mockResolvedValue([item({ id: 'a', title: 'Standup' })]);
+    const wrapper = mountWithDetailStub();
+    await flushPromises();
+    emitEvent('recorder://state', localRecorderState());
+    await flushPromises();
+
+    // rows[0] is Standup (10:00); rows[1] is the recording (14:30). Move off the
+    // recording onto Standup.
+    const rows = wrapper.findAll('.meeting-item');
+    await rows[0].trigger('click');
+    await flushPromises();
+
+    expect(wrapper.find('.strip').exists()).toBe(false);
+    const pill = wrapper.find('.add-btn--recording');
+    expect(pill.exists()).toBe(true);
+    expect(pill.text()).toContain('In recording');
+    // It renders the mini waveform, not the plain "Start recording" button.
+    expect(pill.find('.rec-wave').exists()).toBe(true);
+    expect(wrapper.find('.add-btn').text()).not.toContain('Start recording');
+  });
+
+  // Req 2: clicking the indicator re-docks the strip on the recording meeting.
+  it('clicking the "Recording" indicator re-docks the strip on the recording meeting', async () => {
+    listMeetings.mockResolvedValue([item({ id: 'a', title: 'Standup' })]);
+    const wrapper = mountWithDetailStub();
+    await flushPromises();
+    emitEvent('recorder://state', localRecorderState());
+    await flushPromises();
+    await wrapper.findAll('.meeting-item')[0].trigger('click');
+    await flushPromises();
+    expect(wrapper.find('.add-btn--recording').exists()).toBe(true);
+    expect(wrapper.find('.strip').exists()).toBe(false);
+
+    await wrapper.find('.add-btn--recording').trigger('click');
+    await flushPromises();
+
+    expect(wrapper.find('.strip').exists()).toBe(true);
+    expect(wrapper.find('.add-btn--recording').exists()).toBe(false);
+    expect(wrapper.find('.add-btn').attributes('disabled')).toBeDefined();
+  });
+
+  // Req 2: closing the detail pane mid-recording also surfaces the indicator.
+  it('shows the "Recording" indicator after the detail pane is closed mid-recording', async () => {
+    listMeetings.mockResolvedValue([item({ id: 'a', title: 'Standup' })]);
+    const wrapper = mountWithDetailStub();
+    await flushPromises();
+    emitEvent('recorder://state', localRecorderState());
+    await flushPromises();
+    expect(wrapper.find('.strip').exists()).toBe(true);
+
+    await wrapper.find('.detail-stub .btn-close').trigger('click');
+    await flushPromises();
+
+    expect(wrapper.find('.strip').exists()).toBe(false);
+    expect(wrapper.find('.add-btn--recording').exists()).toBe(true);
   });
 
   it('reloads when the recording closes so the finalized row replaces the synthetic one', async () => {

--- a/src/views/LibraryView.vue
+++ b/src/views/LibraryView.vue
@@ -670,6 +670,7 @@ function onGlobalKeydown(event: KeyboardEvent): void {
 
 let clockTimer: number | undefined;
 let unlistenRecordingStarted: UnlistenFn | null = null;
+let unlistenRecordingReveal: UnlistenFn | null = null;
 
 // Recover the attached meeting for a recording that started before this
 // library window existed. The `recording://started` event is one-shot, so a
@@ -691,6 +692,13 @@ onMounted(() => {
   void listen('recording://started', onRecordingStarted).then((un) => {
     unlistenRecordingStarted = un;
   });
+  // The floating recorder pill asks (on click) to surface the meeting it's
+  // recording — re-dock the strip even if the user had navigated away.
+  void listen('recording://reveal', () => {
+    void showRecordingMeeting();
+  }).then((un) => {
+    unlistenRecordingReveal = un;
+  });
   clockTimer = window.setInterval(() => {
     now.value = new Date();
   }, 30_000);
@@ -703,6 +711,7 @@ onUnmounted(() => {
   window.removeEventListener('focus', onWindowFocus);
   window.removeEventListener('keydown', onGlobalKeydown);
   unlistenRecordingStarted?.();
+  unlistenRecordingReveal?.();
 });
 </script>
 

--- a/src/views/LibraryView.vue
+++ b/src/views/LibraryView.vue
@@ -223,9 +223,13 @@ const recorderStripVisible = computed(
 // detail or navigated to another meeting). The titlebar then shows a
 // "Recording" indicator instead of the Start button.
 const recordingOffscreen = computed(() => recordingActive.value && !recorderStripVisible.value);
-// Block starting a second recording while one is already shown here, or while
-// a session is otherwise live (waveform window up, before the strip heartbeats).
-const startDisabled = computed(() => recording.value || recorderStripVisible.value);
+// Disable "Start recording" only while the recorder strip is docked here (its
+// meeting is on-screen). This tracks the live strip — which clears the instant
+// recording ends — rather than the `recording` flag, which only resets on a
+// window refocus and would otherwise leave the button stuck disabled after a
+// stop. A redundant second start is harmless anyway: the backend just refocuses
+// the existing recorder window.
+const startDisabled = computed(() => recorderStripVisible.value);
 // Ad-hoc meetings we recorded this session that the backend list doesn't surface
 // yet (e.g. "Record a new meeting" — created via /meeting-notes/audio, so it
 // isn't a calendar-scheduled meeting and never appears in listMeetings()). We

--- a/src/views/LibraryView.vue
+++ b/src/views/LibraryView.vue
@@ -19,7 +19,35 @@
           <line x1="6.75" y1="3" x2="6.75" y2="15" stroke="currentColor" stroke-width="1.5" />
         </svg>
       </button>
-      <button class="add-btn" aria-label="Start recording" title="Start recording" @click="startRecording">
+      <!-- While a recording runs off-screen (its meeting isn't shown), the
+           Start button becomes a "Recording" indicator that re-docks the strip
+           when clicked. Otherwise it starts a recording, disabled while the
+           strip is already on-screen so a second recording can't begin. -->
+      <button
+        v-if="recordingOffscreen"
+        class="add-btn add-btn--recording"
+        type="button"
+        aria-label="Show current recording"
+        title="Show current recording"
+        @click="showRecordingMeeting"
+      >
+        <span class="rec-wave" aria-hidden="true">
+          <span class="rec-wave-bar" />
+          <span class="rec-wave-bar" />
+          <span class="rec-wave-bar" />
+          <span class="rec-wave-bar" />
+        </span>
+        <span class="add-btn-label">In recording</span>
+      </button>
+      <button
+        v-else
+        class="add-btn"
+        type="button"
+        :disabled="startDisabled"
+        aria-label="Start recording"
+        title="Start recording"
+        @click="startRecording"
+      >
         <svg width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden="true">
           <path d="M8 3v10M3 8h10" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" />
         </svg>
@@ -182,6 +210,22 @@ const recordingMeetingId = ref<string | null>(null);
 // True only while audio is actively being captured — gates the red dot so it
 // stops pulsing the moment recording ends (e.g. a lingering failed-upload pill).
 const recordingActive = ref(false);
+
+// The recorder strip is docked in the detail pane when an active recording's
+// meeting is the one on-screen (a recording with no home row shows anywhere).
+// Mirrors RecorderStrip's own visibility rule.
+const recorderStripVisible = computed(
+  () =>
+    recordingActive.value &&
+    (recordingMeetingId.value == null || recordingMeetingId.value === selectedItem.value?.id)
+);
+// A recording is running but its meeting isn't on-screen (the user closed the
+// detail or navigated to another meeting). The titlebar then shows a
+// "Recording" indicator instead of the Start button.
+const recordingOffscreen = computed(() => recordingActive.value && !recorderStripVisible.value);
+// Block starting a second recording while one is already shown here, or while
+// a session is otherwise live (waveform window up, before the strip heartbeats).
+const startDisabled = computed(() => recording.value || recorderStripVisible.value);
 // Ad-hoc meetings we recorded this session that the backend list doesn't surface
 // yet (e.g. "Record a new meeting" — created via /meeting-notes/audio, so it
 // isn't a calendar-scheduled meeting and never appears in listMeetings()). We
@@ -294,6 +338,15 @@ async function clearSelection(): Promise<void> {
   await detailView.value?.saveNotesNow?.();
   if (my !== selectionReqId) return;
   selectedItem.value = null;
+}
+
+// Re-dock the recorder strip: pull the in-progress recording's meeting back
+// into the detail pane (the titlebar "Recording" indicator's action).
+async function showRecordingMeeting(): Promise<void> {
+  const id = recordingMeetingId.value;
+  if (!id) return;
+  const m = displayMeetings.value.find((x) => x.id === id);
+  if (m) await selectMeeting(m);
 }
 
 function openSearchPalette(): void {
@@ -738,6 +791,39 @@ onUnmounted(() => {
   white-space: nowrap;
 }
 .add-btn:hover { box-shadow: 0 0 0 #e7e5e2; transform: translate(1px, 1px); }
+.add-btn:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+.add-btn:disabled:hover { box-shadow: 1px 1px 0 #e7e5e2; transform: none; }
+/* Recording indicator: same pill, tinted red, pausing-glyph + "Recording". */
+.add-btn--recording {
+  color: #c5352f;
+  border-color: #f0c5c3;
+  background: #fdf3f2;
+}
+.add-btn--recording .add-btn-label { color: #c5352f; }
+/* Mini live waveform: four bars pulsing on a staggered cycle. */
+.rec-wave {
+  display: inline-flex;
+  align-items: center;
+  gap: 1.5px;
+  height: 12px;
+}
+.rec-wave-bar {
+  width: 2px;
+  height: 4px;
+  border-radius: 1px;
+  background: currentColor;
+  animation: rec-wave 0.9s ease-in-out infinite;
+}
+.rec-wave-bar:nth-child(2) { animation-delay: 0.15s; }
+.rec-wave-bar:nth-child(3) { animation-delay: 0.3s; }
+.rec-wave-bar:nth-child(4) { animation-delay: 0.45s; }
+@keyframes rec-wave {
+  0%, 100% { height: 4px; }
+  50% { height: 12px; }
+}
 
 .search-trigger {
   display: flex;

--- a/src/views/WaveformView.vue
+++ b/src/views/WaveformView.vue
@@ -212,10 +212,14 @@ function collapse() {
 }
 
 // Clicking the pill body (not the controls or the drag handle) brings up the
-// meetings window.
+// meetings window and surfaces the meeting being recorded. A window that was
+// only minimized is already running, so it needs the explicit `reveal` nudge;
+// a freshly-created one instead lands on the recording via its own
+// recordingMeetingId watch once the recorder strip's first heartbeat arrives.
 async function showMeetings() {
   try {
     await invoke('create_library_window');
+    await emit('recording://reveal');
   } catch (e) {
     console.error('Failed to open meetings window', e);
   }


### PR DESCRIPTION

<img width="899" height="600" alt="Screenshot 2026-06-19 at 16 03 51" src="https://github.com/user-attachments/assets/e85b6364-ac8b-4b18-9888-63f395502f64" />

## Summary

Polishes the recording experience in the Meetings (`library`) window and the floating recorder pill.

- **Disable / "In recording" indicator** — While the recorder strip is docked in the detail pane, the top-right **Start recording** button is disabled. When a recording continues off-screen (detail closed or another meeting selected), the button becomes an **"In recording"** indicator with an animated mini waveform; clicking it re-docks the strip on the meeting being recorded.
- **Pill docks to the right edge** — The floating recorder pill now docks to the right edge of the screen whenever it's revealed (Meetings window minimized *or* closed mid-recording), not just at creation — previously it surfaced at the OS default mid-screen spot. Positioning is factored into a shared, unit-tested helper in `recorder_pill.rs`.
- **Click pill → reveal recording** — Clicking the pill already restored the Meetings window; it now also emits `recording://reveal` so an already-open (minimized) window re-docks the strip on the recording meeting even if the user had navigated away. A freshly-created window lands on it via the existing `recordingMeetingId` watch.
- **Fix: Start button no longer sticks disabled** — Disabling was keyed partly off the internal `recording` flag, which only resets on a window refocus. Stopping a recording from the in-library strip leaves the window focused (no `focus` event), so the flag stayed `true` and the button stayed disabled. Disabling is now driven solely by the docked strip (`recorderStripVisible`), which clears the moment recording ends.

## Testing

- Frontend (`LibraryView.test.ts`): added behavior + regression tests for the disabled state, the "In recording" indicator, click-to-re-dock, the `recording://reveal` listener, and the stuck-disabled regression. `npm run vite:build` compiles clean.
- Rust (`recorder_pill.rs`): added unit tests for the right-edge docking math (scale + multi-monitor offset). `cargo test … recorder_pill` → 8 passed.

> Note: the `LibraryView`/`MeetingDetailView` Vitest files have a pre-existing full-run flake on this machine (incomplete `../tauri` mock + jsdom/TipTap gaps), so new tests were verified in isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Recording" indicator that appears when recording is active but the recorder strip is off-screen
  * Added reveal mechanism to show the recording when the indicator is clicked

* **Bug Fixes**
  * Improved recorder strip positioning to consistently dock to the right edge of the screen
  * Enhanced visibility coordination between recorder strip and detail pane during active recording

* **Tests**
  * Expanded test coverage for recorder strip docking behavior and state transitions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->