### PR TITLE
feat: check for updates every 2h while running

### DIFF
--- a/docs/superpowers/specs/2026-05-25-in-app-updates-design.md
+++ b/docs/superpowers/specs/2026-05-25-in-app-updates-design.md
@@ -14,7 +14,7 @@ Add a Sparkle-style in-app update experience to the Ariso Mac app: silent backgr
 |---|---|
 | Distribution source | GitHub Releases (existing) — `latest/download/latest.json` |
 | Channels | Stable only (beta channel is a future addition, not in scope) |
-| Check cadence | On launch (after 10s) + every 24h while running |
+| Check cadence | On launch (after 10s) + every 2h while running |
 | User controls | Install Update / Remind Me Later / Skip This Version |
 | Mandatory updates | Supported via a `mandatory: true` flag in the manifest |
 | Download behavior | Prompt first, then download on user confirmation (classic Sparkle) |
@@ -36,7 +36,7 @@ Each decision and the alternatives considered are below.
 │  │  tauri-plugin-process  (relaunch)           │  │
 │  │  update_manager.rs                          │  │
 │  │    • startup check (10s delay)              │  │
-│  │    • hourly tick, runs check at most /24h   │  │
+│  │    • 30-min tick, runs check at most /2h    │  │
 │  │    • commands: update_check,                │  │
 │  │      update_install_and_relaunch,           │  │
 │  │      update_skip_version, update_snooze,    │  │
@@ -224,18 +224,18 @@ spawn(async move {
         if should_check(&state).await {
             check(&state).await;
         }
-        sleep(Duration::from_secs(3600)).await;
+        sleep(Duration::from_secs(1800)).await;
     }
 });
 
 fn should_check(s: &UpdateState) -> bool {
     s.auto_check_enabled
-        && s.last_check.map_or(true, |t| Utc::now() - t > Duration::hours(24))
+        && s.last_check.map_or(true, |t| Utc::now() - t > Duration::hours(2))
         && s.snoozed_until.map_or(true, |t| Utc::now() > t)
 }
 ```
 
-The hourly wake-up keeps the loop simple; sleeping for 24h directly doesn't survive sleep/wake reliably, while a short tick + a cheap predicate does.
+The 30-min wake-up keeps the loop simple; sleeping for 2h directly doesn't survive sleep/wake reliably, while a short tick + a cheap predicate does.
 
 ### 3.5 Skip semantics
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -247,15 +247,15 @@ fn main() {
                 }
             });
 
-            // Background update scheduler: wake every hour, but only
-            // actually check once per 24h (or on snooze expiry). The
+            // Background update scheduler: wake every 30 min, but only
+            // actually check once per 2h (or on snooze expiry). The
             // initial 10-second delay lets startup finish first.
             let app_handle = app.handle().clone();
             tauri::async_runtime::spawn(async move {
                 tokio::time::sleep(std::time::Duration::from_secs(10)).await;
                 loop {
                     update_manager::run_check(app_handle.clone(), false).await;
-                    tokio::time::sleep(std::time::Duration::from_secs(3600)).await;
+                    tokio::time::sleep(std::time::Duration::from_secs(1800)).await;
                 }
             });
 

--- a/src-tauri/src/update_manager.rs
+++ b/src-tauri/src/update_manager.rs
@@ -37,7 +37,7 @@ pub struct UpdateInfo {
 ///
 /// Returns true iff:
 /// - auto-check is enabled, AND
-/// - no check has happened in the last 24h (or never), AND
+/// - no check has happened in the last 2h (or never), AND
 /// - we are not currently snoozed
 pub fn should_check(state: &UpdateState, now_unix: i64) -> bool {
     if !state.auto_check_enabled {
@@ -45,7 +45,7 @@ pub fn should_check(state: &UpdateState, now_unix: i64) -> bool {
     }
     let last_ok = match state.last_check_unix {
         None => true,
-        Some(t) => now_unix - t > 24 * 60 * 60,
+        Some(t) => now_unix - t > 2 * 60 * 60,
     };
     let snooze_ok = match state.snoozed_until_unix {
         None => true,
@@ -483,6 +483,24 @@ mod tests {
             ..Default::default()
         };
         assert!(!should_check(&s, NOW));
+    }
+
+    #[test]
+    fn should_not_check_when_check_is_90min_old() {
+        let s = UpdateState {
+            last_check_unix: Some(NOW - 90 * 60),
+            ..Default::default()
+        };
+        assert!(!should_check(&s, NOW));
+    }
+
+    #[test]
+    fn should_check_when_check_is_3h_old() {
+        let s = UpdateState {
+            last_check_unix: Some(NOW - 3 * 60 * 60),
+            ..Default::default()
+        };
+        assert!(should_check(&s, NOW));
     }
 
     #[test]


### PR DESCRIPTION
Reduces the background auto-check throttle from once per 24h to once per 2h. The startup check (10s after launch) and manual tray/Settings checks are unchanged.

- `should_check()` throttle: 24h → 2h
- Scheduler tick: 60 min → 30 min, so the realized cadence actually lands near 2h (a strict `> 2h` predicate on an hourly tick wouldn't fire until ~3h)
- Added boundary tests (90min → no check, 3h → check); updated the design spec

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Update checks now run more frequently, improving how quickly the app detects available updates.
  * Background checking behavior has been adjusted to better handle sleep and wake cycles.
* **Documentation**
  * Updated the in-app update design notes to reflect the new checking schedule and timing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->