### PR TITLE
feat: cloud multi-recording support in oats (stacked clips, per-clip transcript + delete)

### DIFF
--- a/docs/superpowers/specs/2026-06-30-cloud-multi-recording-oats-design.md
+++ b/docs/superpowers/specs/2026-06-30-cloud-multi-recording-oats-design.md
@@ -1,0 +1,164 @@
+# Cloud (Ariso) multi-recording support in oats — design
+
+**Date:** 2026-06-30
+**Status:** Approved (brainstorming) → ready for implementation plan
+**Scope:** PR 1 of 2. This spec covers the **Ariso (cloud)** backend only. The
+**Local (offline)** backend is a separate follow-up PR with its own spec (see
+§8).
+
+## 1. Problem
+
+A single meeting can now be recorded more than once — e.g. you record a
+calendar meeting, stop (break, accidental stop, app quit), then record more of
+the *same* meeting shortly after. Each recording session should become an
+additional **clip** on that meeting rather than overwriting the previous one or
+creating a brand-new meeting.
+
+The **cloud backend already supports this**. The agents-repo series
+(PRs 5918–5921, merged; 5922 incremental summary open) made each audio upload a
+first-class clip: a per-upload `transcript_id`, an S3 key
+`{org}/meetings/{id}/audio/{transcriptId}.{ext}`, a `meeting_audio_files` row,
+per-clip transcription, and a read surface exposing `audio_clips` plus per-clip
+audio/transcript. web-ui (PR 5921/5920) already renders stacked players,
+per-clip transcript switching, and host-only per-clip delete.
+
+This PR brings oats to parity on the desktop side.
+
+## 2. Current state in oats (what already works)
+
+**Resume trigger = same calendar meeting.** An auto- or manually-triggered
+recording resolves its target meeting via
+`resolveAssociation` → `pickDefaultMeeting`, which returns the calendar
+meeting's own `id` (`src/composables/useAutoTrigger.ts:16`,
+`src/composables/pickDefaultMeeting.ts`). Recording the same calendar meeting
+again resolves the **same `meetingId`**.
+
+**Producing path re-attaches cleanly.** `ArisoBackend.finalizeRecording`
+(`src/composables/useBackend.ts:256`) buffers then calls `uploadAudio`
+(`src/composables/useMeetingApi.ts:457`) →
+`POST /desktop/meetings/{id}/audio/presign` → PUT → `…/confirm`. It does **not**
+call `endMeeting`, so nothing blocks a second upload. Combined with the merged
+backend change (clips instead of overwrite), re-recording the same calendar
+meeting already produces two clips.
+
+**Consuming path is single-recording.** `MeetingDetailView.vue` renders one
+`RecordingAudioPlayer` (`getMeetingAudio` → `GET /meeting-notes/{id}/audio`,
+one blob) and one whole-meeting transcript. It has no notion of clips.
+
+**Conclusion:** the producing path needs *verification + a test*, not new
+behavior. The substantive work is making the consuming UI clip-aware.
+
+## 3. Goals / non-goals
+
+**Goals**
+- Surface a meeting's multiple clips in oats's `MeetingDetailView` with
+  web-ui parity: stacked per-clip players, per-clip transcript switching,
+  host-only per-clip delete.
+- Keep single-clip and legacy meetings visually identical to today.
+- Lock in the producing behavior with a test.
+- Keep the cloud/offline backend abstraction intact.
+
+**Non-goals**
+- Local (offline) multi-clip — PR 2 (§8).
+- Speaker / voice-print reconciliation across clips (documented backend
+  limitation).
+- Any change to the recording/upload behavior.
+
+## 4. Design
+
+### 4.1 API / plumbing layer
+
+`src/composables/useMeetingApi.ts`
+- Add `interface MeetingAudioClip { transcript_id: string; duration_ms: number | null; created_at: string; legacy: boolean }`.
+- Parse `audio_clips` off the `GET /meeting-notes/:id` response (backend
+  guarantees ≥1 entry when audio exists; a pre-clip meeting yields a single
+  `{ transcript_id: 'legacy', legacy: true }` entry).
+- Add `transcript_id: string` to `TranscriptChunk` (the transcript endpoint
+  already tags every chunk; legacy chunks come back as `'legacy'`).
+- Add `deleteMeetingRecordingClip(meetingId, transcriptId)` →
+  `DELETE /meeting-notes/:id/recording/:transcriptId` (expects 200).
+
+`src/tauri.ts` + `src-tauri/src/commands.rs`
+- Extend the `fetch_meeting_audio` command and its `tauri.ts` wrapper with an
+  optional `transcriptId`. Present → `GET /meeting-notes/:id/audio/:transcriptId`;
+  omitted → today's `/audio` (legacy). Rust unit test covers URL construction.
+
+### 4.2 Backend abstraction — `src/composables/useBackend.ts`
+
+- `MeetingDetail` gains `audioClips: MeetingAudioClip[]` (empty when none).
+- Ariso `getMeetingDetail` maps `data.audio_clips`.
+- `getMeetingAudio(item, transcriptId?)`: Ariso routes to the per-clip endpoint
+  when `transcriptId` is a real (non-legacy) id; Local **ignores** `transcriptId`
+  and returns its single recording (unchanged until PR 2).
+- New `deleteMeetingClip(item, transcriptId)` on the `Backend` interface: Ariso
+  calls `deleteMeetingRecordingClip`; Local throws an "unsupported" error for
+  now (delete lands with PR 2).
+
+### 4.3 UI — `src/views/MeetingDetailView.vue`
+
+- **Stacked players.** Replace the single `RecordingAudioPlayer` with one per
+  clip (oldest-first, the `audio_clips` order). Label `Recording N · Mm SSs`
+  (drop `· Mm SSs` when `duration_ms` is null). Each player's `load` resolves
+  its own clip via `getMeetingAudio(item, clip.transcript_id)`.
+- **Per-clip transcript switching.** Add `activeClipId` (default = first clip).
+  Fetch the meeting transcript once and **partition chunks by `transcript_id`
+  client-side**; the transcript pane renders the active clip's chunks. Clicking
+  a clip sets it active. Client-side partitioning avoids web-ui's async
+  request-sequence race entirely (no in-flight token needed).
+- **Host-only per-clip delete.** When there is more than one non-legacy clip
+  **and** `isHost` (already computed at `MeetingDetailView.vue:326`), render a
+  delete button per clip → existing `ConfirmDialog` → `deleteMeetingClip` →
+  refetch detail. If the deleted clip was active, reset active to the first
+  remaining clip. The single whole-recording delete is suppressed in multi-clip
+  mode (mirrors web-ui `showPerClipDelete`).
+- **Degradation.** 1 clip or legacy → identical to today (one player, whole
+  transcript, single delete button). 0 clips but `hasTranscript` (imported
+  transcript) → no players, whole transcript as now. Per-clip audio 404 → the
+  player's existing "No audio" state.
+
+### 4.4 Producing path — verify only
+
+No code change expected. Add a unit test asserting a second recording of the
+same calendar meeting resolves the same `meetingId` (through
+`resolveAssociation`) and that `finalizeRecording`/`uploadAudio` carries it to
+the `…/{id}/audio/presign` path, so the two-clip outcome is pinned.
+
+## 5. Data flow
+
+1. Open detail → `getMeetingDetail` returns `audioClips` + (on transcript-tab
+   open) the tagged transcript chunks.
+2. Render one player per clip; partition chunks by `transcript_id`; active =
+   `audioClips[0]`.
+3. Click a clip → set `activeClipId` → transcript pane shows that clip's chunks.
+4. Host clicks delete on a clip → confirm → `DELETE …/recording/:transcriptId`
+   → refetch detail → players + transcript re-derive; active resets if needed.
+
+## 6. Error handling / edge cases
+
+- Meeting with transcript but no clips (imported) → whole-transcript fallback.
+- Legacy meeting → single player via `/audio`; transcript unpartitioned.
+- Per-clip audio 404 → "No audio" (existing behavior).
+- Delete of the active clip → active resets to first remaining clip.
+- Non-host viewer → no delete buttons.
+- Local backend → single player, no per-clip delete (unsupported).
+
+## 7. Testing
+
+- **Vitest** (`MeetingDetailView`, `useMeetingApi`): N players for N clips;
+  transcript partition by clip; host-gated delete visibility; single/legacy
+  fallback; delete → refetch. ⚠️ `MeetingDetailView` Vitest files are brittle in
+  full runs (incomplete `../tauri` mock + jsdom/TipTap gaps) — verify in
+  isolation.
+- **Rust** (`cargo test`, with the documented `DYLD_LIBRARY_PATH` +
+  `--test-threads=1` workaround): `fetch_meeting_audio` per-clip URL
+  construction.
+
+## 8. Follow-up — Local (offline) backend (PR 2, separate spec)
+
+Local has no calendar; the resume trigger is a **time window since last stop**
+(if a new recording starts within N minutes of the previous stopping, treat it
+as the same meeting). Rather than modelling N recording dirs, PR 2 **appends the
+new clip's audio to the existing recording and stitches its transcript onto the
+existing transcript**, then regenerates notes **incrementally**. That work — the
+on-disk append, transcript stitching, and incremental notes — gets its own
+brainstorm → spec → plan cycle and does not block this PR.

--- a/docs/superpowers/specs/2026-06-30-cloud-multi-recording-oats-design.md
+++ b/docs/superpowers/specs/2026-06-30-cloud-multi-recording-oats-design.md
@@ -105,12 +105,16 @@ behavior. The substantive work is making the consuming UI clip-aware.
   client-side**; the transcript pane renders the active clip's chunks. Clicking
   a clip sets it active. Client-side partitioning avoids web-ui's async
   request-sequence race entirely (no in-flight token needed).
-- **Host-only per-clip delete.** When there is more than one non-legacy clip
-  **and** `isHost` (already computed at `MeetingDetailView.vue:326`), render a
-  delete button per clip → existing `ConfirmDialog` → `deleteMeetingClip` →
+- **Host-only per-clip delete.** oats has **no delete UI today** (no
+  whole-recording delete, no generic confirm dialog — only
+  `AriJoinConfirmDialog`), so this introduces oats's first destructive action.
+  When there is more than one non-legacy clip **and** `isHost` (already computed
+  at `MeetingDetailView.vue:326`), render a delete button per clip → a new
+  confirm dialog modeled on `AriJoinConfirmDialog` → `deleteMeetingClip` →
   refetch detail. If the deleted clip was active, reset active to the first
-  remaining clip. The single whole-recording delete is suppressed in multi-clip
-  mode (mirrors web-ui `showPerClipDelete`).
+  remaining clip. Single-clip / legacy meetings show no delete (unchanged from
+  today) — this matches web-ui's `showPerClipDelete` gate (>1 clip) without
+  oats needing a whole-recording delete.
 - **Degradation.** 1 clip or legacy → identical to today (one player, whole
   transcript, single delete button). 0 clips but `hasTranscript` (imported
   transcript) → no players, whole transcript as now. Per-clip audio 404 → the

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -876,6 +876,34 @@ fn validate_meeting_id(id: &str) -> Result<(), String> {
     Ok(())
 }
 
+/// Clip transcript ids are `randomUUID()`s (or the sentinel `"legacy"`, which
+/// callers route to the no-arg endpoint instead). Allow only ascii-alphanumerics
+/// and dashes so a caller can't smuggle path segments or a query string into the
+/// URL below.
+fn validate_transcript_id(id: &str) -> Result<(), String> {
+    if id.is_empty() || !id.chars().all(|c| c.is_ascii_alphanumeric() || c == '-') {
+        return Err(format!("invalid transcript id: {id}"));
+    }
+    Ok(())
+}
+
+/// Build the meeting-audio URL, validating ids first. `None` transcript id →
+/// the whole-meeting/legacy endpoint; `Some(id)` → the per-clip endpoint.
+fn meeting_audio_url(
+    base: &str,
+    meeting_id: &str,
+    transcript_id: Option<&str>,
+) -> Result<String, String> {
+    validate_meeting_id(meeting_id)?;
+    match transcript_id {
+        Some(tid) => {
+            validate_transcript_id(tid)?;
+            Ok(format!("{base}/meeting-notes/{meeting_id}/audio/{tid}"))
+        }
+        None => Ok(format!("{base}/meeting-notes/{meeting_id}/audio")),
+    }
+}
+
 /// Fetch a meeting's recorded audio from the Ariso API as raw bytes (the
 /// endpoint streams the file directly). Non-200 responses become an error
 /// whose message is prefixed with the HTTP status so the frontend can map
@@ -884,11 +912,11 @@ fn validate_meeting_id(id: &str) -> Result<(), String> {
 pub async fn fetch_meeting_audio(
     app: tauri::AppHandle,
     meeting_id: String,
+    transcript_id: Option<String>,
 ) -> Result<tauri::ipc::Response, String> {
-    validate_meeting_id(&meeting_id)?;
+    let url = meeting_audio_url(&api_base_url(), &meeting_id, transcript_id.as_deref())?;
     let token = get_session_token(&app).unwrap_or_default();
     let client = http_client();
-    let url = format!("{}/meeting-notes/{}/audio", api_base_url(), meeting_id);
 
     // Bound the request so a stalled upstream/TCP connection can't hang the
     // command indefinitely; reqwest's builder has no default timeout.
@@ -1308,6 +1336,28 @@ mod tests {
         assert!(validate_meeting_id("12/audio").is_err());
         assert!(validate_meeting_id("abc").is_err());
         assert!(validate_meeting_id("12 ").is_err());
+    }
+
+    #[test]
+    fn meeting_audio_url_builds_legacy_and_per_clip() {
+        let base = "https://api.example.com";
+        assert_eq!(
+            meeting_audio_url(base, "42", None).unwrap(),
+            "https://api.example.com/meeting-notes/42/audio"
+        );
+        assert_eq!(
+            meeting_audio_url(base, "42", Some("3f8c1e2a-0000-4aaa-8bbb-1234567890ab")).unwrap(),
+            "https://api.example.com/meeting-notes/42/audio/3f8c1e2a-0000-4aaa-8bbb-1234567890ab"
+        );
+    }
+
+    #[test]
+    fn meeting_audio_url_rejects_injection() {
+        let base = "https://api.example.com";
+        assert!(meeting_audio_url(base, "42", Some("../secret")).is_err());
+        assert!(meeting_audio_url(base, "42", Some("a/b")).is_err());
+        assert!(meeting_audio_url(base, "42", Some("a?x=1")).is_err());
+        assert!(meeting_audio_url(base, "not-numeric", None).is_err());
     }
 
     #[test]

--- a/src/composables/useAutoTrigger.test.ts
+++ b/src/composables/useAutoTrigger.test.ts
@@ -30,4 +30,17 @@ describe('resolveAssociation', () => {
   it('ariso with no meetings falls back to confirm', () => {
     expect(resolveAssociation('ariso', [], now)).toEqual({ kind: 'confirm' });
   });
+
+  it('resolves the same meetingId across repeat recordings of one calendar meeting (resume)', () => {
+    const now = new Date('2026-06-30T10:15:00Z');
+    const meetings = [meeting(99, '2026-06-30T10:00:00Z')];
+    const first = resolveAssociation('ariso', meetings, now);
+    const second = resolveAssociation(
+      'ariso',
+      meetings,
+      new Date('2026-06-30T10:40:00Z') // stopped, restarted 25 min later, still current
+    );
+    expect(first).toEqual({ kind: 'matched', meetingId: 99 });
+    expect(second).toEqual({ kind: 'matched', meetingId: 99 });
+  });
 });

--- a/src/composables/useBackend.test.ts
+++ b/src/composables/useBackend.test.ts
@@ -17,6 +17,7 @@ const discardPendingAudio = vi.fn();
 const fetchMeetingAudio = vi.fn();
 const readRecordingAudio = vi.fn();
 const getMeetingNotes = vi.fn();
+const deleteMeetingRecordingClip = vi.fn();
 
 vi.mock('../tauri', () => ({
   local: {
@@ -46,6 +47,7 @@ vi.mock('./useMeetingApi', () => ({
     searchMeetings: (...a: unknown[]) => searchMeetings(...a),
     updateMeetingNotesTitle: (...a: unknown[]) => updateMeetingNotesTitle(...a),
     getMeetingNotes: (...a: unknown[]) => getMeetingNotes(...a),
+    deleteMeetingRecordingClip: (...a: unknown[]) => deleteMeetingRecordingClip(...a),
   }),
 }));
 
@@ -283,7 +285,7 @@ describe('ArisoBackend', () => {
     const buf = new ArrayBuffer(4);
     fetchMeetingAudio.mockResolvedValue(buf);
     expect(await b.getMeetingAudio(item)).toBe(buf);
-    expect(fetchMeetingAudio).toHaveBeenCalledWith('7');
+    expect(fetchMeetingAudio).toHaveBeenCalledWith('7', undefined);
 
     fetchMeetingAudio.mockRejectedValue('404: audio fetch failed');
     expect(await b.getMeetingAudio(item)).toBeNull();
@@ -312,6 +314,68 @@ describe('ArisoBackend', () => {
     expect(d.publicShareExpiresAt).toBe('2026-07-01T10:00:00Z');
     expect(d.shareMeetingNotesToPublic).toBe('host_only');
     expect(d.participants[0].id).toBe(11);
+  });
+});
+
+describe('ArisoBackend clips', () => {
+  it('getMeetingDetail surfaces audio_clips', async () => {
+    getMeetingNotes.mockResolvedValue({
+      id: 42,
+      title: 'Sync',
+      start_at: '2026-06-01T10:00:00Z',
+      audio_clips: [
+        { transcript_id: 'c1', duration_ms: 1000, created_at: 't', legacy: false },
+      ],
+    });
+    const detail = await new ArisoBackend().getMeetingDetail({
+      id: '42',
+      title: 'Sync',
+      timestamp: '2026-06-01T10:00:00Z',
+    });
+    expect(detail.audioClips).toEqual([
+      { transcript_id: 'c1', duration_ms: 1000, created_at: 't', legacy: false },
+    ]);
+  });
+
+  it('getMeetingDetail defaults audioClips to an empty array when absent', async () => {
+    getMeetingNotes.mockResolvedValue({
+      id: 42,
+      title: 'Sync',
+      start_at: '2026-06-01T10:00:00Z',
+    });
+    const detail = await new ArisoBackend().getMeetingDetail({
+      id: '42',
+      title: 'Sync',
+      timestamp: '2026-06-01T10:00:00Z',
+    });
+    expect(detail.audioClips).toEqual([]);
+  });
+
+  it('getMeetingAudio forwards a real transcriptId to the per-clip fetch', async () => {
+    fetchMeetingAudio.mockResolvedValue(new ArrayBuffer(4));
+    const item = { id: '42', title: 'T', timestamp: 't' };
+    await new ArisoBackend().getMeetingAudio(item, 'c1');
+    expect(fetchMeetingAudio).toHaveBeenCalledWith('42', 'c1');
+  });
+
+  it('deleteMeetingClip calls deleteMeetingRecordingClip', async () => {
+    deleteMeetingRecordingClip.mockResolvedValue(undefined);
+    const item = { id: '42', title: 'T', timestamp: 't' };
+    await new ArisoBackend().deleteMeetingClip(item, 'c1');
+    expect(deleteMeetingRecordingClip).toHaveBeenCalledWith('42', 'c1');
+  });
+});
+
+describe('LocalBackend clips', () => {
+  it('getMeetingDetail returns empty audioClips', async () => {
+    const item = { id: 'a', title: 'T', timestamp: 't' };
+    const detail = await new LocalBackend().getMeetingDetail(item);
+    expect(detail.audioClips).toEqual([]);
+  });
+
+  it('deleteMeetingClip rejects as unsupported', async () => {
+    const item = { id: 'a', title: 'T', timestamp: 't' };
+    await expect(new LocalBackend().deleteMeetingClip(item, 'x')).rejects.toThrow(/not supported/i);
   });
 });
 

--- a/src/composables/useBackend.ts
+++ b/src/composables/useBackend.ts
@@ -361,7 +361,8 @@ export class ArisoBackend implements Backend {
 
   async getMeetingAudio(item: MeetingListItem, transcriptId?: string): Promise<ArrayBuffer | null> {
     try {
-      return await api.fetchMeetingAudio(item.id, transcriptId);
+      const clipId = transcriptId && transcriptId !== 'legacy' ? transcriptId : undefined;
+      return await api.fetchMeetingAudio(item.id, clipId);
     } catch (e) {
       // fetch_meeting_audio prefixes errors with the HTTP status; 404 means
       // the meeting simply has no recorded audio.

--- a/src/composables/useBackend.ts
+++ b/src/composables/useBackend.ts
@@ -4,6 +4,7 @@ import {
   type ScheduledMeeting,
   type MeetingSearchResult,
   type TranscriptChunk,
+  type MeetingAudioClip,
 } from './useMeetingApi';
 import { arisoTruthy } from './autoJoin';
 
@@ -104,6 +105,9 @@ export interface MeetingDetail {
   durationSeconds?: number;
   note?: string;
   transcript?: string;
+  /** Ariso: one entry per recorded clip (oldest-first). Empty for local
+   *  recordings and imported-transcript meetings. */
+  audioClips: MeetingAudioClip[];
 }
 
 export interface Backend {
@@ -130,8 +134,12 @@ export interface Backend {
   /** Rename a meeting. Ariso PATCHes the meeting-notes endpoint; local
    *  rewrites the title in the recording's meta.json. */
   renameMeeting(id: string, title: string): Promise<void>;
-  /** Fetch the meeting's recorded audio bytes; null when none exists. */
-  getMeetingAudio(item: MeetingListItem): Promise<ArrayBuffer | null>;
+  /** Fetch a meeting's recorded audio bytes; null when none exists. Pass a
+   *  clip's transcript_id for a specific clip (Ariso); omit for the whole
+   *  meeting / legacy audio. Local ignores transcriptId. */
+  getMeetingAudio(item: MeetingListItem, transcriptId?: string): Promise<ArrayBuffer | null>;
+  /** Delete a single recording clip by transcript_id. Ariso only; local throws. */
+  deleteMeetingClip(item: MeetingListItem, transcriptId: string): Promise<void>;
 }
 
 interface RawMeetingSummary {
@@ -330,6 +338,7 @@ export class ArisoBackend implements Backend {
       hasIndividualNote: !!data.individual_note?.content,
       isLocal: false,
       autoJoinScheduled: item.autoJoinScheduled ?? false,
+      audioClips: data.audio_clips ?? [],
     };
   }
 
@@ -350,15 +359,20 @@ export class ArisoBackend implements Backend {
     await updateMeetingNotesTitle(id, title);
   }
 
-  async getMeetingAudio(item: MeetingListItem): Promise<ArrayBuffer | null> {
+  async getMeetingAudio(item: MeetingListItem, transcriptId?: string): Promise<ArrayBuffer | null> {
     try {
-      return await api.fetchMeetingAudio(item.id);
+      return await api.fetchMeetingAudio(item.id, transcriptId);
     } catch (e) {
       // fetch_meeting_audio prefixes errors with the HTTP status; 404 means
       // the meeting simply has no recorded audio.
       if (String(e).startsWith('404')) return null;
       throw e;
     }
+  }
+
+  async deleteMeetingClip(item: MeetingListItem, transcriptId: string): Promise<void> {
+    const { deleteMeetingRecordingClip } = useMeetingApi();
+    await deleteMeetingRecordingClip(item.id, transcriptId);
   }
 }
 
@@ -431,6 +445,7 @@ export class LocalBackend implements Backend {
       transcript: transcript ?? undefined,
       hasTranscript: !!item.files?.hasTranscript,
       autoJoinScheduled: false,
+      audioClips: [],
     };
   }
 
@@ -448,9 +463,13 @@ export class LocalBackend implements Backend {
     await local.renameRecording(id, title);
   }
 
-  async getMeetingAudio(item: MeetingListItem): Promise<ArrayBuffer | null> {
+  async getMeetingAudio(item: MeetingListItem, _transcriptId?: string): Promise<ArrayBuffer | null> {
     if (!item.files?.hasAudio) return null;
     return local.readRecordingAudio(item.id);
+  }
+
+  async deleteMeetingClip(): Promise<void> {
+    throw new Error('Deleting individual recordings is not supported for local meetings');
   }
 }
 

--- a/src/composables/useMeetingApi.test.ts
+++ b/src/composables/useMeetingApi.test.ts
@@ -80,3 +80,31 @@ describe('share methods', () => {
     expect(apiRequest).toHaveBeenCalledWith('DELETE', '/meeting-notes/5/share-email?email=a%2Bb%40x.com');
   });
 });
+
+describe('multi-clip', () => {
+  it('deleteMeetingRecordingClip DELETEs the per-clip recording route', async () => {
+    apiRequest.mockResolvedValue({ status: 200, data: {} });
+    await useMeetingApi().deleteMeetingRecordingClip(42, 'clip-uuid');
+    expect(apiRequest).toHaveBeenCalledWith(
+      'DELETE',
+      '/meeting-notes/42/recording/clip-uuid'
+    );
+  });
+
+  it('getMeetingTranscript keeps transcript_id per chunk (legacy default)', async () => {
+    apiRequest.mockResolvedValue({
+      status: 200,
+      data: {
+        transcript: [
+          { chunk_index: 0, start_ms: 0, content: 'a', transcript_id: 'clip-1' },
+          { chunk_index: 1, start_ms: 10, content: 'b' },
+        ],
+      },
+    });
+    const chunks = await useMeetingApi().getMeetingTranscript(7);
+    expect(chunks).toEqual([
+      { chunk_index: 0, start_ms: 0, content: 'a', transcript_id: 'clip-1' },
+      { chunk_index: 1, start_ms: 10, content: 'b', transcript_id: 'legacy' },
+    ]);
+  });
+});

--- a/src/composables/useMeetingApi.ts
+++ b/src/composables/useMeetingApi.ts
@@ -9,11 +9,23 @@ interface TranscriptSegment {
 
 // A single line of a stored transcript: the speaker-attributed `content`
 // (e.g. "Speaker 1: …"), its zero-based `chunk_index`, and `start_ms` offset
-// from the start of the recording.
+// from the start of the recording. `transcript_id` ties the chunk back to the
+// audio clip it came from ('legacy' for pre-multi-clip transcripts).
 interface TranscriptChunk {
   chunk_index: number;
   start_ms: number;
   content: string;
+  transcript_id: string;
+}
+
+// A single recorded audio segment ("clip") within a meeting. Legacy
+// (pre-multi-clip) meetings surface exactly one clip:
+// `{ transcript_id: 'legacy', legacy: true }`.
+export interface MeetingAudioClip {
+  transcript_id: string;
+  duration_ms: number | null;
+  created_at: string;
+  legacy: boolean;
 }
 
 interface Meeting {
@@ -80,6 +92,7 @@ interface MeetingNotes {
   hasTranscript?: boolean;
   // Requester's personal note (authenticated view); null when none written.
   individual_note?: { content?: string | null; title?: string | null } | null;
+  audio_clips?: MeetingAudioClip[];
 }
 
 interface ScheduledMeetingsResponse {
@@ -97,6 +110,7 @@ function parseTranscriptChunks(raw: unknown): TranscriptChunk[] | null {
       chunk_index: typeof c.chunk_index === 'number' ? c.chunk_index : 0,
       start_ms: typeof c.start_ms === 'number' ? c.start_ms : 0,
       content: typeof c.content === 'string' ? c.content.trim() : '',
+      transcript_id: typeof c.transcript_id === 'string' ? c.transcript_id : 'legacy',
     }))
     .filter((c) => c.content.length > 0);
   return chunks.length ? chunks : null;
@@ -279,6 +293,21 @@ export function useMeetingApi() {
     const encodedMeetingId = encodeURIComponent(String(meetingId));
     const res = await api.request('PATCH', `/meeting-notes/${encodedMeetingId}`, { title });
     assertOk(res, 200, 'update meeting title');
+  }
+
+  // Host-only delete of a single recording clip by its transcript id, leaving
+  // the meeting's other clips/transcripts/notes intact.
+  async function deleteMeetingRecordingClip(
+    meetingId: number | string,
+    transcriptId: string
+  ): Promise<void> {
+    const encodedMeetingId = encodeURIComponent(String(meetingId));
+    const encodedTranscriptId = encodeURIComponent(transcriptId);
+    const res = await api.request(
+      'DELETE',
+      `/meeting-notes/${encodedMeetingId}/recording/${encodedTranscriptId}`
+    );
+    assertOk(res, 200, 'delete recording clip');
   }
 
   // Fetch a meeting's stored transcript as an ordered list of chunks. Resolves
@@ -512,6 +541,7 @@ export function useMeetingApi() {
     getMeeting,
     getMeetingNotes,
     updateMeetingNotesTitle,
+    deleteMeetingRecordingClip,
     getMeetingTranscript,
     getMeetingIndividualNote,
     updateMeeting,

--- a/src/tauri.ts
+++ b/src/tauri.ts
@@ -81,8 +81,14 @@ export const api = {
 
   /** Raw audio bytes for an Ariso meeting. Rejects with a message prefixed
    *  by the HTTP status (e.g. "404: …") when the server has no audio. */
-  async fetchMeetingAudio(meetingId: string | number): Promise<ArrayBuffer> {
-    return invoke<ArrayBuffer>('fetch_meeting_audio', { meetingId: String(meetingId) });
+  async fetchMeetingAudio(
+    meetingId: string | number,
+    transcriptId?: string
+  ): Promise<ArrayBuffer> {
+    return invoke<ArrayBuffer>('fetch_meeting_audio', {
+      meetingId: String(meetingId),
+      transcriptId: transcriptId ?? null,
+    });
   },
 };
 

--- a/src/views/MeetingDetailView.test.ts
+++ b/src/views/MeetingDetailView.test.ts
@@ -43,6 +43,7 @@ vi.mock('../tauri', () => ({
 
 import MeetingDetailView from './MeetingDetailView.vue';
 import MeetingNotesEditor from './MeetingNotesEditor.vue';
+import RecordingAudioPlayer from './RecordingAudioPlayer.vue';
 
 function detail(over: Partial<MeetingDetail> = {}): MeetingDetail {
   return {
@@ -52,6 +53,7 @@ function detail(over: Partial<MeetingDetail> = {}): MeetingDetail {
     participants: [],
     actionItems: [],
     isLocal: false,
+    audioClips: [],
     ...over,
   };
 }
@@ -74,7 +76,7 @@ beforeEach(() => {
     getMeetingDetail: (i: MeetingListItem) => getMeetingDetail(i),
     getMeetingTranscript: (i: MeetingListItem) => getMeetingTranscript(i),
     renameMeeting: (...a: unknown[]) => renameMeeting(...a),
-    getMeetingAudio: (i: MeetingListItem) => getMeetingAudio(i),
+    getMeetingAudio: (...a: [MeetingListItem, string?]) => getMeetingAudio(...a),
   });
   notesCanEdit.mockReturnValue(false);
   loadNote.mockResolvedValue({ content: '', title: '' });
@@ -559,6 +561,95 @@ describe('MeetingDetailView audio player', () => {
     await wrapper.find('.card-audio .play-btn').trigger('click');
     await flushPromises();
     expect(wrapper.find('.card-audio .play-btn').text()).toContain('No audio');
+  });
+
+  it('renders one player per clip and filters transcript to the active clip', async () => {
+    getMeetingTranscript.mockResolvedValue([
+      { chunk_index: 0, start_ms: 0, content: 'from clip one', transcript_id: 'c1' },
+      { chunk_index: 1, start_ms: 0, content: 'from clip two', transcript_id: 'c2' },
+    ]);
+    const wrapper = await mountWith(
+      detail({
+        hasTranscript: true,
+        audioClips: [
+          { transcript_id: 'c1', duration_ms: 60000, created_at: 't1', legacy: false },
+          { transcript_id: 'c2', duration_ms: 30000, created_at: 't2', legacy: false },
+        ],
+      })
+    );
+    await flushPromises();
+
+    expect(wrapper.findAllComponents(RecordingAudioPlayer)).toHaveLength(2);
+    // Active defaults to the first clip -> only its chunk shows.
+    expect(wrapper.text()).toContain('from clip one');
+    expect(wrapper.text()).not.toContain('from clip two');
+  });
+
+  it('switches the displayed transcript when a different clip row is clicked', async () => {
+    getMeetingTranscript.mockResolvedValue([
+      { chunk_index: 0, start_ms: 0, content: 'from clip one', transcript_id: 'c1' },
+      { chunk_index: 1, start_ms: 0, content: 'from clip two', transcript_id: 'c2' },
+    ]);
+    const wrapper = await mountWith(
+      detail({
+        hasTranscript: true,
+        audioClips: [
+          { transcript_id: 'c1', duration_ms: 60000, created_at: 't1', legacy: false },
+          { transcript_id: 'c2', duration_ms: 30000, created_at: 't2', legacy: false },
+        ],
+      })
+    );
+    await flushPromises();
+
+    const rows = wrapper.findAll('.clip-row');
+    expect(rows).toHaveLength(2);
+    expect(rows[0].classes()).toContain('clip-row--active');
+
+    await rows[1].trigger('click');
+    await flushPromises();
+
+    expect(rows[1].classes()).toContain('clip-row--active');
+    expect(wrapper.text()).toContain('from clip two');
+    expect(wrapper.text()).not.toContain('from clip one');
+  });
+
+  it("fetches a clip's audio via its transcript id when Play is clicked", async () => {
+    getMeetingAudio.mockResolvedValue(new ArrayBuffer(4));
+    const wrapper = await mountWith(
+      detail({
+        hasTranscript: true,
+        audioClips: [
+          { transcript_id: 'c1', duration_ms: 60000, created_at: 't1', legacy: false },
+          { transcript_id: 'c2', duration_ms: 30000, created_at: 't2', legacy: false },
+        ],
+      })
+    );
+    await flushPromises();
+
+    const rows = wrapper.findAll('.clip-row');
+    await rows[1].find('.play-btn').trigger('click');
+    await flushPromises();
+
+    expect(getMeetingAudio).toHaveBeenCalledWith(item, 'c2');
+  });
+
+  it('keeps the single-player fallback and whole-meeting audio for a legacy single clip', async () => {
+    getMeetingAudio.mockResolvedValue(new ArrayBuffer(4));
+    const wrapper = await mountWith(
+      detail({
+        hasTranscript: true,
+        audioClips: [{ transcript_id: 'legacy', duration_ms: null, created_at: 't0', legacy: true }],
+      })
+    );
+    await flushPromises();
+
+    expect(wrapper.find('.clip-row').exists()).toBe(false);
+    expect(wrapper.findAllComponents(RecordingAudioPlayer)).toHaveLength(1);
+
+    await wrapper.find('.card-audio .play-btn').trigger('click');
+    await flushPromises();
+
+    expect(getMeetingAudio).toHaveBeenCalledWith(item);
   });
 });
 

--- a/src/views/MeetingDetailView.test.ts
+++ b/src/views/MeetingDetailView.test.ts
@@ -917,4 +917,56 @@ describe('MeetingDetailView per-clip delete', () => {
 
     expect(wrapper.findAll('.clip-del-btn')).toHaveLength(0);
   });
+
+  it('surfaces an inline error and keeps the clip when deleteMeetingClip rejects', async () => {
+    getMeetingDetail.mockResolvedValue(hostDetail({ audioClips: twoClips }));
+    getMeetingTranscript.mockResolvedValue([]);
+    deleteMeetingClip.mockRejectedValue(new Error('network down'));
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const wrapper = mount(MeetingDetailView, { props: { item } });
+    await flushPromises();
+
+    await wrapper.findAll('.clip-del-btn')[0].trigger('click');
+    await wrapper.find('.danger-btn').trigger('click');
+    await flushPromises();
+
+    expect(deleteMeetingClip).toHaveBeenCalledWith(item, 'c1');
+    // The dialog closed but the clip was NOT removed, and the failure is surfaced.
+    expect(wrapper.findAll('.clip-del-btn')).toHaveLength(2);
+    expect(wrapper.find('.clip-delete-error').exists()).toBe(true);
+    expect(wrapper.find('.clip-delete-error').text()).toContain('Could not delete this recording');
+  });
+
+  it('preserves the active clip and its transcript when a non-active clip is deleted', async () => {
+    getMeetingTranscript.mockResolvedValue([
+      { chunk_index: 0, start_ms: 0, content: 'from clip one', transcript_id: 'c1' },
+      { chunk_index: 1, start_ms: 0, content: 'from clip two', transcript_id: 'c2' },
+    ]);
+    getMeetingDetail
+      .mockResolvedValueOnce(hostDetail({ audioClips: twoClips }))
+      .mockResolvedValueOnce(
+        hostDetail({
+          audioClips: [{ transcript_id: 'c2', duration_ms: 1000, created_at: 't2', legacy: false }],
+        })
+      );
+
+    const wrapper = mount(MeetingDetailView, { props: { item } });
+    await flushPromises();
+
+    // Switch active clip to c2, then delete c1 (the non-active clip).
+    const rows = wrapper.findAll('.clip-row');
+    await rows[1].trigger('click');
+    await flushPromises();
+    expect(wrapper.text()).toContain('from clip two');
+
+    await wrapper.findAll('.clip-del-btn')[0].trigger('click');
+    await wrapper.find('.danger-btn').trigger('click');
+    await flushPromises();
+
+    expect(deleteMeetingClip).toHaveBeenCalledWith(item, 'c1');
+    // c2 stays active/showing, rather than snapping back to the (now sole) first clip.
+    expect(wrapper.text()).toContain('from clip two');
+    expect(wrapper.text()).not.toContain('from clip one');
+  });
 });

--- a/src/views/MeetingDetailView.test.ts
+++ b/src/views/MeetingDetailView.test.ts
@@ -615,6 +615,38 @@ describe('MeetingDetailView audio player', () => {
     expect(wrapper.text()).not.toContain('from clip one');
   });
 
+  it('activates a clip row on Space and reflects the selection via aria-pressed', async () => {
+    getMeetingTranscript.mockResolvedValue([
+      { chunk_index: 0, start_ms: 0, content: 'from clip one', transcript_id: 'c1' },
+      { chunk_index: 1, start_ms: 0, content: 'from clip two', transcript_id: 'c2' },
+    ]);
+    const wrapper = await mountWith(
+      detail({
+        hasTranscript: true,
+        audioClips: [
+          { transcript_id: 'c1', duration_ms: 60000, created_at: 't1', legacy: false },
+          { transcript_id: 'c2', duration_ms: 30000, created_at: 't2', legacy: false },
+        ],
+      })
+    );
+    await flushPromises();
+
+    const rows = wrapper.findAll('.clip-row');
+    // Default: first clip active, and aria-pressed mirrors the active row.
+    expect(rows[0].attributes('aria-pressed')).toBe('true');
+    expect(rows[1].attributes('aria-pressed')).toBe('false');
+
+    // role="button" must activate on Space, not just Enter/click.
+    await rows[1].trigger('keydown', { key: ' ' });
+    await flushPromises();
+
+    expect(rows[1].classes()).toContain('clip-row--active');
+    expect(rows[1].attributes('aria-pressed')).toBe('true');
+    expect(rows[0].attributes('aria-pressed')).toBe('false');
+    expect(wrapper.text()).toContain('from clip two');
+    expect(wrapper.text()).not.toContain('from clip one');
+  });
+
   it("fetches a clip's audio via its transcript id when Play is clicked", async () => {
     getMeetingAudio.mockResolvedValue(new ArrayBuffer(4));
     const wrapper = await mountWith(

--- a/src/views/MeetingDetailView.test.ts
+++ b/src/views/MeetingDetailView.test.ts
@@ -7,6 +7,7 @@ const getMeetingDetail = vi.fn();
 const getMeetingTranscript = vi.fn();
 const renameMeeting = vi.fn();
 const getMeetingAudio = vi.fn();
+const deleteMeetingClip = vi.fn();
 const activeBackend = vi.fn();
 const notesCanEdit = vi.fn(() => false);
 const loadNote = vi.fn();
@@ -77,6 +78,7 @@ beforeEach(() => {
     getMeetingTranscript: (i: MeetingListItem) => getMeetingTranscript(i),
     renameMeeting: (...a: unknown[]) => renameMeeting(...a),
     getMeetingAudio: (...a: [MeetingListItem, string?]) => getMeetingAudio(...a),
+    deleteMeetingClip: (...a: [MeetingListItem, string]) => deleteMeetingClip(...a),
   });
   notesCanEdit.mockReturnValue(false);
   loadNote.mockResolvedValue({ content: '', title: '' });
@@ -838,5 +840,81 @@ describe('MeetingDetailView local generation progress', () => {
     // A note exists (old body) but notes are generating -> chip owns the row.
     expect(wrapper.find('.tab-status-label').text()).toBe('Generating AI Notes');
     expect(wrapper.find('.tab-regen').exists()).toBe(false);
+  });
+});
+
+describe('MeetingDetailView per-clip delete', () => {
+  const hostDetail = (over: Partial<MeetingDetail> = {}): MeetingDetail =>
+    detail({
+      hasTranscript: true,
+      participants: [{ role: 'host', self: true }],
+      ...over,
+    });
+  const twoClips = [
+    { transcript_id: 'c1', duration_ms: 1000, created_at: 't1', legacy: false },
+    { transcript_id: 'c2', duration_ms: 1000, created_at: 't2', legacy: false },
+  ];
+
+  it('shows a delete button per clip for a host with >1 clip, and deletes on confirm', async () => {
+    getMeetingDetail
+      .mockResolvedValueOnce(hostDetail({ audioClips: twoClips }))
+      .mockResolvedValueOnce(
+        hostDetail({
+          audioClips: [{ transcript_id: 'c2', duration_ms: 1000, created_at: 't2', legacy: false }],
+        })
+      );
+    getMeetingTranscript.mockResolvedValue([]);
+
+    const wrapper = mount(MeetingDetailView, { props: { item } });
+    await flushPromises();
+
+    const delButtons = wrapper.findAll('.clip-del-btn');
+    expect(delButtons).toHaveLength(2);
+
+    await delButtons[0].trigger('click');
+    expect(deleteMeetingClip).not.toHaveBeenCalled();
+    await wrapper.find('.danger-btn').trigger('click');
+    await flushPromises();
+
+    expect(deleteMeetingClip).toHaveBeenCalledWith(item, 'c1');
+    // refetched -> one clip left -> per-clip delete no longer shown
+    expect(wrapper.findAll('.clip-del-btn')).toHaveLength(0);
+  });
+
+  it('cancels without deleting', async () => {
+    getMeetingDetail.mockResolvedValue(hostDetail({ audioClips: twoClips }));
+    getMeetingTranscript.mockResolvedValue([]);
+
+    const wrapper = mount(MeetingDetailView, { props: { item } });
+    await flushPromises();
+
+    await wrapper.findAll('.clip-del-btn')[0].trigger('click');
+    await wrapper.find('.secondary-btn').trigger('click');
+    await flushPromises();
+
+    expect(deleteMeetingClip).not.toHaveBeenCalled();
+    expect(wrapper.findAll('.clip-del-btn')).toHaveLength(2);
+  });
+
+  it('shows no per-clip delete for a non-host, even with >1 clip', async () => {
+    getMeetingDetail.mockResolvedValue(
+      hostDetail({ participants: [{ role: 'host', self: false }], audioClips: twoClips })
+    );
+    getMeetingTranscript.mockResolvedValue([]);
+    const wrapper = mount(MeetingDetailView, { props: { item } });
+    await flushPromises();
+
+    expect(wrapper.findAll('.clip-del-btn')).toHaveLength(0);
+  });
+
+  it('shows no per-clip delete for a host with a single (or legacy) clip', async () => {
+    getMeetingDetail.mockResolvedValue(
+      hostDetail({ audioClips: [{ transcript_id: 'legacy', duration_ms: null, created_at: 't0', legacy: true }] })
+    );
+    getMeetingTranscript.mockResolvedValue([]);
+    const wrapper = mount(MeetingDetailView, { props: { item } });
+    await flushPromises();
+
+    expect(wrapper.findAll('.clip-del-btn')).toHaveLength(0);
   });
 });

--- a/src/views/MeetingDetailView.vue
+++ b/src/views/MeetingDetailView.vue
@@ -636,6 +636,9 @@ async function refreshAfterClipDelete(): Promise<void> {
 }
 
 async function load(item: MeetingListItem | null): Promise<void> {
+  showClipDeleteConfirm.value = false;
+  clipPendingDelete.value = null;
+  clipDeleteError.value = null;
   await flushPendingNoteBeforeReset();
   // Bump the token first so any in-flight load for the previous selection
   // (including one cleared by item=null) is treated as stale on resolve.
@@ -653,7 +656,6 @@ async function load(item: MeetingListItem | null): Promise<void> {
   transcriptLoaded.value = false;
   loadingTranscript.value = false;
   activeClipId.value = null;
-  clipDeleteError.value = null;
   progress.reset();
   individualNote.value = null;
   individualNoteLoaded.value = false;

--- a/src/views/MeetingDetailView.vue
+++ b/src/views/MeetingDetailView.vue
@@ -220,7 +220,10 @@
                 :key="clip.transcript_id"
                 class="clip-row"
                 :class="{ 'clip-row--active': clip.transcript_id === activeClipId }"
+                role="button"
+                tabindex="0"
                 @click="activeClipId = clip.transcript_id"
+                @keydown.enter="activeClipId = clip.transcript_id"
               >
                 <span class="clip-label">{{ clipLabel(clip, i) }}</span>
                 <RecordingAudioPlayer :key="clip.transcript_id" :load="() => loadClipAudio(clip)" />
@@ -237,6 +240,7 @@
               </div>
             </template>
             <RecordingAudioPlayer v-else :key="detail.id" :load="loadAudio" />
+            <p v-if="clipDeleteError" class="clip-delete-error" role="alert">⚠ {{ clipDeleteError }}</p>
           </div>
 
           <div v-if="loadingTranscript" class="card-state"><span class="spinner" /><span>Loading transcript…</span></div>
@@ -574,8 +578,13 @@ const showPerClipDelete = computed(
 const showClipDeleteConfirm = ref(false);
 const clipPendingDelete = ref<MeetingAudioClip | null>(null);
 const deletingClip = ref(false);
+// Surfaced inline near the clip players when a delete fails — the confirm
+// dialog has already closed by then, so this is the user's only signal that
+// the clip they were told "can't be undone" actually still exists.
+const clipDeleteError = ref<string | null>(null);
 
 function askDeleteClip(clip: MeetingAudioClip): void {
+  clipDeleteError.value = null;
   clipPendingDelete.value = clip;
   showClipDeleteConfirm.value = true;
 }
@@ -597,6 +606,7 @@ async function confirmDeleteClip(): Promise<void> {
     await refreshAfterClipDelete();
   } catch (e) {
     console.error('Failed to delete recording clip', e);
+    clipDeleteError.value = 'Could not delete this recording. Please try again.';
   } finally {
     deletingClip.value = false;
     clipPendingDelete.value = null;
@@ -604,14 +614,22 @@ async function confirmDeleteClip(): Promise<void> {
 }
 
 // Re-pull the detail so the clip list + transcript reflect the deletion, then
-// reset the active clip and reload the transcript if that tab is open.
+// reload the transcript if that tab is open. Guarded by reqId (same pattern as
+// load()/loadTranscript()) so a meeting switch mid-refetch drops the stale
+// result instead of clobbering the newly-selected meeting's detail.
 async function refreshAfterClipDelete(): Promise<void> {
   const item = props.item;
   const backend = detailBackend;
   if (!item || !backend) return;
+  const my = reqId;
   const d = await backend.getMeetingDetail(item);
+  if (my !== reqId) return;
   detail.value = d;
-  activeClipId.value = d.audioClips[0]?.transcript_id ?? null;
+  // Keep the currently active clip selected if it survived the delete;
+  // otherwise fall back to the first remaining clip (or none).
+  activeClipId.value = d.audioClips.some((c) => c.transcript_id === activeClipId.value)
+    ? activeClipId.value
+    : (d.audioClips[0]?.transcript_id ?? null);
   transcript.value = null;
   transcriptLoaded.value = false;
   if (activeTab.value === 'transcript') void loadTranscript();
@@ -635,6 +653,7 @@ async function load(item: MeetingListItem | null): Promise<void> {
   transcriptLoaded.value = false;
   loadingTranscript.value = false;
   activeClipId.value = null;
+  clipDeleteError.value = null;
   progress.reset();
   individualNote.value = null;
   individualNoteLoaded.value = false;
@@ -1135,6 +1154,7 @@ const durationLabel = computed<string | null>(() => {
 }
 .clip-del-btn:hover:not(:disabled) { background: #fef2f2; border-color: #fca5a5; color: #dc2626; }
 .clip-del-btn:disabled { opacity: 0.6; cursor: default; }
+.clip-delete-error { margin: 4px 8px 0; font-size: 12px; color: #dc2626; }
 .meta-item { display: flex; align-items: center; gap: 4px; color: #6f6f6f; }
 .meta-item .ic { width: 15px; height: 15px; }
 .dur { color: #1c1c1c; font-size: 14px; }

--- a/src/views/MeetingDetailView.vue
+++ b/src/views/MeetingDetailView.vue
@@ -222,8 +222,10 @@
                 :class="{ 'clip-row--active': clip.transcript_id === activeClipId }"
                 role="button"
                 tabindex="0"
+                :aria-pressed="clip.transcript_id === activeClipId"
                 @click="activeClipId = clip.transcript_id"
                 @keydown.enter="activeClipId = clip.transcript_id"
+                @keydown.space.prevent="activeClipId = clip.transcript_id"
               >
                 <span class="clip-label">{{ clipLabel(clip, i) }}</span>
                 <RecordingAudioPlayer :key="clip.transcript_id" :load="() => loadClipAudio(clip)" />

--- a/src/views/MeetingDetailView.vue
+++ b/src/views/MeetingDetailView.vue
@@ -224,6 +224,16 @@
               >
                 <span class="clip-label">{{ clipLabel(clip, i) }}</span>
                 <RecordingAudioPlayer :key="clip.transcript_id" :load="() => loadClipAudio(clip)" />
+                <button
+                  v-if="showPerClipDelete"
+                  class="clip-del-btn"
+                  type="button"
+                  :disabled="deletingClip"
+                  title="Delete this recording"
+                  @click.stop="askDeleteClip(clip)"
+                >
+                  Delete
+                </button>
               </div>
             </template>
             <RecordingAudioPlayer v-else :key="detail.id" :load="loadAudio" />
@@ -278,6 +288,12 @@
           />
         </div>
       </div>
+
+      <RecordingDeleteConfirmDialog
+        :open="showClipDeleteConfirm"
+        @confirm="confirmDeleteClip"
+        @cancel="cancelDeleteClip"
+      />
     </template>
   </div>
 </template>
@@ -298,6 +314,7 @@ import {
 import AriWillJoinTag from './AriWillJoinTag.vue';
 import MeetingNotesEditor from './MeetingNotesEditor.vue';
 import RecordingAudioPlayer from './RecordingAudioPlayer.vue';
+import RecordingDeleteConfirmDialog from './RecordingDeleteConfirmDialog.vue';
 import ShareMeetingPopover from './ShareMeetingPopover.vue';
 import { composeLocalShareText } from './meetingShareText';
 import { shareTextNative, local } from '../tauri';
@@ -545,6 +562,59 @@ function clipLabel(clip: MeetingAudioClip, index: number): string {
   const m = Math.floor(total / 60);
   const s = total % 60;
   return `Recording ${n} · ${m}m ${String(s).padStart(2, '0')}s`;
+}
+
+// Host-only, and only when there are >=2 real (non-legacy) clips to choose
+// between — oats has no whole-recording delete, so single-clip (or legacy)
+// meetings simply show no delete affordance.
+const showPerClipDelete = computed(
+  () => isHost.value && audioClips.value.filter((c) => !c.legacy).length > 1
+);
+
+const showClipDeleteConfirm = ref(false);
+const clipPendingDelete = ref<MeetingAudioClip | null>(null);
+const deletingClip = ref(false);
+
+function askDeleteClip(clip: MeetingAudioClip): void {
+  clipPendingDelete.value = clip;
+  showClipDeleteConfirm.value = true;
+}
+
+function cancelDeleteClip(): void {
+  showClipDeleteConfirm.value = false;
+  clipPendingDelete.value = null;
+}
+
+async function confirmDeleteClip(): Promise<void> {
+  const clip = clipPendingDelete.value;
+  const item = props.item;
+  const backend = detailBackend;
+  showClipDeleteConfirm.value = false;
+  if (!clip || !item || !backend || deletingClip.value) return;
+  deletingClip.value = true;
+  try {
+    await backend.deleteMeetingClip(item, clip.transcript_id);
+    await refreshAfterClipDelete();
+  } catch (e) {
+    console.error('Failed to delete recording clip', e);
+  } finally {
+    deletingClip.value = false;
+    clipPendingDelete.value = null;
+  }
+}
+
+// Re-pull the detail so the clip list + transcript reflect the deletion, then
+// reset the active clip and reload the transcript if that tab is open.
+async function refreshAfterClipDelete(): Promise<void> {
+  const item = props.item;
+  const backend = detailBackend;
+  if (!item || !backend) return;
+  const d = await backend.getMeetingDetail(item);
+  detail.value = d;
+  activeClipId.value = d.audioClips[0]?.transcript_id ?? null;
+  transcript.value = null;
+  transcriptLoaded.value = false;
+  if (activeTab.value === 'transcript') void loadTranscript();
 }
 
 async function load(item: MeetingListItem | null): Promise<void> {
@@ -1057,6 +1127,14 @@ const durationLabel = computed<string | null>(() => {
 .clip-row { display: flex; align-items: center; gap: 12px; padding: 6px 8px; border-radius: 8px; cursor: pointer; }
 .clip-row--active { background: #f7f6f4; }
 .clip-label { flex-shrink: 0; min-width: 120px; font-size: 13px; font-weight: 500; color: #535353; }
+.clip-del-btn {
+  margin-left: auto;
+  height: 26px; padding: 0 10px;
+  background: transparent; border: 1px solid #d6d6d6; border-radius: 6px;
+  font-family: inherit; font-size: 12px; font-weight: 500; color: #6f6f6f; cursor: pointer;
+}
+.clip-del-btn:hover:not(:disabled) { background: #fef2f2; border-color: #fca5a5; color: #dc2626; }
+.clip-del-btn:disabled { opacity: 0.6; cursor: default; }
 .meta-item { display: flex; align-items: center; gap: 4px; color: #6f6f6f; }
 .meta-item .ic { width: 15px; height: 15px; }
 .dur { color: #1c1c1c; font-size: 14px; }

--- a/src/views/MeetingDetailView.vue
+++ b/src/views/MeetingDetailView.vue
@@ -214,13 +214,25 @@
                read_recording_audio off disk), and the player shows "No audio" when
                that resolves to null. -->
           <div v-if="activeTab === 'transcript'" class="card-audio">
-            <RecordingAudioPlayer :key="detail.id" :load="loadAudio" />
+            <template v-if="audioClips.length > 1">
+              <div
+                v-for="(clip, i) in audioClips"
+                :key="clip.transcript_id"
+                class="clip-row"
+                :class="{ 'clip-row--active': clip.transcript_id === activeClipId }"
+                @click="activeClipId = clip.transcript_id"
+              >
+                <span class="clip-label">{{ clipLabel(clip, i) }}</span>
+                <RecordingAudioPlayer :key="clip.transcript_id" :load="() => loadClipAudio(clip)" />
+              </div>
+            </template>
+            <RecordingAudioPlayer v-else :key="detail.id" :load="loadAudio" />
           </div>
 
           <div v-if="loadingTranscript" class="card-state"><span class="spinner" /><span>Loading transcript…</span></div>
           <div v-else-if="transcriptMarkdown" class="md" v-html="renderMarkdown(transcriptMarkdown)" />
-          <ol v-else-if="transcriptChunks" class="transcript">
-            <li v-for="c in transcriptChunks" :key="c.chunk_index" class="transcript-line">
+          <ol v-else-if="displayedChunks" class="transcript">
+            <li v-for="c in displayedChunks" :key="c.chunk_index" class="transcript-line">
               <span class="transcript-ts">{{ formatTimestamp(c.start_ms) }}</span>
               <span class="transcript-content">{{ c.content }}</span>
             </li>
@@ -273,7 +285,7 @@
 <script setup lang="ts">
 import { ref, computed, watch, nextTick, onBeforeUnmount } from 'vue';
 import { renderMarkdown, stripFrontmatter } from '../utils/markdown';
-import type { TranscriptChunk } from '../composables/useMeetingApi';
+import type { TranscriptChunk, MeetingAudioClip } from '../composables/useMeetingApi';
 import { useMeetingNotesPersistence } from '../composables/useMeetingNotesPersistence';
 import {
   getActiveBackend,
@@ -499,6 +511,42 @@ function loadAudio(): Promise<ArrayBuffer | null> {
   return backend.getMeetingAudio(i);
 }
 
+// Meetings recorded across multiple sessions surface one clip per session
+// (oldest-first); legacy and imported-transcript meetings surface none/one.
+// A single clip (legacy or not) keeps today's single-player behavior via the
+// `loadAudio` fallback below, rather than routing through `loadClipAudio`.
+const activeClipId = ref<string | null>(null);
+const audioClips = computed<MeetingAudioClip[]>(() => detail.value?.audioClips ?? []);
+
+// Chunks shown in the transcript pane. With <=1 clip we show everything; with
+// several, we show only the active clip's chunks (partitioned client-side from
+// the already clip-tagged transcript — no extra fetch, no async race).
+const displayedChunks = computed<TranscriptChunk[] | null>(() => {
+  const t = transcript.value;
+  if (!Array.isArray(t)) return null;
+  if (audioClips.value.length <= 1 || !activeClipId.value) return t;
+  return t.filter((c) => c.transcript_id === activeClipId.value);
+});
+
+// Resolve a single clip's audio bytes. Legacy clips use the whole-meeting
+// endpoint (no transcript id).
+function loadClipAudio(clip: MeetingAudioClip): Promise<ArrayBuffer | null> {
+  const i = props.item;
+  const backend = detailBackend;
+  if (!i || !backend) return Promise.resolve(null);
+  return backend.getMeetingAudio(i, clip.legacy ? undefined : clip.transcript_id);
+}
+
+// "Recording N · Mm SSs" (drops the duration when unknown).
+function clipLabel(clip: MeetingAudioClip, index: number): string {
+  const n = index + 1;
+  if (clip.duration_ms == null) return `Recording ${n}`;
+  const total = Math.round(clip.duration_ms / 1000);
+  const m = Math.floor(total / 60);
+  const s = total % 60;
+  return `Recording ${n} · ${m}m ${String(s).padStart(2, '0')}s`;
+}
+
 async function load(item: MeetingListItem | null): Promise<void> {
   await flushPendingNoteBeforeReset();
   // Bump the token first so any in-flight load for the previous selection
@@ -516,6 +564,7 @@ async function load(item: MeetingListItem | null): Promise<void> {
   transcript.value = null;
   transcriptLoaded.value = false;
   loadingTranscript.value = false;
+  activeClipId.value = null;
   progress.reset();
   individualNote.value = null;
   individualNoteLoaded.value = false;
@@ -541,6 +590,7 @@ async function load(item: MeetingListItem | null): Promise<void> {
     if (my !== reqId) return;
     detail.value = d;
     detailBackend = backend;
+    activeClipId.value = d.audioClips[0]?.transcript_id ?? null;
     activeTab.value = firstTabFor(d, item); // default to the first available tab
     if (activeTab.value === 'mynote') {
       await loadIndividualNote();
@@ -653,10 +703,6 @@ const transcriptMarkdown = computed<string | null>(() => {
   if (!detail.value?.isLocal) return null;
   const md = detail.value?.transcript;
   return md ? stripFrontmatter(md) : null;
-});
-const transcriptChunks = computed<TranscriptChunk[] | null>(() => {
-  if (detail.value?.isLocal) return null;
-  return Array.isArray(transcript.value) ? transcript.value : null;
 });
 
 // Render a chunk's `start_ms` offset as M:SS (or H:MM:SS past an hour).
@@ -1007,7 +1053,10 @@ const durationLabel = computed<string | null>(() => {
 /* Meta band — full-bleed strip below the header (Figma 2827:34384) */
 .card-meta { display: flex; flex-wrap: wrap; align-items: center; gap: 16px; padding: 11px 24px; background: #f7f6f4; border-bottom: 1px solid #e5e6e3; font-size: 14px; }
 .meta-ari { margin-left: auto; }
-.card-audio { display: flex; padding: 0 0 12px; }
+.card-audio { display: flex; flex-direction: column; gap: 8px; padding: 0 0 12px; }
+.clip-row { display: flex; align-items: center; gap: 12px; padding: 6px 8px; border-radius: 8px; cursor: pointer; }
+.clip-row--active { background: #f7f6f4; }
+.clip-label { flex-shrink: 0; min-width: 120px; font-size: 13px; font-weight: 500; color: #535353; }
 .meta-item { display: flex; align-items: center; gap: 4px; color: #6f6f6f; }
 .meta-item .ic { width: 15px; height: 15px; }
 .dur { color: #1c1c1c; font-size: 14px; }

--- a/src/views/RecordingDeleteConfirmDialog.test.ts
+++ b/src/views/RecordingDeleteConfirmDialog.test.ts
@@ -1,0 +1,19 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import RecordingDeleteConfirmDialog from './RecordingDeleteConfirmDialog.vue';
+
+describe('RecordingDeleteConfirmDialog', () => {
+  it('renders nothing when closed', () => {
+    const w = mount(RecordingDeleteConfirmDialog, { props: { open: false } });
+    expect(w.find('[role="dialog"]').exists()).toBe(false);
+  });
+
+  it('emits confirm and cancel from its buttons', async () => {
+    const w = mount(RecordingDeleteConfirmDialog, { props: { open: true } });
+    await w.find('.danger-btn').trigger('click');
+    await w.find('.secondary-btn').trigger('click');
+    expect(w.emitted('confirm')).toHaveLength(1);
+    expect(w.emitted('cancel')).toHaveLength(1);
+  });
+});

--- a/src/views/RecordingDeleteConfirmDialog.vue
+++ b/src/views/RecordingDeleteConfirmDialog.vue
@@ -1,0 +1,74 @@
+<template>
+  <div
+    v-if="open"
+    class="rec-del"
+    role="dialog"
+    aria-modal="true"
+    aria-labelledby="rec-del-title"
+    @click.self="$emit('cancel')"
+  >
+    <div class="rec-del__card">
+      <h2 id="rec-del-title" class="rec-del__title">Delete this recording?</h2>
+      <p class="rec-del__body">
+        This removes the selected recording and its transcript from the meeting.
+        The meeting's other recordings and notes are kept. This can't be undone.
+      </p>
+      <div class="rec-del__actions">
+        <button class="secondary-btn" @click="$emit('cancel')">Cancel</button>
+        <button class="danger-btn" @click="$emit('confirm')">Delete</button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+defineProps<{ open: boolean }>();
+defineEmits<{ (e: 'confirm'): void; (e: 'cancel'): void }>();
+</script>
+
+<style scoped>
+.rec-del {
+  position: fixed;
+  inset: 0;
+  z-index: 100;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.35);
+  padding: 24px;
+}
+.rec-del__card {
+  background: #ffffff;
+  border: 1px solid #e5e6e3;
+  border-radius: 12px;
+  padding: 20px;
+  max-width: 360px;
+  box-shadow: 2px 2px 0 #e7e5e2;
+}
+.rec-del__title {
+  font-size: 16px;
+  font-weight: 700;
+  margin: 0 0 8px;
+  color: #1c1c1c;
+}
+.rec-del__body {
+  font-size: 13px;
+  color: #6f6f6f;
+  margin: 0 0 16px;
+  line-height: 1.5;
+}
+.rec-del__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+.danger-btn {
+  font-size: 13px;
+  padding: 6px 14px;
+  border-radius: 6px;
+  border: 1px solid #fca5a5;
+  background: #dc2626;
+  color: #ffffff;
+  cursor: pointer;
+}
+</style>


### PR DESCRIPTION
## Cloud (Ariso) multi-recording support in oats — PR 1 of 2

Makes oats surface a meeting's **multiple audio recordings ("clips")** now that the cloud backend stores each upload as a first-class clip (agents-repo PRs 5918–5921). Recording the same calendar meeting again already re-attaches to the same `meetingId`; before the backend change the second upload overwrote the first, now both are kept — this PR lets oats **consume and manage** them.

Spec: `docs/superpowers/specs/2026-06-30-cloud-multi-recording-oats-design.md`

### What changed
- **Per-clip audio fetch (Rust + tauri.ts):** `fetch_meeting_audio` gains an optional `transcript_id`, built via a testable `meeting_audio_url` helper with a `validate_transcript_id` path-injection guard. Legacy meetings still use the no-arg `/audio` endpoint.
- **API types (`useMeetingApi`):** `MeetingAudioClip`, `audio_clips` on the meeting-notes response, `transcript_id` on transcript chunks (defaults to `legacy`), and `deleteMeetingRecordingClip`.
- **Backend abstraction (`useBackend`):** `MeetingDetail.audioClips`, clip-aware `getMeetingAudio(item, transcriptId?)`, and `deleteMeetingClip` (Ariso implemented; Local throws "unsupported").
- **`MeetingDetailView`:** stacked per-clip players + per-clip transcript switching (client-side partition of the clip-tagged transcript — no extra fetch, no async race), and **host-only per-clip delete** (oats's first destructive action) gated behind a confirm dialog and shown only when there's >1 non-legacy clip.
- **Regression test:** pins that repeat recordings of one calendar meeting resolve the same `meetingId`.

Single-clip, legacy, and local meetings render exactly as before.

### Testing
- Rust: 163 passed / 2 ignored (macOS DYLD workaround).
- Frontend: the 5 touched test files pass 104/104. (7 full-suite failures are pre-existing in untouched `UpdateView`/`LibraryView` — version-string drift + known-brittle heavy-view tests.)
- `tsc --noEmit` clean.

Built via subagent-driven development: 7 TDD tasks, each spec+quality reviewed, plus a whole-branch review whose one Important finding (silent delete failure) and recommended fixes were applied (`c410d10`).

### Out of scope / follow-ups
- **PR 2 — Local (offline) backend:** time-window resume → append clip to the existing recording + stitch transcript + incremental notes (its own spec/plan).
- Speaker/voice-print reconciliation across clips (documented backend limitation).
- Minor polish: a couple of test-coverage gaps, Escape-to-cancel on the delete dialog, doc-comment wording.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added multi-clip support for meeting audio with selectable clip rows and per-clip playback.
  * Introduced a confirmation dialog and host-only controls to delete individual non-legacy clips.
  * Updated transcript display to show only the currently selected clip’s transcript chunks.
* **Bug Fixes**
  * Preserved legacy single-recording behavior for older/legacy meetings.
  * Improved resilience: after clip deletion, the active selection and transcript/audio reload correctly; missing clip audio/deletion errors won’t break the view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->