### PR TITLE
fix: guard null device UID and validate tap format (GHSA-cvf3-62r6-ch7v)

### DIFF
--- a/src-tauri/src/audio_capture.rs
+++ b/src-tauri/src/audio_capture.rs
@@ -50,8 +50,9 @@ mod imp {
         CATapDescription, CATapMuteBehavior,
     };
     use objc2_core_audio_types::{
-        kAudioFormatFlagIsFloat, kAudioFormatLinearPCM, AudioBufferList, AudioStreamBasicDescription,
-        AudioTimeStamp,
+        kAudioFormatFlagIsBigEndian, kAudioFormatFlagIsFloat, kAudioFormatFlagIsPacked,
+        kAudioFormatLinearPCM, kLinearPCMFormatFlagIsNonInterleaved, AudioBufferList,
+        AudioStreamBasicDescription, AudioTimeStamp,
     };
     use objc2_core_foundation::{CFDictionary, CFRetained, CFString};
     use objc2_foundation::{NSArray, NSDictionary, NSNumber, NSObject, NSString};
@@ -168,6 +169,15 @@ mod imp {
         if status != 0 {
             return Err(format!("AudioObjectGetPropertyData({selector}) failed: {status}"));
         }
+        // Core Audio can return status 0 with a short read (e.g. 0 bytes for an
+        // absent property), which would leave the buffer uninitialized. Only
+        // `assume_init` once the written size matches `T` exactly.
+        let expected = std::mem::size_of::<T>() as u32;
+        if size != expected {
+            return Err(format!(
+                "AudioObjectGetPropertyData({selector}) returned {size} bytes; expected {expected}"
+            ));
+        }
         Ok(unsafe { value.assume_init() })
     }
 
@@ -224,14 +234,21 @@ mod imp {
         NSDictionary::from_slices(&keys, &values)
     }
 
-    /// Whether a tap stream format is the 32-bit float LinearPCM layout that the
-    /// IO block assumes when `downmix_to_mono` reinterprets buffer bytes as
-    /// `*const f32`. Any other layout would be read as garbage samples, so the
-    /// caller must reject it.
+    /// Whether a tap stream format is the packed, little-endian, interleaved
+    /// 32-bit float LinearPCM layout that the IO block assumes when
+    /// `downmix_to_mono` reinterprets buffer bytes as `*const f32` (dividing
+    /// `mDataByteSize` by 4 bytes per sample). Any other layout — padded,
+    /// big-endian, non-interleaved, or a non-positive sample rate (which would
+    /// make the resampler step 0.0 and stall `Resampler::process` in an infinite
+    /// loop) — would be misread, so the caller must reject it.
     fn is_supported_tap_format(asbd: &AudioStreamBasicDescription) -> bool {
         asbd.mFormatID == kAudioFormatLinearPCM
             && asbd.mFormatFlags & kAudioFormatFlagIsFloat != 0
+            && asbd.mFormatFlags & kAudioFormatFlagIsPacked != 0
+            && asbd.mFormatFlags & kAudioFormatFlagIsBigEndian == 0
+            && asbd.mFormatFlags & kLinearPCMFormatFlagIsNonInterleaved == 0
             && asbd.mBitsPerChannel == 32
+            && asbd.mSampleRate > 0.0
     }
 
     pub fn start(app: tauri::AppHandle) -> Result<(), String> {
@@ -552,6 +569,39 @@ mod imp {
         fn rejects_non_32_bit_depth() {
             let mut asbd = float32_pcm();
             asbd.mBitsPerChannel = 16; // would be misread as f32
+            assert!(!is_supported_tap_format(&asbd));
+        }
+
+        #[test]
+        fn rejects_non_positive_sample_rate() {
+            // step = src_rate / 16_000 would be 0.0, stalling Resampler::process.
+            let mut zero = float32_pcm();
+            zero.mSampleRate = 0.0;
+            assert!(!is_supported_tap_format(&zero));
+
+            let mut negative = float32_pcm();
+            negative.mSampleRate = -48_000.0;
+            assert!(!is_supported_tap_format(&negative));
+        }
+
+        #[test]
+        fn rejects_unpacked_format() {
+            let mut asbd = float32_pcm();
+            asbd.mFormatFlags = kAudioFormatFlagIsFloat; // padded, not tightly packed
+            assert!(!is_supported_tap_format(&asbd));
+        }
+
+        #[test]
+        fn rejects_big_endian_format() {
+            let mut asbd = float32_pcm();
+            asbd.mFormatFlags |= kAudioFormatFlagIsBigEndian;
+            assert!(!is_supported_tap_format(&asbd));
+        }
+
+        #[test]
+        fn rejects_non_interleaved_format() {
+            let mut asbd = float32_pcm();
+            asbd.mFormatFlags |= kLinearPCMFormatFlagIsNonInterleaved;
             assert!(!is_supported_tap_format(&asbd));
         }
     }

--- a/src-tauri/src/audio_capture.rs
+++ b/src-tauri/src/audio_capture.rs
@@ -49,7 +49,10 @@ mod imp {
         AudioHardwareDestroyProcessTap, AudioObjectGetPropertyData, AudioObjectPropertyAddress,
         CATapDescription, CATapMuteBehavior,
     };
-    use objc2_core_audio_types::{AudioBufferList, AudioStreamBasicDescription, AudioTimeStamp};
+    use objc2_core_audio_types::{
+        kAudioFormatFlagIsFloat, kAudioFormatLinearPCM, AudioBufferList, AudioStreamBasicDescription,
+        AudioTimeStamp,
+    };
     use objc2_core_foundation::{CFDictionary, CFRetained, CFString};
     use objc2_foundation::{NSArray, NSDictionary, NSNumber, NSObject, NSString};
     use std::ffi::{c_void, CStr};
@@ -258,7 +261,18 @@ mod imp {
             };
             let output_uid_cf: CFRetained<CFString> =
                 match get_property::<*const CFString>(output_id, kAudioDevicePropertyDeviceUID) {
-                    Ok(ptr) => CFRetained::from_raw(NonNull::new(ptr as *mut CFString).unwrap()),
+                    // Core Audio can return status 0 with a null/absent UID for some
+                    // virtual or aggregate output devices. Guard the pointer instead of
+                    // unwrapping: a null here would panic, and handing a non-owned null to
+                    // `CFRetained::from_raw` (which assumes a +1 retained object) is the
+                    // start of a refcount/UAF bug, not just a crash.
+                    Ok(ptr) => match NonNull::new(ptr as *mut CFString) {
+                        Some(nn) => CFRetained::from_raw(nn),
+                        None => {
+                            AudioHardwareDestroyProcessTap(tap_id);
+                            return Err("default output device has no UID".into());
+                        }
+                    },
                     Err(e) => {
                         AudioHardwareDestroyProcessTap(tap_id);
                         return Err(e);
@@ -275,6 +289,20 @@ mod imp {
                         return Err(e);
                     }
                 };
+            // The IO block reinterprets buffer bytes as `*const f32` in
+            // `downmix_to_mono`, so the tap must actually deliver 32-bit float
+            // LinearPCM. Taps normally do, but verify before trusting the cast:
+            // a non-Float32 layout would otherwise be read as garbage samples.
+            if asbd.mFormatID != kAudioFormatLinearPCM
+                || asbd.mFormatFlags & kAudioFormatFlagIsFloat == 0
+                || asbd.mBitsPerChannel != 32
+            {
+                AudioHardwareDestroyProcessTap(tap_id);
+                return Err(format!(
+                    "unsupported tap stream format (id={}, flags={:#x}, bits={}); expected 32-bit float LinearPCM",
+                    asbd.mFormatID, asbd.mFormatFlags, asbd.mBitsPerChannel
+                ));
+            }
             let src_rate = asbd.mSampleRate;
 
             // 4. Private aggregate device wrapping the tap.

--- a/src-tauri/src/audio_capture.rs
+++ b/src-tauri/src/audio_capture.rs
@@ -224,6 +224,16 @@ mod imp {
         NSDictionary::from_slices(&keys, &values)
     }
 
+    /// Whether a tap stream format is the 32-bit float LinearPCM layout that the
+    /// IO block assumes when `downmix_to_mono` reinterprets buffer bytes as
+    /// `*const f32`. Any other layout would be read as garbage samples, so the
+    /// caller must reject it.
+    fn is_supported_tap_format(asbd: &AudioStreamBasicDescription) -> bool {
+        asbd.mFormatID == kAudioFormatLinearPCM
+            && asbd.mFormatFlags & kAudioFormatFlagIsFloat != 0
+            && asbd.mBitsPerChannel == 32
+    }
+
     pub fn start(app: tauri::AppHandle) -> Result<(), String> {
         let mut guard = CAPTURE.lock().map_err(|e| e.to_string())?;
         if guard.is_some() {
@@ -293,10 +303,7 @@ mod imp {
             // `downmix_to_mono`, so the tap must actually deliver 32-bit float
             // LinearPCM. Taps normally do, but verify before trusting the cast:
             // a non-Float32 layout would otherwise be read as garbage samples.
-            if asbd.mFormatID != kAudioFormatLinearPCM
-                || asbd.mFormatFlags & kAudioFormatFlagIsFloat == 0
-                || asbd.mBitsPerChannel != 32
-            {
+            if !is_supported_tap_format(&asbd) {
                 AudioHardwareDestroyProcessTap(tap_id);
                 return Err(format!(
                     "unsupported tap stream format (id={}, flags={:#x}, bits={}); expected 32-bit float LinearPCM",
@@ -500,6 +507,53 @@ mod imp {
         }
         // Safety: base64 output is always valid UTF-8.
         unsafe { String::from_utf8_unchecked(out) }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+        use objc2_core_audio_types::kAudioFormatFlagIsPacked;
+
+        /// A 32-bit float LinearPCM tap format like Core Audio actually delivers.
+        fn float32_pcm() -> AudioStreamBasicDescription {
+            AudioStreamBasicDescription {
+                mSampleRate: 48_000.0,
+                mFormatID: kAudioFormatLinearPCM,
+                mFormatFlags: kAudioFormatFlagIsFloat | kAudioFormatFlagIsPacked,
+                mBytesPerPacket: 4,
+                mFramesPerPacket: 1,
+                mBytesPerFrame: 4,
+                mChannelsPerFrame: 1,
+                mBitsPerChannel: 32,
+                mReserved: 0,
+            }
+        }
+
+        #[test]
+        fn accepts_float32_linear_pcm() {
+            assert!(is_supported_tap_format(&float32_pcm()));
+        }
+
+        #[test]
+        fn rejects_non_linear_pcm_format() {
+            let mut asbd = float32_pcm();
+            asbd.mFormatID = u32::from_be_bytes(*b"aac "); // compressed, not LinearPCM
+            assert!(!is_supported_tap_format(&asbd));
+        }
+
+        #[test]
+        fn rejects_integer_pcm_missing_float_flag() {
+            let mut asbd = float32_pcm();
+            asbd.mFormatFlags = kAudioFormatFlagIsPacked; // no float flag
+            assert!(!is_supported_tap_format(&asbd));
+        }
+
+        #[test]
+        fn rejects_non_32_bit_depth() {
+            let mut asbd = float32_pcm();
+            asbd.mBitsPerChannel = 16; // would be misread as f32
+            assert!(!is_supported_tap_format(&asbd));
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes the system-audio capture vulnerability tracked in **GHSA-cvf3-62r6-ch7v** (CWE-476 — null pointer dereference; local DoS, with a latent memory-safety edge). All changes are in `src-tauri/src/audio_capture.rs` (`start_system_audio_capture`).

## The problem

System-audio capture reads the default output device's UID via `get_property::<*const CFString>(output_id, kAudioDevicePropertyDeviceUID)`, which returns `Ok` on any status-0 result — even when Core Audio wrote a **null/absent UID**, as some virtual or aggregate output devices do (e.g. a misbehaving virtual audio cable). The old code did `NonNull::new(ptr).unwrap()`, which:

- **Panics** → crashes `start_system_audio_capture` (local DoS).
- Worse, handing a non-owned null to `CFRetained::from_raw` (which assumes a `+1` retained object) is the start of a **refcount/UAF bug**, not just a crash.

## The fix

1. **Guard the UID pointer.** Match the `NonNull` instead of unwrapping: on `None`, destroy the already-created process tap and return `Err("default output device has no UID")` — no panic, no leaked tap, no bogus ownership transfer.

2. **Validate the tap stream format.** The IO block's `downmix_to_mono` reinterprets buffer bytes as `*const f32`. Added a check right after reading the tap's `AudioStreamBasicDescription` that rejects (and tears down the tap) unless the format is **LinearPCM + Float32 flag + 32 bits per channel**, so a non-Float32 layout can never be read as garbage samples.

Both error paths reuse the existing `AudioHardwareDestroyProcessTap(tap_id)` cleanup already used elsewhere in `start()`, so no resource is leaked.

## Testing

- `cargo check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of macOS audio capture by adding safety checks when reading Core Audio properties.
  * Enhanced default output device detection with better handling for missing device UID data.
  * Added strict validation for the captured audio stream format, rejecting unsupported configurations with clearer errors.

* **Tests**
  * Expanded unit tests to cover supported and rejected audio tap format scenarios, including endianness, packing, bit depth, flags, channel layout, and sample-rate edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->