### PR TITLE
ci: only scan Swift CodeQL on PRs that touch Swift

### DIFF
--- a/.github/workflows/codeql-swift.yaml
+++ b/.github/workflows/codeql-swift.yaml
@@ -18,6 +18,13 @@ on:
   pull_request:
     branches:
       - main
+    # A traced Swift compile is the slow part of this scan, so on PRs only run it
+    # when Swift sources/dependencies (or this workflow) actually change. Push to
+    # main and the weekly schedule stay unfiltered to keep main's scan baseline
+    # current even after a no-Swift PR merges.
+    paths:
+      - 'src-tauri/ariso-stt/**'
+      - '.github/workflows/codeql-swift.yaml'
   schedule:
     # Weekly, matching the cadence the default setup used for Swift.
     - cron: '19 19 * * 1'


### PR DESCRIPTION
## Summary

Swift CodeQL still takes a while on every PR because the traced Swift compile is the slow part of the scan (e.g. [this run](https://github.com/ariso-ai/oats/actions/runs/28468573914/job/84374750440)). Add a `paths` filter to the `pull_request` trigger so the job only runs when Swift code actually changes.

## What changed

`.github/workflows/codeql-swift.yaml` — the `pull_request` trigger now filters on:
- `src-tauri/ariso-stt/**` — all Swift sources plus `Package.resolved`/`Package.swift`
- `.github/workflows/codeql-swift.yaml` — re-run when the scan config itself changes

PRs that only touch Rust/Vue/CI now skip the job instead of burning ~25 min compiling the MLX/FluidAudio tree.

## Why this scope

- All Swift code lives under `src-tauri/ariso-stt/`, so the filter is exhaustive.
- `push: main` and the weekly `schedule` stay **unfiltered** on purpose — they keep main's security-scan baseline current (and finish in minutes on a cache hit).
- `main` has **no required status checks**, so a path-skipped PR run won't leave a required check stuck pending (the usual path-filtered-CodeQL gotcha doesn't apply here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated automated code scanning so Swift-focused checks run only on pull requests targeting `main` when the workflow itself or `src-tauri/ariso-stt/**` changes, reducing unnecessary runs.
  * Main-branch push checks and the existing weekly scheduled scans continue to run unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->