### PR TITLE
fix meeting ordering

### DIFF
--- a/src/composables/groupMeetingsByDate.test.ts
+++ b/src/composables/groupMeetingsByDate.test.ts
@@ -83,20 +83,28 @@ describe('nextDaySection', () => {
 });
 
 describe('groupMeetingsByDate', () => {
-  it('buckets every meeting by calendar date, newest date first, earliest-first within a date', () => {
+  it('buckets meetings by date with upcoming days nearest-first, then past days newest-first', () => {
     const meetings = [
+      m('older', '2026-06-08T09:00:00'),
       m('past1', '2026-06-09T09:00:00'),
       m('today1', '2026-06-10T09:00:00'),
       m('today2', '2026-06-10T11:00:00'),
       m('soon', '2026-06-10T18:00:00'),
+      m('tomorrow', '2026-06-11T09:00:00'),
       m('future', '2026-06-12T10:00:00'),
     ];
     const sections = groupMeetingsByDate(meetings, NOW);
     // No UPCOMING section: future meetings live under their own date header.
-    expect(sections.map((s) => s.label)).toEqual(['FRI, JUN 12', 'TODAY', 'YESTERDAY']);
+    expect(sections.map((s) => s.label)).toEqual([
+      'TODAY',
+      'TOMORROW',
+      'FRI, JUN 12',
+      'YESTERDAY',
+      'MON, JUN 8',
+    ]);
     // Within a date, earliest-first (ascending).
-    expect(sections[1].items.map((x) => x.id)).toEqual(['today1', 'today2', 'soon']);
-    expect(sections[0].items.map((x) => x.id)).toEqual(['future']);
+    expect(sections[0].items.map((x) => x.id)).toEqual(['today1', 'today2', 'soon']);
+    expect(sections[2].items.map((x) => x.id)).toEqual(['future']);
   });
 
   it('returns an empty array for no meetings', () => {

--- a/src/composables/groupMeetingsByDate.ts
+++ b/src/composables/groupMeetingsByDate.ts
@@ -104,8 +104,8 @@ export function nextDaySection(meetings: MeetingListItem[], now: Date): MeetingS
   return { key: nextKey, label: dayLabelWithDate(nextKey, now), items };
 }
 
-/** Bucket every meeting under per-calendar-date headers, newest date first, and
- *  within each date ordered earliest-first (ascending by start time). */
+/** Bucket every meeting under per-calendar-date headers in a meeting-list order:
+ *  today and future dates read nearest-first, while past dates read newest-first. */
 export function groupMeetingsByDate(meetings: MeetingListItem[], now: Date): MeetingSection[] {
   const buckets = new Map<string, MeetingListItem[]>();
   for (const meeting of meetings) {
@@ -117,10 +117,14 @@ export function groupMeetingsByDate(meetings: MeetingListItem[], now: Date): Mee
   }
 
   const sections: MeetingSection[] = [];
-  // Lexical sort == chronological because keys are zero-padded YYYY-MM-DD;
-  // .reverse() then puts the newest date first.
-  const datedKeys = [...buckets.keys()].filter((k) => k !== 'unknown').sort().reverse();
-  for (const key of datedKeys) {
+  const today = localDateKey(now);
+  // Lexical sort == chronological because keys are zero-padded YYYY-MM-DD. The
+  // split keeps upcoming days from being pushed below farther-future meetings.
+  const datedKeys = [...buckets.keys()].filter((k) => k !== 'unknown');
+  const futureAndTodayKeys = datedKeys.filter((key) => key >= today).sort();
+  const pastKeys = datedKeys.filter((key) => key < today).sort().reverse();
+
+  for (const key of [...futureAndTodayKeys, ...pastKeys]) {
     const items = [...buckets.get(key)!].sort(
       (a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime()
     );

--- a/src/views/LibraryView.test.ts
+++ b/src/views/LibraryView.test.ts
@@ -687,6 +687,28 @@ describe('LibraryView', () => {
     expect(invoke).not.toHaveBeenCalledWith('open_meeting_picker', {});
   });
 
+  it('Today view ignores an auto-selected earlier today row when a meeting is live', async () => {
+    backendId.mockReturnValue('ariso');
+    usesMeetingPicker.mockReturnValue(true);
+    const earlierToday = new Date(new Date().setHours(7, 0, 0, 0)).toISOString();
+    const start = new Date(Date.now() - 30 * 60_000).toISOString();
+    const end = new Date(Date.now() + 30 * 60_000).toISOString();
+    listMeetings.mockResolvedValue([
+      item({ id: '50', title: 'Earlier Today', timestamp: earlierToday, files: undefined }),
+      item({ id: '99', title: 'Live Standup', timestamp: start, endTimestamp: end, files: undefined }),
+    ]);
+    const wrapper = mountWithDetailStub();
+    await flushPromises();
+    expect(wrapper.find('.meeting-item').text()).toContain('Earlier Today');
+
+    await wrapper.get('button[title="Today"]').trigger('click');
+    await wrapper.get('.add-btn').trigger('click');
+    await flushPromises();
+
+    expect(invoke).toHaveBeenCalledWith('start_recording_window', { meetingId: 99 });
+    expect(invoke).not.toHaveBeenCalledWith('start_recording_window', { meetingId: 50 });
+  });
+
   it('Today view opens the picker when no meeting is live and none is selected today', async () => {
     backendId.mockReturnValue('ariso');
     usesMeetingPicker.mockReturnValue(true);

--- a/src/views/LibraryView.vue
+++ b/src/views/LibraryView.vue
@@ -88,7 +88,7 @@
             class="meeting-item"
             :class="{ selected: selectedItem?.id === m.id }"
             :aria-pressed="selectedItem?.id === m.id"
-            @click="selectMeeting(m)"
+            @click="selectMeeting(m, { userSelected: true })"
           >
             <span v-if="recordingActive && recordingMeetingId === m.id" class="mi-rec-dot" aria-hidden="true" />
             <span class="mi-head">
@@ -135,7 +135,7 @@
           v-else
           :meetings="displayMeetings"
           :now="now"
-          @select="selectMeeting"
+          @select="(m) => selectMeeting(m, { userSelected: true })"
           @start="startRecordingFor"
           @record="startRecording"
         />
@@ -196,6 +196,9 @@ const error = ref<string | null>(null);
 const recording = ref(false);
 const leftPanelVisible = ref(true);
 const selectedItem = ref<MeetingListItem | null>(null);
+// Tracks the row the user intentionally selected; auto-load and recorder-driven
+// selections must not override Today's "record the live meeting" behavior.
+const userSelectedMeetingId = ref<string | null>(null);
 const ariConfirm = useAriJoinConfirm();
 const activeBackend = ref<Backend | null>(null);
 const searchPaletteOpen = ref(false);
@@ -329,7 +332,9 @@ function itemSub(m: MeetingListItem): string {
 // slow autosave from the previous meeting cannot land after the row changed.
 let selectionReqId = 0;
 
-async function selectMeeting(m: MeetingListItem): Promise<void> {
+async function selectMeeting(m: MeetingListItem, options: { userSelected?: boolean } = {}): Promise<void> {
+  if (options.userSelected) userSelectedMeetingId.value = m.id;
+  else if (userSelectedMeetingId.value !== m.id) userSelectedMeetingId.value = null;
   if (selectedItem.value?.id === m.id) return;
   const my = ++selectionReqId;
   await detailView.value?.saveNotesNow?.();
@@ -342,6 +347,7 @@ async function clearSelection(): Promise<void> {
   await detailView.value?.saveNotesNow?.();
   if (my !== selectionReqId) return;
   selectedItem.value = null;
+  userSelectedMeetingId.value = null;
 }
 
 // Re-dock the recorder strip: pull the in-progress recording's meeting back
@@ -350,7 +356,7 @@ async function showRecordingMeeting(): Promise<void> {
   const id = recordingMeetingId.value;
   if (!id) return;
   const m = displayMeetings.value.find((x) => x.id === id);
-  if (m) await selectMeeting(m);
+  if (m) await selectMeeting(m, { userSelected: false });
 }
 
 function openSearchPalette(): void {
@@ -369,7 +375,7 @@ async function searchMeetings(query: string): Promise<MeetingListItem[]> {
 
 async function onSearchResultSelected(meeting: MeetingListItem): Promise<void> {
   searchPaletteOpen.value = false;
-  await selectMeeting(meeting);
+  await selectMeeting(meeting, { userSelected: true });
 }
 
 // The palette's Home command returns the Library to its neutral detail state:
@@ -446,7 +452,9 @@ async function loadMeetings(autoSelectFirst = false): Promise<void> {
       console.warn('Failed to sync tray after meeting list refresh', err);
     });
     if (autoSelectFirst && !selectedItem.value && meetings.value.length > 0) {
-      await selectMeeting(displayedSections.value[0]?.items[0] ?? meetings.value[0]);
+      await selectMeeting(displayedSections.value[0]?.items[0] ?? meetings.value[0], {
+        userSelected: false,
+      });
     } else if (selectedItem.value) {
       selectedItem.value =
         meetings.value.find((m) => m.id === selectedItem.value?.id) ?? selectedItem.value;
@@ -549,7 +557,10 @@ async function startRecording(): Promise<void> {
     const backend = await getActiveBackend();
     const usesPicker = backend.usesMeetingPicker;
     const selectedTodayId =
-      usesPicker && activeView.value === 'today' && isTodayItem(selectedItem.value)
+      usesPicker &&
+      activeView.value === 'today' &&
+      selectedItem.value?.id === userSelectedMeetingId.value &&
+      isTodayItem(selectedItem.value)
         ? numericMeetingId(selectedItem.value)
         : undefined;
     const nowMeetingId = usesPicker ? numericMeetingId(currentNowItem()) : undefined;
@@ -630,7 +641,7 @@ async function selectRecordingMeeting(id: number | null | undefined): Promise<vo
     await pinRecordedMeeting(idStr);
     m = displayMeetings.value.find((x) => x.id === idStr);
   }
-  if (m) await selectMeeting(m);
+  if (m) await selectMeeting(m, { userSelected: false });
 }
 
 // Keep the detail panel on the recorded meeting: surface its row when the
@@ -643,7 +654,7 @@ watch(recordingMeetingId, async (id, prevId) => {
     // Ariso meeting the calendar list doesn't carry.
     await pinRecordedMeeting(id);
     const m = displayMeetings.value.find((x) => x.id === id);
-    if (m && selectedItem.value?.id !== id) await selectMeeting(m);
+    if (m && selectedItem.value?.id !== id) await selectMeeting(m, { userSelected: false });
     return;
   }
   await loadMeetings();
@@ -652,6 +663,7 @@ watch(recordingMeetingId, async (id, prevId) => {
     // Discarded/crashed recording — its row is gone (and nothing pinned it);
     // fall back to the first available meeting.
     selectedItem.value = displayMeetings.value[0] ?? null;
+    userSelectedMeetingId.value = null;
   }
 });
 

--- a/src/views/LibraryView.vue
+++ b/src/views/LibraryView.vue
@@ -419,9 +419,9 @@ function setRecording(next: boolean): void {
 let loadMeetingsRequest = 0;
 
 // `autoSelectFirst` is only set for the initial mount load: opening the window
-// lands on the most recent meeting. Refresh-driven reloads (window focus/move,
-// upload completion) pass false so they never yank the user off the Up Next
-// greeting/card view back into a meeting detail.
+// lands on the first visible grouped row, not the backend's raw list order.
+// Refresh-driven reloads (window focus/move, upload completion) pass false so
+// they never yank the user off the Up Next greeting/card view back into detail.
 async function loadMeetings(autoSelectFirst = false): Promise<void> {
   const requestId = ++loadMeetingsRequest;
   loading.value = true;
@@ -446,7 +446,7 @@ async function loadMeetings(autoSelectFirst = false): Promise<void> {
       console.warn('Failed to sync tray after meeting list refresh', err);
     });
     if (autoSelectFirst && !selectedItem.value && meetings.value.length > 0) {
-      await selectMeeting(meetings.value[0]);
+      await selectMeeting(displayedSections.value[0]?.items[0] ?? meetings.value[0]);
     } else if (selectedItem.value) {
       selectedItem.value =
         meetings.value.find((m) => m.id === selectedItem.value?.id) ?? selectedItem.value;


### PR DESCRIPTION
Fixes the Meetings list ordering that put farther-future days above Tomorrow/Today.

Root cause: date groups were sorted newest-first. Updated shared grouping so Today/future dates read nearest-first, then past dates newest-first, and initial selection follows the first visible row.

Tested on both, cloud and local meeting notes data

<img width="594" height="1710" alt="Screenshot 2026-06-24 at 10 49 30 AM" src="https://github.com/user-attachments/assets/80314b8b-03d0-456d-a496-f533877a5a0f" />
<img width="612" height="1818" alt="Screenshot 2026-06-24 at 10 37 36 AM" src="https://github.com/user-attachments/assets/9a61187c-967b-4eb1-bcd0-c312684b46e0" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved meeting grouping and ordering so today and upcoming meetings appear first (nearest first), while past meetings remain ordered from most recent to older.
  * Updated initial selection to highlight the first visible grouped meeting row, improving consistency of the “Up Next” view.
  * Refined recording start behavior to respect user-chosen selection vs auto/refresh selection, preventing unintended “Today” targeting.

* **Tests**
  * Updated and added coverage to verify the new grouping/order and Today recording selection scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->