### PR TITLE
fix(notes): migrate to @tiptap/markdown and fix list/checkbox rendering

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,9 +20,9 @@
         "@tiptap/extension-task-item": "^3.27.1",
         "@tiptap/extension-task-list": "^3.27.1",
         "@tiptap/extension-typography": "^3.27.1",
+        "@tiptap/markdown": "^3.27.1",
         "@tiptap/starter-kit": "^3.27.1",
         "@tiptap/vue-3": "^3.27.1",
-        "tiptap-markdown": "^0.9.0",
         "vue": "^3.5.39",
         "vue-router": "^5.1.0"
       },
@@ -1714,6 +1714,23 @@
         "@tiptap/pm": "3.27.1"
       }
     },
+    "node_modules/@tiptap/markdown": {
+      "version": "3.27.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/markdown/-/markdown-3.27.1.tgz",
+      "integrity": "sha512-4m2LZcj/uN0uLlGnXr3i7sfdxbQNNmeMn4wFyFrP2xpshcKPL5WujUAcqT2rgKfaDjKQ8gIK/GpgSQKuRENFwg==",
+      "license": "MIT",
+      "dependencies": {
+        "marked": "^17.0.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.27.1",
+        "@tiptap/pm": "3.27.1"
+      }
+    },
     "node_modules/@tiptap/pm": {
       "version": "3.27.1",
       "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.27.1.tgz",
@@ -2022,28 +2039,6 @@
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/@types/jsesc/-/jsesc-2.5.1.tgz",
       "integrity": "sha512-9VN+6yxLOPLOav+7PwjZbxiID2bVaeq0ED4qSQmdQTdjnXJSaCVKTR58t15oqH1H5t8Ng2ZX1SabJVoN9Q34bw==",
-      "license": "MIT"
-    },
-    "node_modules/@types/linkify-it": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-3.0.5.tgz",
-      "integrity": "sha512-yg6E+u0/+Zjva+buc3EIb+29XEg4wltq7cSmd4Uc2EE/1nUVmxyzpX6gUXD0V8jIrG0r7YeOGVIbYRkxeooCtw==",
-      "license": "MIT"
-    },
-    "node_modules/@types/markdown-it": {
-      "version": "13.0.9",
-      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-13.0.9.tgz",
-      "integrity": "sha512-1XPwR0+MgXLWfTn9gCsZ55AHOKW1WN+P9vr0PaQh5aerR9LLQXUbjfEAFhjmEmyoYFWAyuN2Mqkn40MZ4ukjBw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/linkify-it": "^3",
-        "@types/mdurl": "^1"
-      }
-    },
-    "node_modules/@types/mdurl": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-1.0.5.tgz",
-      "integrity": "sha512-6L6VymKTzYSrEf4Nev4Xa1LCHKrlTlYCBMTlQKFuddo1CvQcE52I0mwfOJayueUC7MJuXOeHTcIU683lzd0cUA==",
       "license": "MIT"
     },
     "node_modules/@vitejs/plugin-vue": {
@@ -2486,12 +2481,6 @@
       "engines": {
         "node": ">=8.5"
       }
-    },
-    "node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "license": "Python-2.0"
     },
     "node_modules/assertion-error": {
       "version": "2.0.1",
@@ -4171,25 +4160,6 @@
         "url": "https://opencollective.com/parcel"
       }
     },
-    "node_modules/linkify-it": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.1.tgz",
-      "integrity": "sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/puzrin"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/markdown-it"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "uc.micro": "^2.0.0"
-      }
-    },
     "node_modules/linkifyjs": {
       "version": "4.3.3",
       "resolved": "https://registry.npmjs.org/linkifyjs/-/linkifyjs-4.3.3.tgz",
@@ -4261,49 +4231,16 @@
         "url": "https://github.com/sponsors/sxzz"
       }
     },
-    "node_modules/markdown-it": {
-      "version": "14.2.0",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.2.0.tgz",
-      "integrity": "sha512-1TGiQiJVRQ3NPmZH6sx5Cfnmg6GQm9jvC1ch4TK511NjSJvjzKLzn5pPfZRNZkRPZP0HqCioSndqH8v2nRaWVQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/puzrin"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/markdown-it"
-        }
-      ],
+    "node_modules/marked": {
+      "version": "17.0.6",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-17.0.6.tgz",
+      "integrity": "sha512-gB0gkNafnonOw0obSTEGZTT86IuhILt2Wfx0mWH/1Au83kybTayroZ/V6nS25mN7u8ASy+5fMhgB3XPNrOZdmA==",
       "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1",
-        "entities": "^4.4.0",
-        "linkify-it": "^5.0.1",
-        "mdurl": "^2.0.0",
-        "punycode.js": "^2.3.1",
-        "uc.micro": "^2.1.0"
-      },
       "bin": {
-        "markdown-it": "bin/markdown-it.mjs"
-      }
-    },
-    "node_modules/markdown-it-task-lists": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/markdown-it-task-lists/-/markdown-it-task-lists-2.1.1.tgz",
-      "integrity": "sha512-TxFAc76Jnhb2OUu+n3yz9RMu4CwGfaT788br6HhEDlvWfdeJcLUsxk1Hgw2yJio0OXsxv7pyIPmvECY7bMbluA==",
-      "license": "ISC"
-    },
-    "node_modules/markdown-it/node_modules/entities": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=0.12"
+        "marked": "bin/marked.js"
       },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/math-intrinsics": {
@@ -4322,12 +4259,6 @@
       "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
       "dev": true,
       "license": "CC0-1.0"
-    },
-    "node_modules/mdurl": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
-      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
-      "license": "MIT"
     },
     "node_modules/media-typer": {
       "version": "1.1.0",
@@ -4889,39 +4820,6 @@
         "w3c-keyname": "^2.2.0"
       }
     },
-    "node_modules/prosemirror-markdown": {
-      "version": "1.13.4",
-      "resolved": "https://registry.npmjs.org/prosemirror-markdown/-/prosemirror-markdown-1.13.4.tgz",
-      "integrity": "sha512-D98dm4cQ3Hs6EmjK500TdAOew4Z03EV71ajEFiWra3Upr7diytJsjF4mPV2dW+eK5uNectiRj0xFxYI9NLXDbw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/markdown-it": "^14.0.0",
-        "markdown-it": "^14.0.0",
-        "prosemirror-model": "^1.25.0"
-      }
-    },
-    "node_modules/prosemirror-markdown/node_modules/@types/linkify-it": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
-      "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
-      "license": "MIT"
-    },
-    "node_modules/prosemirror-markdown/node_modules/@types/markdown-it": {
-      "version": "14.1.2",
-      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
-      "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/linkify-it": "^5",
-        "@types/mdurl": "^2"
-      }
-    },
-    "node_modules/prosemirror-markdown/node_modules/@types/mdurl": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
-      "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
-      "license": "MIT"
-    },
     "node_modules/prosemirror-model": {
       "version": "1.25.7",
       "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.7.tgz",
@@ -5023,15 +4921,6 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/punycode.js": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
-      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -5659,24 +5548,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/tiptap-markdown": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/tiptap-markdown/-/tiptap-markdown-0.9.0.tgz",
-      "integrity": "sha512-dKLQ9iiuGNgrlGVjrNauF/UBzWu4LYOx5pkD0jNkmQt/GOwfCJsBuzZTsf1jZ204ANHOm572mZ9PYvGh1S7tpQ==",
-      "license": "MIT",
-      "workspaces": [
-        "example"
-      ],
-      "dependencies": {
-        "@types/markdown-it": "^13.0.7",
-        "markdown-it": "^14.1.0",
-        "markdown-it-task-lists": "^2.1.1",
-        "prosemirror-markdown": "^1.11.1"
-      },
-      "peerDependencies": {
-        "@tiptap/core": "^3.0.1"
-      }
-    },
     "node_modules/tldts": {
       "version": "7.4.2",
       "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.2.tgz",
@@ -5792,12 +5663,6 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
-    },
-    "node_modules/uc.micro": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
-      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
-      "license": "MIT"
     },
     "node_modules/ufo": {
       "version": "1.6.4",

--- a/package.json
+++ b/package.json
@@ -25,9 +25,9 @@
     "@tiptap/extension-task-item": "^3.27.1",
     "@tiptap/extension-task-list": "^3.27.1",
     "@tiptap/extension-typography": "^3.27.1",
+    "@tiptap/markdown": "^3.27.1",
     "@tiptap/starter-kit": "^3.27.1",
     "@tiptap/vue-3": "^3.27.1",
-    "tiptap-markdown": "^0.9.0",
     "vue": "^3.5.39",
     "vue-router": "^5.1.0"
   },

--- a/src/views/MeetingNotesEditor.vue
+++ b/src/views/MeetingNotesEditor.vue
@@ -6,7 +6,7 @@ import Placeholder from '@tiptap/extension-placeholder';
 import Typography from '@tiptap/extension-typography';
 import TaskList from '@tiptap/extension-task-list';
 import TaskItem from '@tiptap/extension-task-item';
-import { Markdown } from 'tiptap-markdown';
+import { Markdown } from '@tiptap/markdown';
 
 // Compact TipTap surface for in-meeting notes. It speaks Markdown at the
 // boundary so local `user-note.md` files and future backend notes share one format.
@@ -32,11 +32,7 @@ const emit = defineEmits<{
 const editor = useEditor({
   extensions: [
     StarterKit.configure({ heading: { levels: [2, 3] } }),
-    Markdown.configure({
-      html: false,
-      transformPastedText: true,
-      transformCopiedText: true,
-    }),
+    Markdown,
     Placeholder.configure({ placeholder: props.placeholder }),
     Typography,
     TaskList,
@@ -52,7 +48,7 @@ const editor = useEditor({
   onUpdate: ({ editor: ed }) => {
     // Emit markdown rather than HTML so the editor stays compatible with the
     // local `user-note.md` artifact and Agents' existing Tiptap markdown convention.
-    emit('update:modelValue', ed.storage.markdown.getMarkdown());
+    emit('update:modelValue', ed.getMarkdown());
   },
   onCreate: ({ editor: ed }) => {
     if (props.modelValue) {
@@ -66,7 +62,7 @@ watch(
   () => props.modelValue,
   (value) => {
     const ed = editor.value;
-    if (!ed || value === ed.storage.markdown.getMarkdown()) return;
+    if (!ed || value === ed.getMarkdown()) return;
     ed.commands.setContent(value || '', { contentType: 'markdown' });
   }
 );
@@ -133,6 +129,21 @@ onBeforeUnmount(() => {
   padding-left: 24px;
 }
 
+/* Tailwind's preflight resets list markers to `none`; restore them so the
+   editing surface shows bullets and numbers as the user types. */
+.meeting-notes-editor :deep(.meeting-notes-prosemirror ul) {
+  list-style-type: disc;
+}
+
+.meeting-notes-editor :deep(.meeting-notes-prosemirror ol) {
+  list-style-type: decimal;
+}
+
+.meeting-notes-editor :deep(.meeting-notes-prosemirror li) {
+  display: list-item;
+  list-style-position: outside;
+}
+
 .meeting-notes-editor :deep(.meeting-notes-prosemirror ul[data-type="taskList"]) {
   list-style: none;
   padding-left: 0;
@@ -140,7 +151,26 @@ onBeforeUnmount(() => {
 
 .meeting-notes-editor :deep(.meeting-notes-prosemirror ul[data-type="taskList"] li) {
   display: flex;
+  align-items: flex-start;
   gap: 8px;
+}
+
+/* Keep the checkbox inline with the first line of its text: pin the label,
+   nudge it to the text's optical center, and drop the paragraph's block
+   margin so the item stays a single tight line. */
+.meeting-notes-editor :deep(.meeting-notes-prosemirror ul[data-type="taskList"] li > label) {
+  flex: 0 0 auto;
+  margin-top: 0;
+  user-select: none;
+}
+
+.meeting-notes-editor :deep(.meeting-notes-prosemirror ul[data-type="taskList"] li > div) {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.meeting-notes-editor :deep(.meeting-notes-prosemirror ul[data-type="taskList"] li > div > p) {
+  margin: 0;
 }
 
 .meeting-notes-editor :deep(.meeting-notes-prosemirror blockquote) {


### PR DESCRIPTION
Replaces the abandoned `tiptap-markdown` with the official `@tiptap/markdown`.

- Swap `tiptap-markdown@^0.9.0` → `@tiptap/markdown@^3.27.1`; use the new `editor.getMarkdown()` API and drop the removed `html`/`transformPastedText`/`transformCopiedText` options (`setContent(..., { contentType: 'markdown' })` unchanged).
- Restore ordered/unordered list markers in the editor, which Tailwind v4 preflight was stripping (`list-style-type: disc`/`decimal`).
- Align task-list checkboxes inline with the first line of their text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated Markdown support to the newer TipTap Markdown package.
  * Improved editor rendering so bulleted lists, numbered lists, and task lists display more consistently.

* **Bug Fixes**
  * Fixed Markdown syncing in the editor so changes are saved and compared using the latest editor output.
  * Restored visible list markers and improved task list spacing/alignment inside notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->