### PR TITLE
feat: local-backend Obsidian vault for notes + audio

### DIFF
--- a/docs/superpowers/specs/2026-07-03-local-backend-vault-design.md
+++ b/docs/superpowers/specs/2026-07-03-local-backend-vault-design.md
@@ -32,22 +32,34 @@ source-of-truth database. Adopting it gives users genuine data ownership and int
 3. **Fixed vault location:** `~/.ariso/vault`. A user-configurable path is deferred.
 4. **oats owns the vault.** oats bootstraps a minimal `.obsidian/` so the folder opens
    cleanly in Obsidian.
-5. **Split of truth:**
-   - **Canonical in the vault:** the note (`<meeting>.md`) and audio
-     (`Attachments/<meeting>.mp3`). Each written once.
+5. **Split of truth (Option A — vault is the sole home for both note and audio):**
+   - **Canonical in the vault:** the note (`<basename>.md`) and audio
+     (`Attachments/<basename>.mp3`). The audio lives *only* here — new recordings do not
+     keep a `recording.mp3` under `~/.ariso`. The whole recording pipeline (fresh write,
+     STT input, append-concatenation, retry, playback) reads and writes audio at the vault
+     attachment path.
    - **Canonical in `~/.ariso/recordings/<id>/`:** `meta.json`, `segments.json`,
-     `transcript.md` — unchanged, oats-private machine state.
-6. **Link by `oats_id`.** The note's front-matter carries `oats_id` equal to the recording
-   folder id. oats locates a note by scanning front-matter, so renames/moves in Obsidian
-   never break the link (path-independent).
-7. **Respect deletions; no mirror.** If the user deletes the vault note, it stays deleted.
-   A `notes_written` timestamp in `meta.json` records that oats already generated the note;
-   its presence + an absent vault note ⇒ user deletion ⇒ never regenerate. That flag is the
-   tombstone (no separate file).
-8. **Cascade delete.** Deleting a recording inside oats removes its vault note + audio
-   attachment as well as the private `~/.ariso` folder.
-9. **Migration = fallback (option B).** Existing local recordings are not migrated. Reads
-   check the vault first (by `oats_id`) and fall back to the legacy
+     `transcript.md` — oats-private machine state. `meta.json` gains two pointer/marker
+     fields (below).
+6. **Link by `oats_id`; resolve audio by `meta.audio_file`.** The note's front-matter
+   carries `oats_id` equal to the recording folder id, so oats locates a note by scanning
+   front-matter (renames/moves in Obsidian never break it). The attachment filename is
+   title-derived, so the pipeline can't guess it from the id — `meta.json` stores
+   `audio_file` (the attachment's basename, e.g. `2026-06-02 Team Standup.mp3`) as the
+   id→attachment pointer. `meta.audio_file` stays private; it just names a file in the vault.
+7. **Respect deletions; no mirror.** If the user deletes the vault note, it stays deleted —
+   oats has no spontaneous regeneration path (notes are only (re)written at finalize, on
+   append, or on an explicit retry), so a deleted note is respected by construction. A
+   `notes_written` timestamp in `meta.json` records that oats generated the note at least
+   once; it exists so `derive_notes_status` can tell "never generated (still pending)" from
+   "generated then deleted (show as absent, not a perpetual spinner)".
+8. **Cascade delete (forward requirement).** Deleting a recording inside oats must remove
+   its vault note + audio attachment as well as the private `~/.ariso` folder. **Note:** the
+   app has no local "delete recording" command today (only Ariso clip deletion exists), so
+   there is nothing to build in v1. `vault::delete_recording_artifacts` is provided so that
+   whoever adds local deletion later wires in the cascade; a unit test covers it.
+9. **Migration = fallback, no backfill.** Existing local recordings are not migrated. Reads
+   check the vault first (by `oats_id` / `meta.audio_file`) and fall back to the legacy
    `~/.ariso/recordings/<id>/ari-note.md` and `recording.mp3`. Only new recordings use the
    vault.
 
@@ -61,15 +73,31 @@ source-of-truth database. Adopting it gives users genuine data ownership and int
     2026-06-02 Team Standup.mp3              # audio — canonical, lives only here
   2026-06-02 Team Standup.md                 # note — canonical, lives only here
 
-~/.ariso/recordings/2026-06-02T14-30-05Z/    # unchanged, oats-private
-  meta.json
+~/.ariso/recordings/2026-06-02T14-30-05Z/    # oats-private
+  meta.json                                  # + audio_file, notes_written
   segments.json
   transcript.md
+  append-clip.mp3                            # transient scratch during an append only
 ```
 
 New recordings no longer write `recording.mp3` or `ari-note.md` under
-`~/.ariso/recordings/<id>/`; those artifacts live in the vault. Legacy recordings keep
-their old files (see Legacy fallback).
+`~/.ariso/recordings/<id>/`; those artifacts live in the vault. The only audio ever written
+under `~/.ariso` is the transient `append-clip.mp3` scratch file (a single clip being
+transcribed mid-append; deleted when the append commits). Legacy recordings keep their old
+files (see Legacy fallback).
+
+`RecordingMeta` gains two optional fields:
+
+```rust
+/// Basename of this recording's audio attachment in the vault
+/// (`<vault>/Attachments/<audio_file>`). None for legacy recordings, whose audio
+/// still lives at `~/.ariso/recordings/<id>/recording.mp3`.
+pub audio_file: Option<String>,
+/// RFC3339 time oats last wrote this recording's note into the vault. None means
+/// never generated. Set means generated at least once; an absent vault note then
+/// signals a user deletion rather than "still pending".
+pub notes_written: Option<String>,
+```
 
 ### Note format
 
@@ -99,34 +127,44 @@ A new `src-tauri/src/vault.rs` module, mirroring `storage.rs` conventions (atomi
 - `ensure_vault()` — first-use bootstrap: create the vault dir, `Attachments/`, and a
   minimal `.obsidian/app.json` (sets `attachmentFolderPath: "Attachments"`). Idempotent.
 - `note_basename(date, title) -> String` — `YYYY-MM-DD <title>`, sanitized (strip path
-  separators, `:`, `..`, reserved chars), collision-suffixed with a numeric counter.
-- `write_note(meta, notes_md)` — render front-matter + audio embed + body; atomic
-  temp-then-rename; called **once**, at notes-generation time.
-- `move_audio_into_vault(meta, bytes|path)` — place the recording's audio in
-  `Attachments/<basename>.mp3` at finalize.
-- `scan_vault() -> HashMap<oats_id, PathBuf>` — read each top-level `.md` file's
-  front-matter head, index by `oats_id`; skip files with no/invalid `oats_id` (same "skip
-  junk" tolerance as `list_recordings`).
-- `find_note(oats_id)`, `read_note(oats_id)`, `delete_note(oats_id)` — the last removes the
-  note and its referenced attachment (cascade).
-
-`meta.json` gains a `notes_written: Option<String>` (RFC3339) field, written when the vault
-note is first created.
+  separators, `:`, `..`, reserved chars). The caller collision-suffixes against existing
+  files with a numeric counter (`(2)`, `(3)`, …); `note_basename` is the pure derivation and
+  a `unique_basename(dir, base)` helper does the suffixing.
+- `audio_path(audio_file) -> PathBuf` / `note_path(basename) -> PathBuf` — resolve
+  `<vault>/Attachments/<audio_file>` and `<vault>/<basename>.md`.
+- `write_audio(audio_file, bytes)` — atomic write into `Attachments/`; used by the whole
+  pipeline (fresh write, append-concat result, retry, save-failed-clip) as the audio's only
+  home.
+- `read_audio(audio_file) -> Vec<u8>` — read the attachment (STT input, append-concat source,
+  retry, playback all go through this).
+- `render_note(meta, notes_md) -> String` — pure: front-matter (`oats_id`, `title`, `date`,
+  `duration`, `participants`) + `![[Attachments/<audio_file>]]` embed + body.
+- `note_body(contents) -> String` — pure inverse: strip front-matter and the leading audio
+  embed, returning just the notes body for in-app rendering.
+- `write_note(basename, contents)` — atomic write of a note `.md`; called by
+  `process_notes`, which then sets `meta.notes_written`.
+- `scan_vault() -> HashMap<oats_id, PathBuf>` — read each top-level `.md` file's front-matter
+  head, index by `oats_id`; skip files with no/invalid `oats_id` (same "skip junk" tolerance
+  as `list_recordings`).
+- `find_note(oats_id)`, `read_note(oats_id)`, `delete_recording_artifacts(oats_id, audio_file)`
+  — the last removes the vault note (by scan) and its attachment (cascade).
 
 ## Data flow
 
-1. **Finalize** (new recording): audio → `vault/Attachments/`; `meta/segments/transcript` →
-   `~/.ariso`; the row appears in the library from `meta.json` as today.
-2. **Notes generation completes:** `write_note` to the vault once, then set
+1. **Fresh recording:** derive `audio_file = unique_basename(...) + ".mp3"`, store it in
+   `meta.audio_file`, `write_audio` into the vault; STT transcribes by reading the attachment
+   back via `read_audio`; `segments`/`transcript`/`meta` → `~/.ariso`. The library row comes
+   from `meta.json` as today.
+2. **Notes generation completes:** `render_note` + `write_note` into the vault, then set
    `notes_written` in `meta.json`.
-3. **Obsidian:** user opens `~/.ariso/vault`, sees the note with inline audio, edits
-   freely. oats never rewrites the body.
-4. **`list_recordings`:** build the `scan_vault` map once per call; `has_note` / `has_audio`
-   derive from vault presence keyed by `oats_id`, falling back to legacy paths. The detail
-   view reads the note from the vault (or legacy).
-5. **Delete in Obsidian:** the next scan finds no note for the id, but `notes_written` is
-   set ⇒ respected, never regenerated. The meeting still shows in the library from
-   `meta.json`, with no note (equivalent to notes-removed).
+3. **Obsidian:** user opens `~/.ariso/vault`, sees the note with inline audio, edits freely.
+   oats never rewrites the body.
+4. **`list_recordings`:** build the `scan_vault` map once per call; `has_note` derives from
+   vault presence by `oats_id` (legacy: `~/.ariso` `ari-note.md`); `has_audio` derives from
+   `meta.audio_file` present + attachment exists (legacy: `~/.ariso` `recording.mp3`). The
+   detail view reads the note body from the vault via `note_body` (or legacy).
+5. **Delete in Obsidian:** the next scan finds no note for the id; `notes_written` is set, so
+   `derive_notes_status` reports "absent" rather than "pending", and nothing regenerates.
 6. **Delete recording in oats:** cascade removes the vault note + attachment and the
    `~/.ariso/recordings/<id>/` folder.
 
@@ -138,22 +176,27 @@ Thereafter the vault is the user's. No mirror, no reconciliation of edits.
 
 Local multi-recording lets a clip that starts within the append window (`APPEND_WINDOW_SECONDS`)
 merge into the prior recording, re-stitching `segments.json` and regenerating notes for the
-merged recording. Because that regeneration must reach the vault, the note may be (re)written
-more than once **while the recording is still appendable**. `notes_written` records the most
-recent write; the recording is only considered "final" (and thus off-limits to further oats
-writes) once the append window has elapsed. User edits made in Obsidian during an active,
-still-appendable recording session are an accepted edge case — appends occur within minutes of
-recording, before a user would normally open and edit the note.
+merged recording. Two consequences for the vault:
+
+- **Audio concatenation reads/writes the vault attachment.** `append_recording_core` reads
+  the target's audio via `read_audio(target.audio_file)`, concatenates the new clip's bytes,
+  and `write_audio`s the result back to the same attachment. The per-clip scratch file
+  (`append-clip.mp3`, used only to transcribe the isolated clip) stays in `~/.ariso` and is
+  deleted when the append commits — it is never the canonical audio.
+- **The note may be (re)written while the recording is still appendable.** `notes_written`
+  records the most recent write. User edits made in Obsidian during an active, still-appendable
+  session are an accepted edge case — appends occur within minutes of recording, before a user
+  would normally open and edit the note.
 
 ## Deletion semantics
 
 | Trigger | Behavior |
 |---|---|
 | User deletes vault note (Obsidian) | Respected. `notes_written` set + note absent ⇒ never regenerate. Meeting remains in library without a note. |
-| User deletes recording (oats library) | Cascade: remove vault note + attachment + `~/.ariso` folder. |
+| User deletes recording (oats library) | Cascade: remove vault note + attachment + `~/.ariso` folder. *No local delete command exists yet — `delete_recording_artifacts` is provided and tested for when one is added.* |
 | User deletes audio attachment only | `has_audio` becomes false via fallback/scan; playback unavailable; note unaffected. |
 
-## Legacy fallback (migration option B)
+## Legacy fallback (no backfill)
 
 No migration runs. Per-recording resolution order for notes and audio:
 
@@ -177,10 +220,13 @@ with no data movement.
 
 ## Security & privacy (`oats-security`)
 
-- A Tauri capability must allow reading `~/.ariso/vault/Attachments/*` for audio playback via
-  the asset protocol / `convertFileSrc`.
+- **No new Tauri capability needed.** Audio plays through the existing `read_recording_audio`
+  command, which returns bytes over IPC (the frontend builds a Blob URL) — it is not the
+  asset protocol, so relocating the file to the vault needs no capability change. The command
+  just resolves the vault attachment (via `meta.audio_file`) with a legacy fallback.
 - Filename sanitization from user-controlled titles guards against path traversal and
-  reserved names.
+  reserved names. `note_basename` strips `/`, `\`, `:`, `..`, and leading dots; a title that
+  sanitizes to empty falls back to the recording id.
 - **Privacy shift:** notes *and audio* now live in the vault. If the user syncs
   `~/.ariso/vault` (iCloud, Obsidian Sync, git), that content leaves the machine — a real
   departure from the offline-mode guarantee. Surface this clearly in the UI. (v1 keeps the
@@ -190,17 +236,25 @@ with no data movement.
 
 Pure-function unit tests with tempdir + `ARISO_ROOT`, matching `storage.rs`:
 
-- `note_basename` derivation and collision suffixing.
-- Front-matter render/parse roundtrip (including `oats_id` extraction).
+- `note_basename` derivation/sanitization (traversal chars, empty→id fallback) and
+  `unique_basename` collision suffixing.
+- `render_note` + `note_body` roundtrip (front-matter + embed + body → body), and `oats_id`
+  extraction by `scan_vault`.
 - `scan_vault` builds the correct `oats_id → path` map and skips junk files.
-- Respect-deletion logic: `notes_written` set + absent note ⇒ skip regeneration.
-- Cascade delete removes note + attachment.
-- Legacy fallback: vault-miss resolves to the old `~/.ariso` paths.
+- `derive_notes_status` with the new `notes_written` arg: absent note + `notes_written` set ⇒
+  not `Pending`; absent note + `notes_written` None ⇒ `Pending`.
+- `write_audio`/`read_audio` roundtrip and `delete_recording_artifacts` cascade (note +
+  attachment removed).
+- Legacy fallback: `meta.audio_file` None ⇒ audio resolves to `~/.ariso` `recording.mp3`;
+  no vault note ⇒ note resolves to `~/.ariso` `ari-note.md`.
+- `finalize_core` / `append_recording_core` / `retry_transcription_core` integration
+  (tempdir + `ARISO_ROOT`): audio ends up in the vault, append concatenates the vault
+  attachment, and no `recording.mp3` is written under `~/.ariso`.
 
 ## Non-goals / deferred (YAGNI)
 
 - User-configurable vault path.
-- Migrating existing recordings' notes/audio into the vault (option A backfill).
+- Migrating existing recordings' notes/audio into the vault (one-time backfill).
 - Putting `transcript.md`, `segments.json`, or `meta.json` in the vault.
 - Wikilinks/backlinks between meetings.
 - Cloud-backend meetings in the vault.

--- a/docs/superpowers/specs/2026-07-03-local-backend-vault-design.md
+++ b/docs/superpowers/specs/2026-07-03-local-backend-vault-design.md
@@ -1,0 +1,217 @@
+# Local backend Obsidian vault — design
+
+**Date:** 2026-07-03
+**Branch:** `feat/local-backend-vault`
+**Status:** Design (pending implementation plan)
+
+## Overview
+
+Store the AI notes and audio for **local-backend** meetings in an Obsidian-compatible
+vault at `~/.ariso/vault`, so users can open, read, and edit their meeting notes in
+Obsidian (or any editor) as first-class markdown. The vault is the **canonical, single
+copy** of the note and its audio — not a mirror of a copy held elsewhere. oats writes each
+note exactly once (at notes-generation time) and never rewrites the body afterward, which
+is what makes shared read/write with Obsidian safe without reconciliation.
+
+This is a local/offline-backend feature only. Cloud-backend meetings (stored on Ariso
+servers) are untouched.
+
+## Motivation
+
+oats' local store is already markdown-first (`transcript.md` and `ari-note.md` with YAML
+front-matter, plain files, no database). Obsidian's vault model is the same philosophy:
+a plain folder of markdown + attachments, with a rebuildable metadata cache rather than a
+source-of-truth database. Adopting it gives users genuine data ownership and interop
+(Obsidian graph/backlinks/plugins) without oats depending on Obsidian being installed.
+
+## Decisions (locked during brainstorming)
+
+1. **Local backend only.** Cloud meetings are out of scope.
+2. **Always-on.** Every local recording writes a note + audio attachment to the vault; no
+   settings toggle in v1.
+3. **Fixed vault location:** `~/.ariso/vault`. A user-configurable path is deferred.
+4. **oats owns the vault.** oats bootstraps a minimal `.obsidian/` so the folder opens
+   cleanly in Obsidian.
+5. **Split of truth:**
+   - **Canonical in the vault:** the note (`<meeting>.md`) and audio
+     (`Attachments/<meeting>.mp3`). Each written once.
+   - **Canonical in `~/.ariso/recordings/<id>/`:** `meta.json`, `segments.json`,
+     `transcript.md` — unchanged, oats-private machine state.
+6. **Link by `oats_id`.** The note's front-matter carries `oats_id` equal to the recording
+   folder id. oats locates a note by scanning front-matter, so renames/moves in Obsidian
+   never break the link (path-independent).
+7. **Respect deletions; no mirror.** If the user deletes the vault note, it stays deleted.
+   A `notes_written` timestamp in `meta.json` records that oats already generated the note;
+   its presence + an absent vault note ⇒ user deletion ⇒ never regenerate. That flag is the
+   tombstone (no separate file).
+8. **Cascade delete.** Deleting a recording inside oats removes its vault note + audio
+   attachment as well as the private `~/.ariso` folder.
+9. **Migration = fallback (option B).** Existing local recordings are not migrated. Reads
+   check the vault first (by `oats_id`) and fall back to the legacy
+   `~/.ariso/recordings/<id>/ari-note.md` and `recording.mp3`. Only new recordings use the
+   vault.
+
+## On-disk layout
+
+```
+~/.ariso/vault/                              # the Obsidian vault (fixed for now)
+  .obsidian/
+    app.json                                 # minimal; attachmentFolderPath: "Attachments"
+  Attachments/
+    2026-06-02 Team Standup.mp3              # audio — canonical, lives only here
+  2026-06-02 Team Standup.md                 # note — canonical, lives only here
+
+~/.ariso/recordings/2026-06-02T14-30-05Z/    # unchanged, oats-private
+  meta.json
+  segments.json
+  transcript.md
+```
+
+New recordings no longer write `recording.mp3` or `ari-note.md` under
+`~/.ariso/recordings/<id>/`; those artifacts live in the vault. Legacy recordings keep
+their old files (see Legacy fallback).
+
+### Note format
+
+```markdown
+---
+oats_id: 2026-06-02T14-30-05Z
+title: Team Standup
+date: 2026-06-02T14:30:05Z
+duration: "00:42:13"
+participants: ["Speaker 1", "Speaker 2"]
+---
+![[Attachments/2026-06-02 Team Standup.mp3]]
+
+<AI notes body>
+```
+
+`oats_id` is the only field oats depends on; the rest populate Obsidian's Properties view
+and may be freely edited by the user. The audio embed uses an Obsidian wikilink so it plays
+inline.
+
+## Components
+
+A new `src-tauri/src/vault.rs` module, mirroring `storage.rs` conventions (atomic writes,
+`ARISO_ROOT`-aware root, traversal-guarded ids, pure functions with tempdir tests).
+
+- `vault_root() -> PathBuf` — `~/.ariso/vault`, honoring `ARISO_ROOT` like `ariso_root()`.
+- `ensure_vault()` — first-use bootstrap: create the vault dir, `Attachments/`, and a
+  minimal `.obsidian/app.json` (sets `attachmentFolderPath: "Attachments"`). Idempotent.
+- `note_basename(date, title) -> String` — `YYYY-MM-DD <title>`, sanitized (strip path
+  separators, `:`, `..`, reserved chars), collision-suffixed with a numeric counter.
+- `write_note(meta, notes_md)` — render front-matter + audio embed + body; atomic
+  temp-then-rename; called **once**, at notes-generation time.
+- `move_audio_into_vault(meta, bytes|path)` — place the recording's audio in
+  `Attachments/<basename>.mp3` at finalize.
+- `scan_vault() -> HashMap<oats_id, PathBuf>` — read each top-level `.md` file's
+  front-matter head, index by `oats_id`; skip files with no/invalid `oats_id` (same "skip
+  junk" tolerance as `list_recordings`).
+- `find_note(oats_id)`, `read_note(oats_id)`, `delete_note(oats_id)` — the last removes the
+  note and its referenced attachment (cascade).
+
+`meta.json` gains a `notes_written: Option<String>` (RFC3339) field, written when the vault
+note is first created.
+
+## Data flow
+
+1. **Finalize** (new recording): audio → `vault/Attachments/`; `meta/segments/transcript` →
+   `~/.ariso`; the row appears in the library from `meta.json` as today.
+2. **Notes generation completes:** `write_note` to the vault once, then set
+   `notes_written` in `meta.json`.
+3. **Obsidian:** user opens `~/.ariso/vault`, sees the note with inline audio, edits
+   freely. oats never rewrites the body.
+4. **`list_recordings`:** build the `scan_vault` map once per call; `has_note` / `has_audio`
+   derive from vault presence keyed by `oats_id`, falling back to legacy paths. The detail
+   view reads the note from the vault (or legacy).
+5. **Delete in Obsidian:** the next scan finds no note for the id, but `notes_written` is
+   set ⇒ respected, never regenerated. The meeting still shows in the library from
+   `meta.json`, with no note (equivalent to notes-removed).
+6. **Delete recording in oats:** cascade removes the vault note + attachment and the
+   `~/.ariso/recordings/<id>/` folder.
+
+**Invariant:** oats writes the note body only while the recording is still accreting; once
+finalized (`notes_written` set and the append window closed), it never rewrites the body.
+Thereafter the vault is the user's. No mirror, no reconciliation of edits.
+
+### Append interaction
+
+Local multi-recording lets a clip that starts within the append window (`APPEND_WINDOW_SECONDS`)
+merge into the prior recording, re-stitching `segments.json` and regenerating notes for the
+merged recording. Because that regeneration must reach the vault, the note may be (re)written
+more than once **while the recording is still appendable**. `notes_written` records the most
+recent write; the recording is only considered "final" (and thus off-limits to further oats
+writes) once the append window has elapsed. User edits made in Obsidian during an active,
+still-appendable recording session are an accepted edge case — appends occur within minutes of
+recording, before a user would normally open and edit the note.
+
+## Deletion semantics
+
+| Trigger | Behavior |
+|---|---|
+| User deletes vault note (Obsidian) | Respected. `notes_written` set + note absent ⇒ never regenerate. Meeting remains in library without a note. |
+| User deletes recording (oats library) | Cascade: remove vault note + attachment + `~/.ariso` folder. |
+| User deletes audio attachment only | `has_audio` becomes false via fallback/scan; playback unavailable; note unaffected. |
+
+## Legacy fallback (migration option B)
+
+No migration runs. Per-recording resolution order for notes and audio:
+
+1. Vault, by `oats_id` (new recordings).
+2. Legacy `~/.ariso/recordings/<id>/ari-note.md` / `recording.mp3` (pre-feature recordings).
+3. Otherwise absent.
+
+Legacy recordings have no `notes_written` flag and no vault entry, so respect-deletion never
+applies to them — they simply render from the old path. New and legacy recordings coexist
+with no data movement.
+
+## Error handling
+
+- **Vault unwritable/missing when notes are ready:** treat like the existing `notes_error`
+  path — status stays `Pending`/`Failed`, retried on the next generation attempt; never
+  crashes.
+- **Unparseable front-matter / missing `oats_id`:** the file is skipped during scan.
+- **Filename collision:** append a numeric suffix.
+- **Path safety:** title→filename sanitization blocks traversal and reserved characters; all
+  writes are atomic (temp+rename in the same dir) and confined to the vault root.
+
+## Security & privacy (`oats-security`)
+
+- A Tauri capability must allow reading `~/.ariso/vault/Attachments/*` for audio playback via
+  the asset protocol / `convertFileSrc`.
+- Filename sanitization from user-controlled titles guards against path traversal and
+  reserved names.
+- **Privacy shift:** notes *and audio* now live in the vault. If the user syncs
+  `~/.ariso/vault` (iCloud, Obsidian Sync, git), that content leaves the machine — a real
+  departure from the offline-mode guarantee. Surface this clearly in the UI. (v1 keeps the
+  vault under `~/.ariso`, which is not synced by default.)
+
+## Testing
+
+Pure-function unit tests with tempdir + `ARISO_ROOT`, matching `storage.rs`:
+
+- `note_basename` derivation and collision suffixing.
+- Front-matter render/parse roundtrip (including `oats_id` extraction).
+- `scan_vault` builds the correct `oats_id → path` map and skips junk files.
+- Respect-deletion logic: `notes_written` set + absent note ⇒ skip regeneration.
+- Cascade delete removes note + attachment.
+- Legacy fallback: vault-miss resolves to the old `~/.ariso` paths.
+
+## Non-goals / deferred (YAGNI)
+
+- User-configurable vault path.
+- Migrating existing recordings' notes/audio into the vault (option A backfill).
+- Putting `transcript.md`, `segments.json`, or `meta.json` in the vault.
+- Wikilinks/backlinks between meetings.
+- Cloud-backend meetings in the vault.
+- A settings toggle to disable vault writing.
+
+## Risks
+
+- **Hidden folder in Obsidian:** `~/.ariso` is hidden; opening it as a vault needs "show
+  hidden folders" in the OS picker. Acceptable for v1; a configurable path removes this
+  later.
+- **Sync amplifies audio:** audio in the vault means a synced vault carries every recording.
+  Mitigated for v1 by keeping the vault unsynced under `~/.ariso`; called out in the UI.
+- **Scan cost:** `scan_vault` reads front-matter for every note per `list_recordings` call.
+  Fine for hundreds of notes; revisit with an index if libraries grow large.

--- a/docs/superpowers/specs/2026-07-03-local-backend-vault-design.md
+++ b/docs/superpowers/specs/2026-07-03-local-backend-vault-design.md
@@ -49,10 +49,11 @@ source-of-truth database. Adopting it gives users genuine data ownership and int
    id→attachment pointer. `meta.audio_file` stays private; it just names a file in the vault.
 7. **Respect deletions; no mirror.** If the user deletes the vault note, it stays deleted —
    oats has no spontaneous regeneration path (notes are only (re)written at finalize, on
-   append, or on an explicit retry), so a deleted note is respected by construction. A
-   `notes_written` timestamp in `meta.json` records that oats generated the note at least
-   once; it exists so `derive_notes_status` can tell "never generated (still pending)" from
-   "generated then deleted (show as absent, not a perpetual spinner)".
+   append, or on an explicit user-initiated retry), so a deleted note is respected **by
+   construction**, with or without a tombstone. A `notes_written` timestamp is recorded in
+   `meta.json` when oats writes the note, for future use (e.g. a status refinement that
+   distinguishes "never generated" from "generated then deleted", or a guard if an
+   auto-regeneration path is ever added). v1 records it but does not branch on it.
 8. **Cascade delete (forward requirement).** Deleting a recording inside oats must remove
    its vault note + audio attachment as well as the private `~/.ariso` folder. **Note:** the
    app has no local "delete recording" command today (only Ariso clip deletion exists), so
@@ -163,8 +164,9 @@ A new `src-tauri/src/vault.rs` module, mirroring `storage.rs` conventions (atomi
    vault presence by `oats_id` (legacy: `~/.ariso` `ari-note.md`); `has_audio` derives from
    `meta.audio_file` present + attachment exists (legacy: `~/.ariso` `recording.mp3`). The
    detail view reads the note body from the vault via `note_body` (or legacy).
-5. **Delete in Obsidian:** the next scan finds no note for the id; `notes_written` is set, so
-   `derive_notes_status` reports "absent" rather than "pending", and nothing regenerates.
+5. **Delete in Obsidian:** the next scan finds no note for the id; nothing regenerates it
+   (no spontaneous regeneration path). `has_note` becomes false; the meeting still shows in
+   the library from `meta.json`, without a note.
 6. **Delete recording in oats:** cascade removes the vault note + attachment and the
    `~/.ariso/recordings/<id>/` folder.
 
@@ -192,7 +194,7 @@ merged recording. Two consequences for the vault:
 
 | Trigger | Behavior |
 |---|---|
-| User deletes vault note (Obsidian) | Respected. `notes_written` set + note absent ⇒ never regenerate. Meeting remains in library without a note. |
+| User deletes vault note (Obsidian) | Respected by construction (no spontaneous regeneration). `has_note` false; meeting remains in library without a note. |
 | User deletes recording (oats library) | Cascade: remove vault note + attachment + `~/.ariso` folder. *No local delete command exists yet — `delete_recording_artifacts` is provided and tested for when one is added.* |
 | User deletes audio attachment only | `has_audio` becomes false via fallback/scan; playback unavailable; note unaffected. |
 
@@ -241,8 +243,6 @@ Pure-function unit tests with tempdir + `ARISO_ROOT`, matching `storage.rs`:
 - `render_note` + `note_body` roundtrip (front-matter + embed + body → body), and `oats_id`
   extraction by `scan_vault`.
 - `scan_vault` builds the correct `oats_id → path` map and skips junk files.
-- `derive_notes_status` with the new `notes_written` arg: absent note + `notes_written` set ⇒
-  not `Pending`; absent note + `notes_written` None ⇒ `Pending`.
 - `write_audio`/`read_audio` roundtrip and `delete_recording_artifacts` cascade (note +
   attachment removed).
 - Legacy fallback: `meta.audio_file` None ⇒ audio resolves to `~/.ariso` `recording.mp3`;

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -851,20 +851,33 @@ fn note_or_transcript_filename(kind: &str) -> Result<&'static str, String> {
 /// meeting recording (mp3 at this app's bitrate is well under 1 MB/min).
 const MAX_AUDIO_BYTES: u64 = 1024 * 1024 * 1024;
 
-/// Read the raw bytes of a recording's `recording.mp3`, returned as a raw
-/// binary IPC response so the frontend can build a Blob URL for an `<audio>`
-/// element (avoids JSON-array bloat from a `Vec<u8>` return).
-#[tauri::command]
-pub fn read_recording_audio(id: String) -> Result<tauri::ipc::Response, String> {
-    let path = recording_dir(&id)?.join("recording.mp3");
+/// Resolve and read a recording's audio bytes. New recordings store audio in
+/// the vault (`meta.audio_file` names the attachment); legacy recordings
+/// (pre-vault, `audio_file: None`) keep it at `<recording_dir>/recording.mp3`.
+/// Bounded by `MAX_AUDIO_BYTES` to avoid loading a pathologically large file.
+fn read_recording_audio_bytes(id: &str) -> Result<Vec<u8>, String> {
+    crate::storage::validate_recording_id(id)?;
+    let dir = recording_dir(id)?;
+    let meta = crate::storage::read_meta(&dir)?;
+    let path = match meta.audio_file {
+        Some(audio_file) => crate::vault::audio_path(&crate::vault::vault_root()?, &audio_file),
+        None => dir.join("recording.mp3"),
+    };
     let size = std::fs::metadata(&path)
         .map_err(|e| format!("read recording audio: {e}"))?
         .len();
     if size > MAX_AUDIO_BYTES {
         return Err(format!("recording audio too large to play: {size} bytes"));
     }
-    let bytes = std::fs::read(&path).map_err(|e| format!("read recording audio: {e}"))?;
-    Ok(tauri::ipc::Response::new(bytes))
+    std::fs::read(&path).map_err(|e| format!("read recording audio: {e}"))
+}
+
+/// Read the raw bytes of a recording's audio, returned as a raw binary IPC
+/// response so the frontend can build a Blob URL for an `<audio>` element
+/// (avoids JSON-array bloat from a `Vec<u8>` return).
+#[tauri::command]
+pub fn read_recording_audio(id: String) -> Result<tauri::ipc::Response, String> {
+    Ok(tauri::ipc::Response::new(read_recording_audio_bytes(&id)?))
 }
 
 /// Meeting ids are numeric on the Ariso backend; rejecting anything else also
@@ -1273,6 +1286,35 @@ mod tests {
             audio_file: None,
             notes_written: None,
         }
+    }
+
+    #[test]
+    fn read_recording_audio_resolves_vault_then_legacy() {
+        let tmp = tempfile::tempdir().unwrap();
+        // SAFETY: see above.
+        unsafe { std::env::set_var("ARISO_ROOT", tmp.path()); }
+        let root = tmp.path();
+
+        // New recording: audio in the vault via meta.audio_file.
+        let id_new = "2026-06-02T10-00-00Z";
+        let dir_new = crate::storage::create_recording_dir(root, id_new).unwrap();
+        let mut meta_new = test_meta(id_new);
+        meta_new.audio_file = Some("clip.mp3".into());
+        crate::storage::write_meta(&dir_new, &meta_new).unwrap();
+        crate::vault::write_audio("clip.mp3", b"newbytes").unwrap();
+        assert_eq!(read_recording_audio_bytes(id_new).unwrap(), b"newbytes");
+        // The public command wraps the same resolution logic; smoke-test it too.
+        assert!(read_recording_audio(id_new.into()).is_ok());
+
+        // Legacy recording: no audio_file, audio in ~/.ariso.
+        let id_old = "2026-06-01T10-00-00Z";
+        let dir_old = crate::storage::create_recording_dir(root, id_old).unwrap();
+        crate::storage::write_meta(&dir_old, &test_meta(id_old)).unwrap();
+        std::fs::write(dir_old.join("recording.mp3"), b"oldbytes").unwrap();
+        assert_eq!(read_recording_audio_bytes(id_old).unwrap(), b"oldbytes");
+        assert!(read_recording_audio(id_old.into()).is_ok());
+
+        unsafe { std::env::remove_var("ARISO_ROOT"); }
     }
 
     #[test]

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -760,10 +760,17 @@ pub fn list_local_recordings() -> Result<Vec<crate::storage::RecordingSummary>, 
     // Overlay vault note presence (a user may have deleted a vault note; a new
     // recording's note lives only in the vault, not as ari-note.md).
     let vault_notes = crate::vault::scan_vault()?;
+    let vault_root = crate::vault::vault_root()?;
     for s in &mut summaries {
         if vault_notes.contains_key(&s.id) {
             s.has_note = true;
         }
+        if let Some(af) = &s.audio_file {
+            // New recording: audio lives in the vault; reflect real existence
+            // (a user may have deleted the attachment in Obsidian).
+            s.has_audio = crate::vault::audio_path(&vault_root, af).is_file();
+        }
+        // Legacy (audio_file None): has_audio already reflects recording.mp3.
     }
     Ok(summaries)
 }
@@ -1673,6 +1680,37 @@ mod tests {
 
         let list = list_local_recordings().unwrap();
         assert!(list.iter().find(|s| s.id == id).unwrap().has_note);
+        unsafe { std::env::remove_var("ARISO_ROOT"); }
+    }
+
+    #[test]
+    fn list_local_recordings_reflects_vault_audio_deletion() {
+        // SAFETY: command tests run with --test-threads=1 (see plan conventions),
+        // so the process-wide ARISO_ROOT mutation below has no concurrent writer.
+        let tmp = tempfile::tempdir().unwrap();
+        unsafe { std::env::set_var("ARISO_ROOT", tmp.path()); }
+        let root = tmp.path();
+        let id = "2026-06-02T10-00-00Z";
+        let dir = crate::storage::create_recording_dir(root, id).unwrap();
+        let mut meta = test_meta(id);
+        meta.audio_file = Some("clip.mp3".into());
+        crate::storage::write_meta(&dir, &meta).unwrap();
+        // No attachment written yet: the vault attachment does not exist, so
+        // has_audio must reflect that even though meta.audio_file is set.
+        let list = list_local_recordings().unwrap();
+        assert!(
+            !list.iter().find(|s| s.id == id).unwrap().has_audio,
+            "attachment missing ⇒ has_audio should be false"
+        );
+
+        // Write the attachment: has_audio should flip to true.
+        crate::vault::write_audio("clip.mp3", b"bytes").unwrap();
+        let list = list_local_recordings().unwrap();
+        assert!(
+            list.iter().find(|s| s.id == id).unwrap().has_audio,
+            "attachment present ⇒ has_audio should be true"
+        );
+
         unsafe { std::env::remove_var("ARISO_ROOT"); }
     }
 }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -756,7 +756,16 @@ pub fn get_desktop_config() -> DesktopConfig {
 #[tauri::command]
 pub fn list_local_recordings() -> Result<Vec<crate::storage::RecordingSummary>, String> {
     let root = crate::storage::ariso_root()?;
-    crate::storage::list_recordings(&root)
+    let mut summaries = crate::storage::list_recordings(&root)?;
+    // Overlay vault note presence (a user may have deleted a vault note; a new
+    // recording's note lives only in the vault, not as ari-note.md).
+    let vault_notes = crate::vault::scan_vault()?;
+    for s in &mut summaries {
+        if vault_notes.contains_key(&s.id) {
+            s.has_note = true;
+        }
+    }
+    Ok(summaries)
 }
 
 /// Lightweight status for a single local recording, used by the detail panel's
@@ -769,7 +778,8 @@ pub fn local_recording_status(
     crate::storage::validate_recording_id(&id)?;
     let dir = recording_dir(&id)?;
     let meta = crate::storage::read_meta(&dir)?;
-    let has_note = dir.join("ari-note.md").is_file();
+    let has_note =
+        dir.join("ari-note.md").is_file() || crate::vault::find_note(&id)?.is_some();
     let has_transcript = dir.join("transcript.md").is_file();
     let notes_status = crate::storage::derive_notes_status(has_note, meta.notes_error.as_deref());
     Ok(crate::storage::RecordingStatusView {
@@ -1645,6 +1655,25 @@ mod tests {
     #[test]
     fn local_recording_status_rejects_bad_id() {
         assert!(local_recording_status("../escape".to_string()).is_err());
+    }
+
+    #[test]
+    fn list_local_recordings_marks_has_note_from_vault() {
+        // SAFETY: command tests run with --test-threads=1 (see plan conventions),
+        // so the process-wide ARISO_ROOT mutation below has no concurrent writer.
+        let tmp = tempfile::tempdir().unwrap();
+        unsafe { std::env::set_var("ARISO_ROOT", tmp.path()); }
+        let root = tmp.path();
+        let id = "2026-06-02T10-00-00Z";
+        let dir = crate::storage::create_recording_dir(root, id).unwrap();
+        let mut meta = test_meta(id);
+        meta.audio_file = Some("clip.mp3".into());
+        crate::storage::write_meta(&dir, &meta).unwrap();
+        crate::vault::write_note("2026-06-02 clip", &meta, "clip.mp3", "b").unwrap();
+
+        let list = list_local_recordings().unwrap();
+        assert!(list.iter().find(|s| s.id == id).unwrap().has_note);
+        unsafe { std::env::remove_var("ARISO_ROOT"); }
     }
 }
 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -974,6 +974,19 @@ const MAX_TEXT_BYTES: u64 = 16 * 1024 * 1024;
 /// `kind` must be `"note"` or `"transcript"`.
 #[tauri::command]
 pub fn read_recording_file(id: String, kind: String) -> Result<Option<String>, String> {
+    crate::storage::validate_recording_id(&id)?;
+    if kind == "note" {
+        // Vault note (new recordings) first, then legacy ~/.ariso/ari-note.md.
+        if let Some(body) = crate::vault::read_note(&id)? {
+            return Ok(Some(body));
+        }
+        let legacy = recording_dir(&id)?.join("ari-note.md");
+        return match std::fs::read_to_string(&legacy) {
+            Ok(text) => Ok(Some(text)),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+            Err(e) => Err(format!("read recording file: {e}")),
+        };
+    }
     let filename = note_or_transcript_filename(&kind)?;
     let path = recording_dir(&id)?.join(filename);
     // Only a genuine "not found" means the file hasn't been generated yet;
@@ -995,6 +1008,21 @@ pub fn read_recording_file(id: String, kind: String) -> Result<Option<String>, S
 #[tauri::command]
 pub fn open_recording_file(app: tauri::AppHandle, id: String, kind: String) -> Result<(), String> {
     use tauri_plugin_opener::OpenerExt;
+
+    crate::storage::validate_recording_id(&id)?;
+    if kind == "note" {
+        let path = match crate::vault::find_note(&id)? {
+            Some(p) => p,
+            None => recording_dir(&id)?.join("ari-note.md"),
+        };
+        if !path.exists() {
+            return Err(format!("recording file not found: {}", path.display()));
+        }
+        return app
+            .opener()
+            .open_path(path.to_string_lossy().into_owned(), None::<&str>)
+            .map_err(|e| e.to_string());
+    }
 
     let filename = note_or_transcript_filename(&kind)?;
     let path = recording_dir(&id)?.join(filename);
@@ -1267,6 +1295,77 @@ mod tests {
         let id = "2026-06-02T14-30-05Z";
         let dir = recording_dir(id).unwrap();
         assert_eq!(dir, crate::storage::recordings_dir(tmp.path()).join(id));
+        unsafe { std::env::remove_var("ARISO_ROOT"); }
+    }
+
+    #[test]
+    fn read_recording_file_note_prefers_vault_body() {
+        let tmp = tempfile::tempdir().unwrap();
+        // SAFETY: env mutation requires `--test-threads=1` so no concurrent
+        // env access races with these calls (same convention as transcribe).
+        unsafe { std::env::set_var("ARISO_ROOT", tmp.path()); }
+        let root = tmp.path();
+        let id = "2026-06-02T10-00-00Z";
+        let dir = crate::storage::create_recording_dir(root, id).unwrap();
+        let mut meta = test_meta(id);
+        meta.audio_file = Some("clip.mp3".into());
+        crate::storage::write_meta(&dir, &meta).unwrap();
+        crate::vault::write_note("2026-06-02 clip", &meta, "clip.mp3", "vault body").unwrap();
+
+        assert_eq!(
+            read_recording_file(id.into(), "note".into())
+                .unwrap()
+                .as_deref(),
+            Some("vault body")
+        );
+        // Transcript still reads ~/.ariso.
+        std::fs::write(dir.join("transcript.md"), b"tscript").unwrap();
+        assert_eq!(
+            read_recording_file(id.into(), "transcript".into())
+                .unwrap()
+                .as_deref(),
+            Some("tscript")
+        );
+        unsafe { std::env::remove_var("ARISO_ROOT"); }
+    }
+
+    #[test]
+    fn read_recording_file_note_falls_back_to_legacy_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        // SAFETY: env mutation requires `--test-threads=1` so no concurrent
+        // env access races with these calls (same convention as transcribe).
+        unsafe { std::env::set_var("ARISO_ROOT", tmp.path()); }
+        let root = tmp.path();
+        let id = "2026-06-02T11-00-00Z";
+        let dir = crate::storage::create_recording_dir(root, id).unwrap();
+        let meta = test_meta(id);
+        crate::storage::write_meta(&dir, &meta).unwrap();
+        // No vault note written; only the legacy on-disk file exists.
+        std::fs::write(dir.join("ari-note.md"), b"legacy note").unwrap();
+
+        assert_eq!(
+            read_recording_file(id.into(), "note".into())
+                .unwrap()
+                .as_deref(),
+            Some("legacy note")
+        );
+        unsafe { std::env::remove_var("ARISO_ROOT"); }
+    }
+
+    #[test]
+    fn read_recording_file_note_missing_returns_none() {
+        let tmp = tempfile::tempdir().unwrap();
+        // SAFETY: env mutation requires `--test-threads=1` so no concurrent
+        // env access races with these calls (same convention as transcribe).
+        unsafe { std::env::set_var("ARISO_ROOT", tmp.path()); }
+        let root = tmp.path();
+        let id = "2026-06-02T12-00-00Z";
+        let dir = crate::storage::create_recording_dir(root, id).unwrap();
+        let meta = test_meta(id);
+        crate::storage::write_meta(&dir, &meta).unwrap();
+        // Neither a vault note nor a legacy file exists yet.
+
+        assert_eq!(read_recording_file(id.into(), "note".into()).unwrap(), None);
         unsafe { std::env::remove_var("ARISO_ROOT"); }
     }
 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1270,6 +1270,8 @@ mod tests {
             error: None,
             notes_error: None,
             last_clip_end_at: None,
+            audio_file: None,
+            notes_written: None,
         }
     }
 
@@ -1471,6 +1473,8 @@ mod tests {
             error: None,
             notes_error: None,
             last_clip_end_at: None,
+            audio_file: None,
+            notes_written: None,
         };
         crate::storage::write_meta(&dir, &meta).unwrap();
         std::fs::write(dir.join("transcript.md"), b"t").unwrap();

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -16,6 +16,7 @@ mod recording_state;
 mod tray;
 mod tray_meeting;
 mod update_manager;
+mod vault;
 
 /// Build the macOS application menu. Mirrors Tauri's default menu (so the
 /// standard Edit/Window/View items and their shortcuts still work) but injects

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -179,6 +179,14 @@ fn main() {
         .setup(|app| {
             use tauri::{Manager, WebviewWindowBuilder, WebviewUrl};
 
+            // Best-effort: create ~/.ariso/vault (+ Attachments/, .obsidian/app.json)
+            // up front so a user can open it in Obsidian before the first
+            // recording. Write paths also call ensure_vault lazily, so a
+            // failure here only logs — it must not block startup.
+            if let Err(e) = crate::vault::ensure_vault() {
+                eprintln!("ensure vault: {e}");
+            }
+
             // Managed state must exist before the tray is created: tray menu
             // rebuilds and the title refresher read RecordingState and
             // FeaturedMeetingState.

--- a/src-tauri/src/storage.rs
+++ b/src-tauri/src/storage.rs
@@ -98,6 +98,16 @@ pub struct RecordingMeta {
     /// which lags behind reality when clips have inter-clip gaps.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub last_clip_end_at: Option<String>,
+    /// Basename of this recording's audio attachment in the vault
+    /// (`<vault>/Attachments/<audio_file>`). `None` for legacy recordings, whose
+    /// audio still lives at `~/.ariso/recordings/<id>/recording.mp3`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub audio_file: Option<String>,
+    /// RFC3339 time oats last wrote this recording's note into the vault. `None`
+    /// means never generated. Recorded for future use (status refinement / an
+    /// auto-regeneration guard); v1 does not branch on it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub notes_written: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -635,7 +645,7 @@ mod tests {
             id: id.into(), title: format!("T {id}"), created_at: created.into(),
             duration_seconds: 1, status: RecordingStatus::Done, language: None,
             participants: vec![], model_version: None, error: None, notes_error: None,
-            last_clip_end_at: None,
+            last_clip_end_at: None, audio_file: None, notes_written: None,
         }
     }
 
@@ -796,6 +806,8 @@ mod tests {
             error: None,
             notes_error: None,
             last_clip_end_at: None,
+            audio_file: None,
+            notes_written: None,
         };
         let segments = vec![
             Segment { speaker: 0, text: "Hello there".into(), start: 3.0, end: 9.0 },
@@ -816,7 +828,7 @@ mod tests {
             id: "x".into(), title: "t".into(), created_at: "c".into(),
             duration_seconds: 0, status: RecordingStatus::Done, language: None,
             participants: vec![], model_version: None, error: None, notes_error: None,
-            last_clip_end_at: None,
+            last_clip_end_at: None, audio_file: None, notes_written: None,
         };
         let segments = vec![Segment { speaker: 5, text: "hi".into(), start: 0.0, end: 1.0 }];
         let md = render_markdown(&meta, &segments);
@@ -995,6 +1007,8 @@ mod tests {
             error: None,
             notes_error: None,
             last_clip_end_at: None,
+            audio_file: None,
+            notes_written: None,
         };
         write_meta(&dir, &meta).unwrap();
         let read = read_meta(&dir).unwrap();

--- a/src-tauri/src/storage.rs
+++ b/src-tauri/src/storage.rs
@@ -120,12 +120,23 @@ pub struct RecordingSummary {
     pub status: RecordingStatus,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub last_clip_end_at: Option<String>,
-    /// Whether `recording.mp3` exists in the recording's directory.
+    /// Whether this recording's audio exists: for vault recordings, the vault
+    /// attachment named by `meta.audio_file`; for legacy recordings, whether
+    /// `recording.mp3` exists in the recording's directory. This layer sets
+    /// an optimistic value from `meta.audio_file.is_some()` alone (it is
+    /// vault-agnostic); the command layer overlays the real vault check.
     pub has_audio: bool,
-    /// Whether `ari-note.md` exists in the recording's directory.
+    /// Whether the recording has a note. This layer only checks the legacy
+    /// `ari-note.md` file; the command layer overlays real vault note
+    /// presence (a new recording's note lives only in the vault).
     pub has_note: bool,
     /// Whether `transcript.md` exists in the recording's directory.
     pub has_transcript: bool,
+    /// The recording's vault audio attachment name (from meta), used by the
+    /// command layer to verify the attachment still exists. Not serialized to
+    /// the frontend.
+    #[serde(skip)]
+    pub audio_file: Option<String>,
 }
 
 /// Lightweight per-recording status for the detail panel's generation poller.
@@ -517,6 +528,7 @@ pub fn list_recordings(root: &Path) -> Result<Vec<RecordingSummary>, String> {
                         || recording_dir.join("recording.mp3").is_file(),
                     has_note: recording_dir.join("ari-note.md").is_file(),
                     has_transcript: recording_dir.join("transcript.md").is_file(),
+                    audio_file: m.audio_file.clone(),
                 });
             }
             Err(_) => continue,

--- a/src-tauri/src/storage.rs
+++ b/src-tauri/src/storage.rs
@@ -513,7 +513,8 @@ pub fn list_recordings(root: &Path) -> Result<Vec<RecordingSummary>, String> {
                     duration_seconds: m.duration_seconds,
                     status: m.status,
                     last_clip_end_at: m.last_clip_end_at,
-                    has_audio: recording_dir.join("recording.mp3").is_file(),
+                    has_audio: m.audio_file.is_some()
+                        || recording_dir.join("recording.mp3").is_file(),
                     has_note: recording_dir.join("ari-note.md").is_file(),
                     has_transcript: recording_dir.join("transcript.md").is_file(),
                 });
@@ -705,6 +706,19 @@ mod tests {
         assert!(!list[1].has_audio);
         assert!(!list[1].has_note);
         assert!(!list[1].has_transcript);
+    }
+
+    #[test]
+    fn list_has_audio_true_when_audio_file_set() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        let id = "2026-06-02T10-00-00Z";
+        let dir = create_recording_dir(root, id).unwrap();
+        let mut m = meta_with(id, "2026-06-02T10:00:00Z");
+        m.audio_file = Some("clip.mp3".into()); // audio lives in the vault, not here
+        write_meta(&dir, &m).unwrap();
+        let list = list_recordings(root).unwrap();
+        assert!(list[0].has_audio, "audio_file set ⇒ has_audio");
     }
 
     #[test]

--- a/src-tauri/src/transcribe.rs
+++ b/src-tauri/src/transcribe.rs
@@ -124,11 +124,16 @@ fn transcript_changed(before: &Option<Vec<u8>>, after: &Option<Vec<u8>>) -> bool
     before != after
 }
 
-/// Best-effort notes generation: runs the sidecar and writes either
-/// `ari-note.md` or `meta.notes_error`. Failures here never affect the
-/// recording's `Done` status. A third outcome exists: if the transcript
-/// changes mid-run (superseded by a later append/regeneration), this writes
-/// neither file and silently discards its result.
+/// Current instant as an RFC3339 string.
+fn now_rfc3339() -> String {
+    chrono::Utc::now().to_rfc3339()
+}
+
+/// Best-effort notes generation: runs the sidecar and writes either the vault
+/// note or `meta.notes_error`. Failures here never affect the recording's
+/// `Done` status. A third outcome exists: if the transcript changes mid-run
+/// (superseded by a later append/regeneration), this writes neither file and
+/// silently discards its result.
 async fn process_notes(dir: PathBuf, models: PathBuf, mut meta: RecordingMeta) {
     let transcript_path = dir.join("transcript.md");
     // Capture the transcript this run generates from; if it changes while notes
@@ -139,19 +144,37 @@ async fn process_notes(dir: PathBuf, models: PathBuf, mut meta: RecordingMeta) {
         return;
     }
     match outcome {
-        // Empty output is a silent failure: it would write a blank
-        // ari-note.md with notes_error unset, reading as success. Record it.
+        // Empty output is a silent failure: it would write a blank note with
+        // notes_error unset, reading as success. Record it.
         Ok(notes) if notes.trim().is_empty() => {
             eprintln!("notes generation: empty output");
             meta.notes_error = Some("notes generation produced empty output".to_string());
             let _ = storage::write_meta(&dir, &meta);
         }
         Ok(notes) => {
-            if let Err(e) = storage::write_notes(&dir, &notes) {
-                eprintln!("write notes: {e}");
+            let audio_file = match &meta.audio_file {
+                Some(a) => a.clone(),
+                // Legacy recording with no vault audio: keep the old location so
+                // its note stays alongside its audio.
+                None => {
+                    if let Err(e) = storage::write_notes(&dir, &notes) {
+                        eprintln!("write notes: {e}");
+                        meta.notes_error = Some(e);
+                        let _ = storage::write_meta(&dir, &meta);
+                    }
+                    return;
+                }
+            };
+            let basename = audio_file.strip_suffix(".mp3").unwrap_or(audio_file.as_str());
+            if let Err(e) = crate::vault::write_note(basename, &meta, &audio_file, &notes) {
+                eprintln!("write vault note: {e}");
                 meta.notes_error = Some(e);
                 let _ = storage::write_meta(&dir, &meta);
+                return;
             }
+            meta.notes_error = None;
+            meta.notes_written = Some(now_rfc3339());
+            let _ = storage::write_meta(&dir, &meta);
         }
         Err(e) => {
             eprintln!("notes generation: {e}");
@@ -692,7 +715,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn finalize_writes_ari_note_md_when_notes_succeed() {
+    async fn finalize_writes_vault_note_when_notes_succeed() {
         let tmp = tempfile::tempdir().unwrap();
         let json = r#"{"language":"en","durationSeconds":12.0,"participants":[{"id":0,"label":"Speaker 1"}],"segments":[{"speaker":0,"text":"hi","start":0.0,"end":1.0}]}"#;
         // Stub: `notes` subcommand prints markdown; otherwise print transcript JSON.
@@ -709,13 +732,46 @@ mod tests {
         ).await.unwrap();
         notes_handle.await.unwrap();
         unsafe { std::env::remove_var("ARISO_STT_BIN"); }
-        unsafe { std::env::remove_var("ARISO_ROOT"); }
 
         assert_eq!(res.status, RecordingStatus::Done);
         let dir = crate::storage::recordings_dir(tmp.path()).join(&res.id);
-        let notes = std::fs::read_to_string(dir.join("ari-note.md")).unwrap();
-        assert!(notes.contains("# Notes"), "got: {notes}");
-        assert!(crate::storage::read_meta(&dir).unwrap().notes_error.is_none());
+        // Note lands in the vault (resolvable by oats_id), not ~/.ariso.
+        let notes = crate::vault::read_note(&res.id).unwrap();
+        assert!(notes.as_deref().unwrap_or("").contains("# Notes"), "got: {notes:?}");
+        assert!(!dir.join("ari-note.md").exists());
+        let meta = crate::storage::read_meta(&dir).unwrap();
+        assert!(meta.notes_error.is_none());
+        assert!(meta.notes_written.is_some());
+        unsafe { std::env::remove_var("ARISO_ROOT"); }
+    }
+
+    #[tokio::test]
+    async fn finalize_writes_vault_note_not_ari_note_md() {
+        let tmp = tempfile::tempdir().unwrap();
+        let json = r#"{"language":"en","durationSeconds":12.0,"participants":[{"id":0,"label":"Speaker 1"}],"segments":[{"speaker":0,"text":"hi","start":0.0,"end":1.0}]}"#;
+        let body = format!(
+            "if [ \"$1\" = notes ]; then echo '# Vault note'; exit 0; fi\ncat <<'EOF'\n{json}\nEOF"
+        );
+        let stub = write_stub(tmp.path(), &body);
+        unsafe { std::env::set_var("ARISO_STT_BIN", &stub); }
+        unsafe { std::env::set_var("ARISO_ROOT", tmp.path()); }
+
+        let (res, notes_handle) = finalize_core(
+            tmp.path(), b"audio".to_vec(),
+            "T".into(), "2026-06-02T10:00:00Z".into(), 1,
+        ).await.unwrap();
+        notes_handle.await.unwrap();
+        unsafe { std::env::remove_var("ARISO_STT_BIN"); }
+
+        // Note is in the vault, resolvable by oats_id; NOT in ~/.ariso.
+        let id = storage::sanitize_iso_to_id("2026-06-02T10:00:00Z");
+        assert_eq!(crate::vault::read_note(&id).unwrap().as_deref(), Some("# Vault note"));
+        let dir = storage::recordings_dir(tmp.path()).join(&id);
+        assert!(!dir.join("ari-note.md").exists());
+        // notes_written stamped.
+        assert!(storage::read_meta(&dir).unwrap().notes_written.is_some());
+        assert_eq!(res.id, id);
+        unsafe { std::env::remove_var("ARISO_ROOT"); }
     }
 
     #[tokio::test]
@@ -736,15 +792,16 @@ mod tests {
         ).await.unwrap();
         notes_handle.await.unwrap();
         unsafe { std::env::remove_var("ARISO_STT_BIN"); }
-        unsafe { std::env::remove_var("ARISO_ROOT"); }
 
         assert_eq!(res.status, RecordingStatus::Done);
         let dir = crate::storage::recordings_dir(tmp.path()).join(&res.id);
         assert!(dir.join("transcript.md").exists());
         assert!(!dir.join("ari-note.md").exists());
+        assert!(crate::vault::read_note(&res.id).unwrap().is_none(), "no vault note on notes failure");
         let meta = crate::storage::read_meta(&dir).unwrap();
         assert_eq!(meta.status, RecordingStatus::Done);
         assert!(meta.notes_error.is_some());
+        unsafe { std::env::remove_var("ARISO_ROOT"); }
     }
 
     #[tokio::test]

--- a/src-tauri/src/transcribe.rs
+++ b/src-tauri/src/transcribe.rs
@@ -384,7 +384,7 @@ async fn append_recording_core(
     // most_recent_appendable check. Fall back to a fresh recording if the
     // target's state is no longer suitable for an append.
     let (mut meta, mut existing) = match (storage::read_meta(&dir), storage::read_segments(&dir)) {
-        (Ok(m), Ok(Some(s))) if m.status == storage::RecordingStatus::Done => (m, s),
+        (Ok(m), Ok(Some(s))) if m.status == storage::RecordingStatus::Done && m.audio_file.is_some() => (m, s),
         _ => return fresh_recording_core(root, audio, title, created_at, duration_seconds).await,
     };
 

--- a/src-tauri/src/transcribe.rs
+++ b/src-tauri/src/transcribe.rs
@@ -496,13 +496,15 @@ pub async fn retry_transcription_core(
 }
 
 /// Regenerate AI notes for a recording from its existing `transcript.md`,
-/// without re-running STT. Clears any prior `notes_error` and removes any
-/// existing `ari-note.md` first — readiness is signaled by that file's
+/// without re-running STT. Clears any prior `notes_error`/`notes_written` and
+/// removes the existing note first — readiness is signaled by a note's
 /// presence, so leaving a stale note in place would make the poller report the
 /// recording as "ready" the instant polling resumes, finishing the regeneration
-/// silently in the background. Removing it makes the regeneration observable
-/// (`hasNote` false → generating → true when the new note lands). Then spawns
-/// `process_notes` detached (it writes `ari-note.md` or a fresh `notes_error`).
+/// silently in the background. Removes the vault note (new recordings, note-only
+/// — the audio attachment is preserved) and any legacy `~/.ariso/ari-note.md`
+/// (pre-feature recordings), making the regeneration observable (`hasNote`
+/// false → generating → true when the new note lands). Then spawns
+/// `process_notes` detached (it writes a fresh note or a fresh `notes_error`).
 /// Returns the handle so tests can await completion; the command drops it.
 ///
 /// Trade-off: a failed regeneration leaves the recording note-less (surfaced as
@@ -515,9 +517,11 @@ pub async fn retry_notes_core(root: &Path, id: &str) -> Result<JoinHandle<()>, S
     }
     let mut meta = storage::read_meta(&dir)?;
     meta.notes_error = None;
+    meta.notes_written = None;
     storage::write_meta(&dir, &meta)?;
-    // Clear the stale note so regeneration is observable (see doc comment).
-    // A missing file is fine — only surface real removal errors.
+    // Clear the stale note so regeneration is observable. Remove the vault note
+    // (new recordings) and any legacy `~/.ariso/ari-note.md` (pre-feature ones).
+    crate::vault::delete_recording_artifacts(id, None)?;
     match std::fs::remove_file(dir.join("ari-note.md")) {
         Ok(()) => {}
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
@@ -873,6 +877,9 @@ mod tests {
     async fn retry_notes_regenerates_from_existing_transcript() {
         let tmp = tempfile::tempdir().unwrap();
         let root = tmp.path();
+        // Isolate the vault lookup `retry_notes_core` now performs so it can't
+        // touch the real ~/.ariso.
+        unsafe { std::env::set_var("ARISO_ROOT", root); }
         let id = "2026-06-02T14-30-05Z";
         let dir = storage::create_recording_dir(root, id).unwrap();
         std::fs::write(dir.join("transcript.md"), b"# Transcript\nhi").unwrap();
@@ -894,9 +901,11 @@ mod tests {
         handle.await.unwrap();
         unsafe { std::env::remove_var("ARISO_STT_BIN"); }
 
+        // Legacy recording (no audio_file): the note still lands in ari-note.md.
         let notes = std::fs::read_to_string(dir.join("ari-note.md")).unwrap();
         assert!(notes.contains("# Notes"), "got: {notes}");
         assert!(read_meta(&dir).unwrap().notes_error.is_none(), "notes_error must be cleared");
+        unsafe { std::env::remove_var("ARISO_ROOT"); }
     }
 
     #[tokio::test]
@@ -907,6 +916,9 @@ mod tests {
         // the regeneration would finish in the background, never surfacing.
         let tmp = tempfile::tempdir().unwrap();
         let root = tmp.path();
+        // Isolate the vault lookup `retry_notes_core` now performs so it can't
+        // touch the real ~/.ariso.
+        unsafe { std::env::set_var("ARISO_ROOT", root); }
         let id = "2026-06-02T14-30-05Z";
         let dir = storage::create_recording_dir(root, id).unwrap();
         std::fs::write(dir.join("transcript.md"), b"# Transcript\nhi").unwrap();
@@ -935,6 +947,83 @@ mod tests {
             "stale note must be removed so regeneration is observable"
         );
         assert!(read_meta(&dir).unwrap().notes_error.is_some());
+        unsafe { std::env::remove_var("ARISO_ROOT"); }
+    }
+
+    #[tokio::test]
+    async fn retry_notes_replaces_vault_note() {
+        // For a vault-backed recording (has `meta.audio_file`), regeneration must
+        // remove the *vault* note, not just the legacy `ari-note.md`, so
+        // `process_notes` observably writes a fresh vault note rather than
+        // silently leaving the stale one in place.
+        let tmp = tempfile::tempdir().unwrap();
+        unsafe { std::env::set_var("ARISO_ROOT", tmp.path()); }
+        let root = tmp.path().to_path_buf();
+
+        let json = r#"{"language":"en","durationSeconds":1.0,"participants":[{"id":0,"label":"Speaker 1"}],"segments":[{"speaker":0,"text":"hi","start":0.0,"end":1.0}]}"#;
+        let body = format!("if [ \"$1\" = notes ]; then echo '# first'; exit 0; fi\ncat <<'EOF'\n{json}\nEOF");
+        let stub = write_stub(&root, &body);
+        unsafe { std::env::set_var("ARISO_STT_BIN", &stub); }
+
+        let (res, h) = finalize_core(
+            &root, b"a".to_vec(), "N".into(), "2026-06-02T10:00:00Z".into(), 1,
+        ).await.unwrap();
+        h.await.unwrap();
+        unsafe { std::env::remove_var("ARISO_STT_BIN"); }
+        assert_eq!(crate::vault::read_note(&res.id).unwrap().as_deref(), Some("# first"));
+
+        // Sidecar now emits new notes: re-stub and re-set ARISO_STT_BIN so
+        // regeneration sees different output the second time.
+        let body2 = format!("if [ \"$1\" = notes ]; then echo '# second'; exit 0; fi\ncat <<'EOF'\n{json}\nEOF");
+        let stub2 = write_stub(&root, &body2);
+        unsafe { std::env::set_var("ARISO_STT_BIN", &stub2); }
+
+        let h2 = retry_notes_core(&root, &res.id).await.unwrap();
+        h2.await.unwrap();
+        unsafe { std::env::remove_var("ARISO_STT_BIN"); }
+
+        assert_eq!(crate::vault::read_note(&res.id).unwrap().as_deref(), Some("# second"));
+        unsafe { std::env::remove_var("ARISO_ROOT"); }
+    }
+
+    #[tokio::test]
+    async fn retry_notes_failure_leaves_vault_note_removed() {
+        // Mirrors `retry_notes_removes_stale_note_so_regeneration_is_observable`
+        // but for a vault-backed recording: a *failed* regeneration must not
+        // leave the old vault note in place (which `write_note`'s in-place
+        // overwrite on success would otherwise mask) — the poller's readiness
+        // signal is the vault note's presence.
+        let tmp = tempfile::tempdir().unwrap();
+        unsafe { std::env::set_var("ARISO_ROOT", tmp.path()); }
+        let root = tmp.path().to_path_buf();
+
+        let json = r#"{"language":"en","durationSeconds":1.0,"participants":[{"id":0,"label":"Speaker 1"}],"segments":[{"speaker":0,"text":"hi","start":0.0,"end":1.0}]}"#;
+        let body = format!("if [ \"$1\" = notes ]; then echo '# first'; exit 0; fi\ncat <<'EOF'\n{json}\nEOF");
+        let stub = write_stub(&root, &body);
+        unsafe { std::env::set_var("ARISO_STT_BIN", &stub); }
+
+        let (res, h) = finalize_core(
+            &root, b"a".to_vec(), "N".into(), "2026-06-02T10:00:00Z".into(), 1,
+        ).await.unwrap();
+        h.await.unwrap();
+        unsafe { std::env::remove_var("ARISO_STT_BIN"); }
+        assert_eq!(crate::vault::read_note(&res.id).unwrap().as_deref(), Some("# first"));
+
+        // Regeneration now fails outright.
+        let fail_stub = write_stub(&root, "if [ \"$1\" = notes ]; then echo 'boom' >&2; exit 1; fi\nexit 1");
+        unsafe { std::env::set_var("ARISO_STT_BIN", &fail_stub); }
+
+        let h2 = retry_notes_core(&root, &res.id).await.unwrap();
+        h2.await.unwrap();
+        unsafe { std::env::remove_var("ARISO_STT_BIN"); }
+
+        assert!(
+            crate::vault::read_note(&res.id).unwrap().is_none(),
+            "stale vault note must be removed so a failed regeneration is observable"
+        );
+        let dir = storage::recordings_dir(&root).join(&res.id);
+        assert!(storage::read_meta(&dir).unwrap().notes_error.is_some());
+        unsafe { std::env::remove_var("ARISO_ROOT"); }
     }
 
     // Helper: a stub that prints notes for `notes`, else a single-segment JSON

--- a/src-tauri/src/transcribe.rs
+++ b/src-tauri/src/transcribe.rs
@@ -212,6 +212,8 @@ async fn fresh_recording_core(
         error: None,
         notes_error: None,
         last_clip_end_at: None,
+        audio_file: None,
+        notes_written: None,
     };
     storage::write_meta(&dir, &meta)?;
 
@@ -285,6 +287,8 @@ fn save_failed_clip(
                 error: Some(err.to_string()),
                 notes_error: None,
                 last_clip_end_at: None,
+                audio_file: None,
+                notes_written: None,
             };
             let _ = storage::write_meta(&dir, &meta);
         }
@@ -700,6 +704,8 @@ mod tests {
             error: Some("old failure".into()),
             notes_error: None,
             last_clip_end_at: None,
+            audio_file: None,
+            notes_written: None,
         };
         storage::write_meta(&dir, &meta).unwrap();
 
@@ -733,7 +739,7 @@ mod tests {
             id: id.into(), title: "T".into(), created_at: "2026-06-02T14:30:05Z".into(),
             duration_seconds: 5, status: RecordingStatus::Failed, language: None,
             participants: vec![], model_version: None, error: None, notes_error: None,
-            last_clip_end_at: None,
+            last_clip_end_at: None, audio_file: None, notes_written: None,
         };
         storage::write_meta(&dir, &meta).unwrap();
 
@@ -753,7 +759,7 @@ mod tests {
             duration_seconds: 5, status: RecordingStatus::Done, language: None,
             participants: vec![], model_version: None, error: None,
             notes_error: Some("prior notes failure".into()),
-            last_clip_end_at: None,
+            last_clip_end_at: None, audio_file: None, notes_written: None,
         };
         storage::write_meta(&dir, &meta).unwrap();
 
@@ -787,7 +793,7 @@ mod tests {
             id: id.into(), title: "T".into(), created_at: "2026-06-02T14:30:05Z".into(),
             duration_seconds: 5, status: RecordingStatus::Done, language: None,
             participants: vec![], model_version: None, error: None, notes_error: None,
-            last_clip_end_at: None,
+            last_clip_end_at: None, audio_file: None, notes_written: None,
         };
         storage::write_meta(&dir, &meta).unwrap();
 
@@ -996,7 +1002,7 @@ mod tests {
             id: id.into(), title: "T".into(), created_at: "2026-06-02T14:30:05Z".into(),
             duration_seconds: 5, status: RecordingStatus::Done, language: None,
             participants: vec![], model_version: None, error: None, notes_error: None,
-            last_clip_end_at: None,
+            last_clip_end_at: None, audio_file: None, notes_written: None,
         };
         storage::write_meta(&dir, &meta).unwrap();
 
@@ -1022,7 +1028,7 @@ mod tests {
             id: id.into(), title: "T".into(), created_at: "2026-06-02T10:00:00Z".into(),
             duration_seconds: 5, status: RecordingStatus::Done, language: None,
             participants: vec![], model_version: None, error: None, notes_error: None,
-            last_clip_end_at: None,
+            last_clip_end_at: None, audio_file: None, notes_written: None,
         };
         storage::write_meta(&dir, &meta).unwrap();
 

--- a/src-tauri/src/transcribe.rs
+++ b/src-tauri/src/transcribe.rs
@@ -197,8 +197,23 @@ async fn fresh_recording_core(
     let id = storage::sanitize_iso_to_id(&created_at);
     let dir = storage::create_recording_dir(root, &id)?;
 
-    // Persist the audio first so it is never lost, even if STT fails.
-    std::fs::write(dir.join("recording.mp3"), &audio).map_err(|e| format!("write audio: {e}"))?;
+    // Persist the audio into the vault first so it is never lost, even if STT
+    // fails. The attachment is this recording's only audio home. On an in-place
+    // rewrite (a retry re-runs this for the same dir), reuse the existing
+    // attachment rather than deriving a fresh unique name — otherwise every
+    // retry would orphan the prior file and repoint an existing note's embed at
+    // a duplicate.
+    let audio_file = match storage::read_meta(&dir).ok().and_then(|m| m.audio_file) {
+        Some(existing) => existing, // in-place rewrite (retry): keep the same attachment
+        None => format!(
+            "{}.mp3",
+            crate::vault::unique_basename(
+                &crate::vault::ensure_vault()?,
+                &crate::vault::note_basename(&created_at, &title, &id),
+            )
+        ),
+    };
+    crate::vault::write_audio(&audio_file, &audio)?;
 
     let mut meta = RecordingMeta {
         id: id.clone(),
@@ -212,13 +227,13 @@ async fn fresh_recording_core(
         error: None,
         notes_error: None,
         last_clip_end_at: None,
-        audio_file: None,
+        audio_file: Some(audio_file.clone()),
         notes_written: None,
     };
     storage::write_meta(&dir, &meta)?;
 
     let models = storage::models_dir(root);
-    let audio_path = dir.join("recording.mp3");
+    let audio_path = crate::vault::audio_path(&crate::vault::vault_root()?, &audio_file);
     match run_transcribe(&audio_path, &models).await {
         Ok(result) => {
             meta.language = Some(result.language.clone());
@@ -272,7 +287,20 @@ fn save_failed_clip(
     let id = storage::sanitize_iso_to_id(created_at);
     match storage::create_recording_dir(root, &id) {
         Ok(dir) => {
-            if let Err(e) = std::fs::write(dir.join("recording.mp3"), audio) {
+            let audio_file = format!(
+                "{}.mp3",
+                match crate::vault::ensure_vault() {
+                    Ok(root) => crate::vault::unique_basename(
+                        &root,
+                        &crate::vault::note_basename(created_at, title, &id),
+                    ),
+                    Err(e) => {
+                        eprintln!("save failed clip: ensure vault: {e}");
+                        return;
+                    }
+                }
+            );
+            if let Err(e) = crate::vault::write_audio(&audio_file, audio) {
                 eprintln!("save failed clip audio: {e}");
             }
             let meta = RecordingMeta {
@@ -287,7 +315,7 @@ fn save_failed_clip(
                 error: Some(err.to_string()),
                 notes_error: None,
                 last_clip_end_at: None,
-                audio_file: None,
+                audio_file: Some(audio_file.clone()),
                 notes_written: None,
             };
             let _ = storage::write_meta(&dir, &meta);
@@ -383,10 +411,15 @@ async fn append_recording_core(
     meta.last_clip_end_at = storage::clip_end_timestamp(&created_at, duration_seconds);
 
     // Content writes, in crash-safe order: audio, then structured segments,
-    // then the rendered transcript.
-    let mut combined = std::fs::read(dir.join("recording.mp3")).map_err(|e| format!("read audio: {e}"))?;
+    // then the rendered transcript. The audio lives only in the vault
+    // attachment; read it, concatenate the clip, and write it back.
+    let audio_file = meta
+        .audio_file
+        .clone()
+        .ok_or_else(|| "append target has no vault audio (legacy recording)".to_string())?;
+    let mut combined = crate::vault::read_audio(&audio_file)?;
     combined.extend_from_slice(&audio);
-    storage::write_atomic(&dir.join("recording.mp3"), &combined)?;
+    crate::vault::write_audio(&audio_file, &combined)?;
     storage::write_segments(&dir, &existing)?;
     let md = storage::render_markdown(&meta, &existing.segments);
     storage::write_transcript(&dir, &md)?;
@@ -429,8 +462,13 @@ pub async fn retry_transcription_core(
             meta.id
         ));
     }
-    let audio = std::fs::read(dir.join("recording.mp3"))
-        .map_err(|e| format!("read recording audio: {e}"))?;
+    // Prefer the vault attachment; fall back to legacy `~/.ariso` audio so old
+    // recordings (pre-vault) can still be retried.
+    let audio = match &meta.audio_file {
+        Some(audio_file) => crate::vault::read_audio(audio_file)?,
+        None => std::fs::read(dir.join("recording.mp3"))
+            .map_err(|e| format!("read recording audio: {e}"))?,
+    };
     finalize_core(root, audio, meta.title, meta.created_at, meta.duration_seconds).await
 }
 
@@ -573,6 +611,9 @@ mod tests {
             format!("if [ \"$1\" = notes ]; then echo '# Notes'; exit 0; fi\ncat <<'EOF'\n{json}\nEOF");
         let stub = write_stub(tmp.path(), &body);
         unsafe { std::env::set_var("ARISO_STT_BIN", &stub); }
+        // Vault resolves via ARISO_ROOT; point it at the same tempdir as `root`
+        // so audio writes stay inside this test's sandbox.
+        unsafe { std::env::set_var("ARISO_ROOT", tmp.path()); }
 
         let (res, notes_handle) = finalize_core(
             tmp.path(), b"audio".to_vec(),
@@ -586,9 +627,16 @@ mod tests {
         assert_eq!(res.status, RecordingStatus::Done);
         assert_eq!(res.id, "2026-06-02T14-30-05Z");
         let dir = crate::storage::recordings_dir(tmp.path()).join(&res.id);
-        assert!(dir.join("recording.mp3").exists());
+        let meta = read_meta(&dir).unwrap();
+        assert_eq!(
+            crate::vault::read_audio(meta.audio_file.as_ref().unwrap()).unwrap(),
+            b"audio",
+            "audio must live in the vault attachment"
+        );
+        assert!(!dir.join("recording.mp3").exists(), "no ~/.ariso audio copy");
         assert!(dir.join("transcript.md").exists());
-        assert_eq!(read_meta(&dir).unwrap().status, RecordingStatus::Done);
+        assert_eq!(meta.status, RecordingStatus::Done);
+        unsafe { std::env::remove_var("ARISO_ROOT"); }
     }
 
     #[tokio::test]
@@ -598,6 +646,7 @@ mod tests {
         let body = format!("if [ \"$1\" = notes ]; then echo '# Notes'; exit 0; fi\ncat <<'EOF'\n{json}\nEOF");
         let stub = write_stub(tmp.path(), &body);
         unsafe { std::env::set_var("ARISO_STT_BIN", &stub); }
+        unsafe { std::env::set_var("ARISO_ROOT", tmp.path()); }
 
         let (res, notes_handle) = finalize_core(
             tmp.path(), b"audio".to_vec(),
@@ -605,6 +654,7 @@ mod tests {
         ).await.unwrap();
         notes_handle.await.unwrap();
         unsafe { std::env::remove_var("ARISO_STT_BIN"); }
+        unsafe { std::env::remove_var("ARISO_ROOT"); }
 
         let dir = crate::storage::recordings_dir(tmp.path()).join(&res.id);
         let seg = crate::storage::read_segments(&dir).unwrap().expect("segments.json written");
@@ -617,6 +667,7 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let stub = write_stub(tmp.path(), "echo 'boom' >&2\nexit 1");
         unsafe { std::env::set_var("ARISO_STT_BIN", &stub); }
+        unsafe { std::env::set_var("ARISO_ROOT", tmp.path()); }
 
         let err = finalize_core(
             tmp.path(), b"audio".to_vec(),
@@ -626,10 +677,18 @@ mod tests {
 
         assert!(err.contains("boom"), "got: {err}");
         let dir = crate::storage::recordings_dir(tmp.path()).join("2026-06-02T14-30-05Z");
-        assert!(dir.join("recording.mp3").exists(), "audio must be retained");
+        // STT fails *after* the vault write, so the attachment is retained even
+        // though no ~/.ariso copy exists.
         let meta = read_meta(&dir).unwrap();
+        assert_eq!(
+            crate::vault::read_audio(meta.audio_file.as_ref().unwrap()).unwrap(),
+            b"audio",
+            "audio must be retained in the vault"
+        );
+        assert!(!dir.join("recording.mp3").exists());
         assert_eq!(meta.status, RecordingStatus::Failed);
         assert!(meta.error.is_some());
+        unsafe { std::env::remove_var("ARISO_ROOT"); }
     }
 
     #[tokio::test]
@@ -642,6 +701,7 @@ mod tests {
         );
         let stub = write_stub(tmp.path(), &body);
         unsafe { std::env::set_var("ARISO_STT_BIN", &stub); }
+        unsafe { std::env::set_var("ARISO_ROOT", tmp.path()); }
 
         let (res, notes_handle) = finalize_core(
             tmp.path(), b"audio".to_vec(),
@@ -649,6 +709,7 @@ mod tests {
         ).await.unwrap();
         notes_handle.await.unwrap();
         unsafe { std::env::remove_var("ARISO_STT_BIN"); }
+        unsafe { std::env::remove_var("ARISO_ROOT"); }
 
         assert_eq!(res.status, RecordingStatus::Done);
         let dir = crate::storage::recordings_dir(tmp.path()).join(&res.id);
@@ -667,6 +728,7 @@ mod tests {
         );
         let stub = write_stub(tmp.path(), &body);
         unsafe { std::env::set_var("ARISO_STT_BIN", &stub); }
+        unsafe { std::env::set_var("ARISO_ROOT", tmp.path()); }
 
         let (res, notes_handle) = finalize_core(
             tmp.path(), b"audio".to_vec(),
@@ -674,6 +736,7 @@ mod tests {
         ).await.unwrap();
         notes_handle.await.unwrap();
         unsafe { std::env::remove_var("ARISO_STT_BIN"); }
+        unsafe { std::env::remove_var("ARISO_ROOT"); }
 
         assert_eq!(res.status, RecordingStatus::Done);
         let dir = crate::storage::recordings_dir(tmp.path()).join(&res.id);
@@ -716,10 +779,12 @@ mod tests {
         );
         let stub = write_stub(tmp.path(), &body);
         unsafe { std::env::set_var("ARISO_STT_BIN", &stub); }
+        unsafe { std::env::set_var("ARISO_ROOT", tmp.path()); }
 
         let (res, notes_handle) = retry_transcription_core(root, id).await.unwrap();
         notes_handle.await.unwrap();
         unsafe { std::env::remove_var("ARISO_STT_BIN"); }
+        unsafe { std::env::remove_var("ARISO_ROOT"); }
 
         assert_eq!(res.status, RecordingStatus::Done);
         assert!(dir.join("transcript.md").exists());
@@ -829,6 +894,7 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let stub = clip_stub(tmp.path());
         unsafe { std::env::set_var("ARISO_STT_BIN", &stub); }
+        unsafe { std::env::set_var("ARISO_ROOT", tmp.path()); }
 
         // First recording: 30s, ends 10:00:30.
         let (r1, h1) = finalize_core(
@@ -856,7 +922,12 @@ mod tests {
         // Meta duration summed; audio concatenated.
         let meta = crate::storage::read_meta(&dir).unwrap();
         assert_eq!(meta.duration_seconds, 45);
-        assert_eq!(std::fs::read(dir.join("recording.mp3")).unwrap(), b"aaabbb");
+        assert_eq!(
+            crate::vault::read_audio(meta.audio_file.as_ref().unwrap()).unwrap(),
+            b"aaabbb",
+            "concatenated audio lives in the vault attachment"
+        );
+        assert!(!dir.join("recording.mp3").exists());
         // transcript.md re-rendered with both clips.
         let md = std::fs::read_to_string(dir.join("transcript.md")).unwrap();
         assert_eq!(md.matches("clip text").count(), 2);
@@ -864,6 +935,7 @@ mod tests {
         let count = std::fs::read_dir(crate::storage::recordings_dir(tmp.path())).unwrap()
             .filter(|e| e.as_ref().unwrap().path().is_dir()).count();
         assert_eq!(count, 1);
+        unsafe { std::env::remove_var("ARISO_ROOT"); }
     }
 
     #[tokio::test]
@@ -871,6 +943,7 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let stub = clip_stub(tmp.path());
         unsafe { std::env::set_var("ARISO_STT_BIN", &stub); }
+        unsafe { std::env::set_var("ARISO_ROOT", tmp.path()); }
 
         let (r1, h1) = finalize_core(
             tmp.path(), b"aaa".to_vec(), "T".into(), "2026-06-02T10:00:00.000Z".into(), 30,
@@ -882,6 +955,7 @@ mod tests {
         ).await.unwrap();
         h2.await.unwrap();
         unsafe { std::env::remove_var("ARISO_STT_BIN"); }
+        unsafe { std::env::remove_var("ARISO_ROOT"); }
 
         assert_ne!(r2.id, r1.id);
         let count = std::fs::read_dir(crate::storage::recordings_dir(tmp.path())).unwrap()
@@ -895,6 +969,7 @@ mod tests {
         // First: success stub.
         let ok_stub = clip_stub(tmp.path());
         unsafe { std::env::set_var("ARISO_STT_BIN", &ok_stub); }
+        unsafe { std::env::set_var("ARISO_ROOT", tmp.path()); }
         let (r1, h1) = finalize_core(
             tmp.path(), b"aaa".to_vec(), "T".into(), "2026-06-02T10:00:00.000Z".into(), 30,
         ).await.unwrap();
@@ -909,17 +984,20 @@ mod tests {
         unsafe { std::env::remove_var("ARISO_STT_BIN"); }
         assert!(err.contains("boom"), "got: {err}");
 
-        // Target untouched: still one segment, 30s, audio "aaa".
+        // Target untouched: still one segment, 30s, audio "aaa" in the vault.
         let dir1 = crate::storage::recordings_dir(tmp.path()).join(&r1.id);
         assert_eq!(crate::storage::read_segments(&dir1).unwrap().unwrap().segments.len(), 1);
-        assert_eq!(crate::storage::read_meta(&dir1).unwrap().duration_seconds, 30);
-        assert_eq!(std::fs::read(dir1.join("recording.mp3")).unwrap(), b"aaa");
+        let meta1 = crate::storage::read_meta(&dir1).unwrap();
+        assert_eq!(meta1.duration_seconds, 30);
+        assert_eq!(crate::vault::read_audio(meta1.audio_file.as_ref().unwrap()).unwrap(), b"aaa");
 
-        // The failed clip is its own recording, audio retained, status Failed.
+        // The failed clip is its own recording, audio retained in the vault, status Failed.
         let dir2 = crate::storage::recordings_dir(tmp.path()).join("2026-06-02T10-01-00Z");
-        assert!(dir2.join("recording.mp3").exists());
-        assert_eq!(crate::storage::read_meta(&dir2).unwrap().status, RecordingStatus::Failed);
+        let meta2 = crate::storage::read_meta(&dir2).unwrap();
+        assert_eq!(crate::vault::read_audio(meta2.audio_file.as_ref().unwrap()).unwrap(), b"bbb");
+        assert_eq!(meta2.status, RecordingStatus::Failed);
         assert!(!dir1.join("append-clip.mp3").exists(), "temp clip cleaned up");
+        unsafe { std::env::remove_var("ARISO_ROOT"); }
     }
 
     #[tokio::test]
@@ -927,6 +1005,7 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let stub = clip_stub(tmp.path());
         unsafe { std::env::set_var("ARISO_STT_BIN", &stub); }
+        unsafe { std::env::set_var("ARISO_ROOT", tmp.path()); }
 
         // First recording: 30s, ends 10:00:30.
         let (r1, h1) = finalize_core(
@@ -955,10 +1034,12 @@ mod tests {
             .filter(|e| e.as_ref().unwrap().path().is_dir()).count();
         assert_eq!(count, 2);
 
-        // The clip's audio is preserved as its own fresh recording.
+        // The clip's audio is preserved as its own fresh recording in the vault.
         let dir2 = crate::storage::recordings_dir(tmp.path()).join(&r2.id);
-        assert_eq!(std::fs::read(dir2.join("recording.mp3")).unwrap(), b"bbb");
-        assert_eq!(crate::storage::read_meta(&dir2).unwrap().status, RecordingStatus::Done);
+        let meta2 = crate::storage::read_meta(&dir2).unwrap();
+        assert_eq!(crate::vault::read_audio(meta2.audio_file.as_ref().unwrap()).unwrap(), b"bbb");
+        assert_eq!(meta2.status, RecordingStatus::Done);
+        unsafe { std::env::remove_var("ARISO_ROOT"); }
     }
 
     #[tokio::test]
@@ -966,6 +1047,7 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let stub = clip_stub(tmp.path());
         unsafe { std::env::set_var("ARISO_STT_BIN", &stub); }
+        unsafe { std::env::set_var("ARISO_ROOT", tmp.path()); }
 
         // First recording: 30s, ends 10:00:30.
         let (r1, h1) = finalize_core(
@@ -986,6 +1068,7 @@ mod tests {
         ).await.unwrap();
         h2.await.unwrap();
         unsafe { std::env::remove_var("ARISO_STT_BIN"); }
+        unsafe { std::env::remove_var("ARISO_ROOT"); }
 
         assert_eq!(r2.id, r1.id);
         let meta = storage::read_meta(&dir).unwrap();
@@ -1045,5 +1128,81 @@ mod tests {
 
         assert!(!dir.join("ari-note.md").exists(), "superseded notes must be discarded");
         assert!(storage::read_meta(&dir).unwrap().notes_error.is_none(), "no stale error written");
+    }
+
+    #[tokio::test]
+    async fn fresh_recording_stores_audio_in_vault_only() {
+        let tmp = tempfile::tempdir().unwrap();
+        unsafe { std::env::set_var("ARISO_ROOT", tmp.path()); }
+        let root = tmp.path().to_path_buf();
+        let stub = clip_stub(tmp.path());
+        unsafe { std::env::set_var("ARISO_STT_BIN", &stub); }
+
+        let (res, notes_handle) = finalize_core(
+            &root, b"audiobytes".to_vec(), "Team Standup".into(), "2026-06-02T10:00:00Z".into(), 1,
+        ).await.unwrap();
+        notes_handle.await.unwrap();
+        unsafe { std::env::remove_var("ARISO_STT_BIN"); }
+
+        let dir = storage::recordings_dir(&root).join(&res.id);
+        let meta = storage::read_meta(&dir).unwrap();
+        let audio_file = meta.audio_file.clone().expect("audio_file set");
+        assert_eq!(audio_file, "2026-06-02 Team Standup.mp3");
+        assert_eq!(crate::vault::read_audio(&audio_file).unwrap(), b"audiobytes");
+        assert!(!dir.join("recording.mp3").exists(), "no ~/.ariso audio copy");
+        unsafe { std::env::remove_var("ARISO_ROOT"); }
+    }
+
+    #[tokio::test]
+    async fn append_concatenates_audio_in_vault() {
+        let tmp = tempfile::tempdir().unwrap();
+        unsafe { std::env::set_var("ARISO_ROOT", tmp.path()); }
+        let root = tmp.path().to_path_buf();
+        let stub = clip_stub(tmp.path());
+        unsafe { std::env::set_var("ARISO_STT_BIN", &stub); }
+        // First clip → fresh recording.
+        let (r1, h1) = finalize_core(
+            &root, b"AAAA".to_vec(), "Chat".into(), "2026-06-02T10:00:00Z".into(), 1,
+        ).await.unwrap();
+        h1.await.unwrap();
+        // Second clip within the append window → merges into r1.
+        let (r2, h2) = finalize_core(
+            &root, b"BBBB".to_vec(), "Chat".into(), "2026-06-02T10:00:30Z".into(), 1,
+        ).await.unwrap();
+        h2.await.unwrap();
+        unsafe { std::env::remove_var("ARISO_STT_BIN"); }
+        assert_eq!(r1.id, r2.id, "second clip appended to the first");
+
+        let dir = storage::recordings_dir(&root).join(&r2.id);
+        let meta = storage::read_meta(&dir).unwrap();
+        assert_eq!(crate::vault::read_audio(meta.audio_file.as_ref().unwrap()).unwrap(), b"AAAABBBB");
+        assert!(!dir.join("recording.mp3").exists());
+        unsafe { std::env::remove_var("ARISO_ROOT"); }
+    }
+
+    #[tokio::test]
+    async fn retry_reads_audio_from_vault() {
+        let tmp = tempfile::tempdir().unwrap();
+        unsafe { std::env::set_var("ARISO_ROOT", tmp.path()); }
+        let root = tmp.path().to_path_buf();
+        let stub = clip_stub(tmp.path());
+        unsafe { std::env::set_var("ARISO_STT_BIN", &stub); }
+        let (res, h) = finalize_core(
+            &root, b"origaudio".to_vec(), "Sync".into(), "2026-06-02T10:00:00Z".into(), 1,
+        ).await.unwrap();
+        h.await.unwrap();
+        // Retry should re-run using the vault audio without error.
+        let (res2, h2) = retry_transcription_core(&root, &res.id).await.unwrap();
+        h2.await.unwrap();
+        unsafe { std::env::remove_var("ARISO_STT_BIN"); }
+        assert_eq!(res2.id, res.id);
+        let meta = storage::read_meta(&storage::recordings_dir(&root).join(&res.id)).unwrap();
+        assert_eq!(crate::vault::read_audio(meta.audio_file.as_ref().unwrap()).unwrap(), b"origaudio");
+        // Retry must REUSE the original attachment, not orphan a duplicate.
+        assert_eq!(meta.audio_file.as_deref(), Some("2026-06-02 Sync.mp3"));
+        let attachments = crate::vault::attachments_dir(&crate::vault::vault_root().unwrap());
+        let count = std::fs::read_dir(&attachments).unwrap().count();
+        assert_eq!(count, 1, "retry must not orphan a duplicate attachment");
+        unsafe { std::env::remove_var("ARISO_ROOT"); }
     }
 }

--- a/src-tauri/src/vault.rs
+++ b/src-tauri/src/vault.rs
@@ -30,6 +30,63 @@ pub fn ensure_vault() -> Result<PathBuf, String> {
     Ok(root)
 }
 
+/// The vault-relative markdown note path for a basename.
+pub fn note_path(root: &Path, basename: &str) -> PathBuf {
+    root.join(format!("{basename}.md"))
+}
+
+/// Strip characters that could escape the vault or break a filename. Keeps
+/// spaces (Obsidian allows them). Collapses runs of whitespace.
+fn sanitize_component(s: &str) -> String {
+    // Filter individual reserved/control chars FIRST, then remove `..`. If we
+    // stripped `..` first, a reserved char between two lone dots (e.g. `.:.`)
+    // would reform `..` after the char filter. Loop the removal to a fixed
+    // point so a single pass can't leave a reformed `..` behind.
+    let filtered: String = s
+        .chars()
+        .filter(|c| !matches!(c, '/' | '\\' | ':' | '*' | '?' | '"' | '<' | '>' | '|') && !c.is_control())
+        .collect();
+    let mut cleaned = filtered;
+    while cleaned.contains("..") {
+        cleaned = cleaned.replace("..", "");
+    }
+    cleaned.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+/// Derive a human note basename: `YYYY-MM-DD <title>`. Falls back to the first
+/// 10 chars of `created_at` if it is not RFC3339, and to `id` if the sanitized
+/// title is empty.
+pub fn note_basename(created_at: &str, title: &str, id: &str) -> String {
+    let date = match chrono::DateTime::parse_from_rfc3339(created_at) {
+        Ok(dt) => dt.format("%Y-%m-%d").to_string(),
+        Err(_) => created_at.chars().take(10).collect(),
+    };
+    let mut name = sanitize_component(title);
+    if name.is_empty() {
+        name = sanitize_component(id);
+    }
+    format!("{date} {name}")
+}
+
+/// Return `base`, or `base (N)` for the smallest N ≥ 2 such that neither the
+/// note (`<base>.md`) nor the audio (`Attachments/<base>.mp3`) already exists.
+pub fn unique_basename(root: &Path, base: &str) -> String {
+    let taken = |b: &str| {
+        note_path(root, b).exists() || attachments_dir(root).join(format!("{b}.mp3")).exists()
+    };
+    if !taken(base) {
+        return base.to_string();
+    }
+    let mut n = 2;
+    loop {
+        let candidate = format!("{base} ({n})");
+        if !taken(&candidate) {
+            return candidate;
+        }
+        n += 1;
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -64,5 +121,57 @@ mod tests {
         unsafe {
             std::env::remove_var("ARISO_ROOT");
         }
+    }
+
+    #[test]
+    fn note_basename_prefixes_date_and_sanitizes_title() {
+        assert_eq!(
+            note_basename("2026-06-02T14:30:05Z", "Team Standup", "2026-06-02T14-30-05Z"),
+            "2026-06-02 Team Standup"
+        );
+    }
+
+    #[test]
+    fn note_basename_strips_path_and_reserved_chars() {
+        assert_eq!(
+            note_basename("2026-06-02T14:30:05Z", "a/b:c\\d..e", "id"),
+            "2026-06-02 abcde"
+        );
+    }
+
+    #[test]
+    fn note_basename_empty_title_falls_back_to_id() {
+        assert_eq!(note_basename("2026-06-02T14:30:05Z", "  ///  ", "myid"), "2026-06-02 myid");
+    }
+
+    #[test]
+    fn note_basename_no_dotdot_reforms_after_char_strip() {
+        let b = note_basename("2026-06-02T14:30:05Z", ".:.", "id");
+        assert!(!b.contains(".."), "sanitized output must not contain ..: {b}");
+        assert_eq!(b, "2026-06-02 id"); // title empties out, falls back to id
+    }
+
+    #[test]
+    fn note_basename_bad_date_falls_back_to_ten_char_slice() {
+        // Unparseable created_at → first 10 chars used as the date prefix.
+        assert_eq!(note_basename("2026-06-02xxx", "T", "id"), "2026-06-02 T");
+    }
+
+    #[test]
+    fn unique_basename_suffixes_on_collision() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        std::fs::create_dir_all(attachments_dir(root)).unwrap();
+        assert_eq!(unique_basename(root, "Note"), "Note");
+        std::fs::write(note_path(root, "Note"), b"x").unwrap();
+        assert_eq!(unique_basename(root, "Note"), "Note (2)");
+        std::fs::write(attachments_dir(root).join("Note (2).mp3"), b"x").unwrap();
+        // A collision on EITHER the .md or the .mp3 bumps the counter.
+        assert_eq!(unique_basename(root, "Note"), "Note (3)");
+
+        // Symmetric OR-branch: a bare `<base>.mp3` with NO matching `.md`
+        // still counts as taken and bumps the base.
+        std::fs::write(attachments_dir(root).join("Audio.mp3"), b"x").unwrap();
+        assert_eq!(unique_basename(root, "Audio"), "Audio (2)");
     }
 }

--- a/src-tauri/src/vault.rs
+++ b/src-tauri/src/vault.rs
@@ -61,7 +61,7 @@ fn sanitize_component(s: &str) -> String {
 pub fn note_basename(created_at: &str, title: &str, id: &str) -> String {
     let date = match chrono::DateTime::parse_from_rfc3339(created_at) {
         Ok(dt) => dt.format("%Y-%m-%d").to_string(),
-        Err(_) => created_at.chars().take(10).collect(),
+        Err(_) => sanitize_component(&created_at.chars().take(10).collect::<String>()),
     };
     let mut name = sanitize_component(title);
     if name.is_empty() {
@@ -132,6 +132,18 @@ pub fn note_body(contents: &str) -> String {
         _ => after_fence,
     };
     body.to_string()
+}
+
+/// Reject a note basename that could escape the vault root.
+fn validate_basename(basename: &str) -> Result<(), String> {
+    if basename.is_empty()
+        || basename.contains('/')
+        || basename.contains('\\')
+        || basename.contains("..")
+    {
+        return Err(format!("invalid note basename: {basename}"));
+    }
+    Ok(())
 }
 
 /// Reject an attachment filename that could escape `Attachments/`.
@@ -227,6 +239,7 @@ pub fn write_note(
     audio_file: &str,
     notes_md: &str,
 ) -> Result<(), String> {
+    validate_basename(basename)?;
     let root = ensure_vault()?;
     let contents = render_note(meta, audio_file, notes_md);
     crate::storage::write_atomic(&note_path(&root, basename), contents.as_bytes())

--- a/src-tauri/src/vault.rs
+++ b/src-tauri/src/vault.rs
@@ -1,4 +1,5 @@
 use crate::storage::{format_hms, RecordingMeta};
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 /// Resolve the vault root `<ariso_root>/vault`.
@@ -164,6 +165,61 @@ pub fn read_audio(audio_file: &str) -> Result<Vec<u8>, String> {
     std::fs::read(audio_path(&root, audio_file)).map_err(|e| format!("read vault audio: {e}"))
 }
 
+/// Extract `oats_id` from a note's front-matter head, if present. Reads only the
+/// lines inside the leading `---` fence.
+fn parse_oats_id(contents: &str) -> Option<String> {
+    let after_open = contents.strip_prefix("---\n")?;
+    let (frontmatter, _body) = after_open.split_once("\n---\n")?;
+    for line in frontmatter.lines() {
+        if let Some(rest) = line.strip_prefix("oats_id:") {
+            let id = rest.trim();
+            if !id.is_empty() {
+                return Some(id.to_string());
+            }
+        }
+    }
+    None
+}
+
+/// Map every top-level `.md` note in the vault by its `oats_id`. Files without a
+/// valid `oats_id` (or unreadable) are skipped. Missing vault → empty map.
+pub fn scan_vault() -> Result<HashMap<String, PathBuf>, String> {
+    let root = vault_root()?;
+    let mut map = HashMap::new();
+    if !root.exists() {
+        return Ok(map);
+    }
+    for entry in std::fs::read_dir(&root).map_err(|e| format!("read vault dir: {e}"))? {
+        let path = entry.map_err(|e| e.to_string())?.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("md") {
+            continue;
+        }
+        let Ok(contents) = std::fs::read_to_string(&path) else { continue };
+        if let Some(id) = parse_oats_id(&contents) {
+            map.insert(id, path);
+        }
+    }
+    Ok(map)
+}
+
+/// Path of the note whose front-matter carries `oats_id`, if any.
+pub fn find_note(oats_id: &str) -> Result<Option<PathBuf>, String> {
+    Ok(scan_vault()?.remove(oats_id))
+}
+
+/// The notes body (front-matter and embed stripped) for a recording, if a note
+/// exists in the vault.
+pub fn read_note(oats_id: &str) -> Result<Option<String>, String> {
+    match find_note(oats_id)? {
+        Some(path) => {
+            let contents =
+                std::fs::read_to_string(&path).map_err(|e| format!("read vault note: {e}"))?;
+            Ok(Some(note_body(&contents)))
+        }
+        None => Ok(None),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -307,6 +363,42 @@ mod tests {
     fn audio_file_rejects_traversal() {
         assert!(write_audio("../evil.mp3", b"x").is_err());
         assert!(write_audio("a/b.mp3", b"x").is_err());
+    }
+
+    #[test]
+    fn scan_indexes_by_oats_id_and_skips_junk() {
+        let tmp = tempfile::tempdir().unwrap();
+        unsafe {
+            std::env::set_var("ARISO_ROOT", tmp.path());
+        }
+        let root = ensure_vault().unwrap();
+        std::fs::write(root.join("A.md"), "---\noats_id: id-a\n---\n![[x]]\n\nbody a").unwrap();
+        std::fs::write(root.join("B.md"), "---\noats_id: id-b\n---\n\nbody b").unwrap();
+        std::fs::write(root.join("junk.md"), "no frontmatter here").unwrap();
+        std::fs::write(root.join("notes.txt"), "not markdown").unwrap();
+
+        let map = scan_vault().unwrap();
+        assert_eq!(map.len(), 2);
+        assert_eq!(map.get("id-a").unwrap(), &root.join("A.md"));
+        assert!(find_note("id-b").unwrap().is_some());
+        assert!(find_note("missing").unwrap().is_none());
+        assert_eq!(read_note("id-a").unwrap().as_deref(), Some("body a"));
+        assert_eq!(read_note("missing").unwrap(), None);
+        unsafe {
+            std::env::remove_var("ARISO_ROOT");
+        }
+    }
+
+    #[test]
+    fn scan_empty_when_no_vault() {
+        let tmp = tempfile::tempdir().unwrap();
+        unsafe {
+            std::env::set_var("ARISO_ROOT", tmp.path());
+        }
+        assert!(scan_vault().unwrap().is_empty());
+        unsafe {
+            std::env::remove_var("ARISO_ROOT");
+        }
     }
 
     #[test]

--- a/src-tauri/src/vault.rs
+++ b/src-tauri/src/vault.rs
@@ -1,0 +1,68 @@
+use std::path::{Path, PathBuf};
+
+/// Resolve the vault root `<ariso_root>/vault`.
+pub fn vault_root() -> Result<PathBuf, String> {
+    Ok(crate::storage::ariso_root()?.join("vault"))
+}
+
+/// Where audio attachments live inside the vault.
+pub fn attachments_dir(root: &Path) -> PathBuf {
+    root.join("Attachments")
+}
+
+/// Minimal Obsidian config so the folder opens cleanly as a vault and routes
+/// pasted attachments into `Attachments/`.
+const OBSIDIAN_APP_JSON: &str = "{\n  \"attachmentFolderPath\": \"Attachments\"\n}\n";
+
+/// Create the vault dir, its `Attachments/` folder, and a minimal `.obsidian/`
+/// on first use. Idempotent: never overwrites an existing `app.json`.
+pub fn ensure_vault() -> Result<PathBuf, String> {
+    let root = vault_root()?;
+    std::fs::create_dir_all(attachments_dir(&root))
+        .map_err(|e| format!("create vault attachments dir: {e}"))?;
+    let obsidian = root.join(".obsidian");
+    std::fs::create_dir_all(&obsidian).map_err(|e| format!("create .obsidian dir: {e}"))?;
+    let app_json = obsidian.join("app.json");
+    if !app_json.exists() {
+        std::fs::write(&app_json, OBSIDIAN_APP_JSON)
+            .map_err(|e| format!("write app.json: {e}"))?;
+    }
+    Ok(root)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // SAFETY (all set_var/remove_var below): tests run with `--test-threads=1`,
+    // so there is no concurrent env mutation while these calls execute.
+
+    #[test]
+    fn attachments_dir_is_under_root() {
+        let root = Path::new("/tmp/v");
+        assert_eq!(attachments_dir(root), Path::new("/tmp/v/Attachments"));
+    }
+
+    #[test]
+    fn ensure_vault_creates_structure_idempotently() {
+        let tmp = tempfile::tempdir().unwrap();
+        unsafe {
+            std::env::set_var("ARISO_ROOT", tmp.path());
+        }
+        let root = ensure_vault().unwrap();
+        assert!(root.is_dir());
+        assert!(attachments_dir(&root).is_dir());
+        assert!(root.join(".obsidian/app.json").is_file());
+        // Overwrite app.json with a distinguishable sentinel, then prove the
+        // second call is idempotent AND does not clobber it. Rewriting the fixed
+        // OBSIDIAN_APP_JSON constant would be indistinguishable from not writing,
+        // so a sentinel is needed to actually exercise the `!exists()` guard.
+        let app_json = root.join(".obsidian/app.json");
+        std::fs::write(&app_json, b"SENTINEL").unwrap();
+        ensure_vault().unwrap();
+        assert_eq!(std::fs::read_to_string(&app_json).unwrap(), "SENTINEL");
+        unsafe {
+            std::env::remove_var("ARISO_ROOT");
+        }
+    }
+}

--- a/src-tauri/src/vault.rs
+++ b/src-tauri/src/vault.rs
@@ -1,3 +1,4 @@
+use crate::storage::{format_hms, RecordingMeta};
 use std::path::{Path, PathBuf};
 
 /// Resolve the vault root `<ariso_root>/vault`.
@@ -87,6 +88,51 @@ pub fn unique_basename(root: &Path, base: &str) -> String {
     }
 }
 
+/// Render a vault note: YAML front-matter, the audio embed, then the notes body.
+pub fn render_note(meta: &RecordingMeta, audio_file: &str, notes_md: &str) -> String {
+    let esc = |s: &str| s.replace('\\', "\\\\").replace('"', "\\\"");
+    let participants = meta
+        .participants
+        .iter()
+        .map(|p| format!("\"{}\"", esc(&p.label)))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let mut out = String::new();
+    out.push_str("---\n");
+    out.push_str(&format!("oats_id: {}\n", meta.id));
+    out.push_str(&format!("title: \"{}\"\n", esc(&meta.title)));
+    out.push_str(&format!("date: \"{}\"\n", esc(&meta.created_at)));
+    out.push_str(&format!("duration: \"{}\"\n", format_hms(meta.duration_seconds as f64)));
+    out.push_str(&format!("participants: [{participants}]\n"));
+    out.push_str("---\n");
+    out.push_str(&format!("![[Attachments/{audio_file}]]\n\n"));
+    out.push_str(notes_md);
+    out
+}
+
+/// Inverse of `render_note` for in-app rendering: drop the front-matter block
+/// and the leading `![[...]]` embed line, returning just the notes body.
+/// Content without a leading `---` front-matter fence is returned unchanged (a
+/// user may have freely rewritten the note).
+pub fn note_body(contents: &str) -> String {
+    let Some(after_open) = contents.strip_prefix("---\n") else {
+        return contents.to_string();
+    };
+    let Some((_frontmatter, after_fence)) = after_open.split_once("\n---\n") else {
+        return contents.to_string();
+    };
+    // `after_fence` is `![[...]]\n\n<body>` as emitted by render_note. Strip one
+    // leading embed line, then exactly one separator newline — never more, so a
+    // body that itself begins with `\n` is preserved.
+    let body = match after_fence.split_once('\n') {
+        Some((first, tail)) if first.trim_start().starts_with("![[") => {
+            tail.strip_prefix('\n').unwrap_or(tail)
+        }
+        _ => after_fence,
+    };
+    body.to_string()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -155,6 +201,62 @@ mod tests {
     fn note_basename_bad_date_falls_back_to_ten_char_slice() {
         // Unparseable created_at → first 10 chars used as the date prefix.
         assert_eq!(note_basename("2026-06-02xxx", "T", "id"), "2026-06-02 T");
+    }
+
+    fn meta_for_note() -> crate::storage::RecordingMeta {
+        crate::storage::RecordingMeta {
+            id: "2026-06-02T14-30-05Z".into(),
+            title: "Team \"Standup\"".into(),
+            created_at: "2026-06-02T14:30:05Z".into(),
+            duration_seconds: 2533,
+            status: crate::storage::RecordingStatus::Done,
+            language: Some("en".into()),
+            participants: vec![
+                crate::storage::Participant { id: 0, label: "Speaker 1".into() },
+                crate::storage::Participant { id: 1, label: "Speaker 2".into() },
+            ],
+            model_version: None, error: None, notes_error: None, last_clip_end_at: None,
+            audio_file: None, notes_written: None,
+        }
+    }
+
+    #[test]
+    fn render_note_has_frontmatter_embed_and_body() {
+        let md = render_note(&meta_for_note(), "2026-06-02 Team Standup.mp3", "# Notes\n- point");
+        assert!(md.starts_with("---\n"));
+        assert!(md.contains("oats_id: 2026-06-02T14-30-05Z\n"));
+        assert!(md.contains("duration: \"00:42:13\"\n"));
+        assert!(md.contains("participants: [\"Speaker 1\", \"Speaker 2\"]\n"));
+        assert!(md.contains("![[Attachments/2026-06-02 Team Standup.mp3]]\n"));
+        assert!(md.contains("# Notes\n- point"));
+    }
+
+    #[test]
+    fn note_body_strips_frontmatter_and_embed() {
+        let md = render_note(&meta_for_note(), "a.mp3", "Body line 1\nBody line 2");
+        assert_eq!(note_body(&md), "Body line 1\nBody line 2");
+    }
+
+    #[test]
+    fn note_body_tolerates_missing_frontmatter() {
+        // A user-mangled note with no front-matter returns its content unchanged.
+        assert_eq!(note_body("just text"), "just text");
+    }
+
+    #[test]
+    fn note_body_leaves_embed_alone_without_frontmatter() {
+        // No `---` fence: the embed/trim logic must NOT run, so a first line that
+        // looks like an embed is preserved verbatim.
+        assert_eq!(note_body("![[X]]\nBody"), "![[X]]\nBody");
+    }
+
+    #[test]
+    fn note_body_roundtrips_body_with_leading_blank_line() {
+        // A body that itself begins with `\n` must survive the roundtrip — the
+        // separator strip removes exactly one newline, not all of them.
+        let body = "\nLeading blank line body";
+        let md = render_note(&meta_for_note(), "a.mp3", body);
+        assert_eq!(note_body(&md), body);
     }
 
     #[test]

--- a/src-tauri/src/vault.rs
+++ b/src-tauri/src/vault.rs
@@ -220,6 +220,40 @@ pub fn read_note(oats_id: &str) -> Result<Option<String>, String> {
     }
 }
 
+/// Atomically write a recording's vault note (front-matter + embed + body).
+pub fn write_note(
+    basename: &str,
+    meta: &RecordingMeta,
+    audio_file: &str,
+    notes_md: &str,
+) -> Result<(), String> {
+    let root = ensure_vault()?;
+    let contents = render_note(meta, audio_file, notes_md);
+    crate::storage::write_atomic(&note_path(&root, basename), contents.as_bytes())
+}
+
+/// Remove a recording's vault note (located by `oats_id`) and its audio
+/// attachment. Missing files are not an error (idempotent cascade).
+pub fn delete_recording_artifacts(oats_id: &str, audio_file: Option<&str>) -> Result<(), String> {
+    if let Some(path) = find_note(oats_id)? {
+        match std::fs::remove_file(&path) {
+            Ok(()) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => return Err(format!("delete vault note: {e}")),
+        }
+    }
+    if let Some(audio_file) = audio_file {
+        validate_audio_file(audio_file)?;
+        let root = vault_root()?;
+        match std::fs::remove_file(audio_path(&root, audio_file)) {
+            Ok(()) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => return Err(format!("delete vault attachment: {e}")),
+        }
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -396,6 +430,44 @@ mod tests {
             std::env::set_var("ARISO_ROOT", tmp.path());
         }
         assert!(scan_vault().unwrap().is_empty());
+        unsafe {
+            std::env::remove_var("ARISO_ROOT");
+        }
+    }
+
+    #[test]
+    fn write_note_persists_renderable_note() {
+        let tmp = tempfile::tempdir().unwrap();
+        unsafe {
+            std::env::set_var("ARISO_ROOT", tmp.path());
+        }
+        let mut meta = meta_for_note();
+        meta.id = "id-w".into();
+        write_note("2026-06-02 Team Standup", &meta, "2026-06-02 Team Standup.mp3", "the body")
+            .unwrap();
+        assert_eq!(read_note("id-w").unwrap().as_deref(), Some("the body"));
+        unsafe {
+            std::env::remove_var("ARISO_ROOT");
+        }
+    }
+
+    #[test]
+    fn delete_removes_note_and_attachment() {
+        let tmp = tempfile::tempdir().unwrap();
+        unsafe {
+            std::env::set_var("ARISO_ROOT", tmp.path());
+        }
+        let mut meta = meta_for_note();
+        meta.id = "id-d".into();
+        write_audio("clip.mp3", b"a").unwrap();
+        write_note("Note D", &meta, "clip.mp3", "b").unwrap();
+        assert!(find_note("id-d").unwrap().is_some());
+
+        delete_recording_artifacts("id-d", Some("clip.mp3")).unwrap();
+        assert!(find_note("id-d").unwrap().is_none());
+        assert!(!audio_path(&vault_root().unwrap(), "clip.mp3").exists());
+        // Idempotent: deleting again is fine.
+        delete_recording_artifacts("id-d", Some("clip.mp3")).unwrap();
         unsafe {
             std::env::remove_var("ARISO_ROOT");
         }

--- a/src-tauri/src/vault.rs
+++ b/src-tauri/src/vault.rs
@@ -133,6 +133,37 @@ pub fn note_body(contents: &str) -> String {
     body.to_string()
 }
 
+/// Reject an attachment filename that could escape `Attachments/`.
+fn validate_audio_file(audio_file: &str) -> Result<(), String> {
+    if audio_file.is_empty()
+        || audio_file.contains('/')
+        || audio_file.contains('\\')
+        || audio_file.contains("..")
+    {
+        return Err(format!("invalid audio filename: {audio_file}"));
+    }
+    Ok(())
+}
+
+/// Path to an audio attachment in the vault.
+pub fn audio_path(root: &Path, audio_file: &str) -> PathBuf {
+    attachments_dir(root).join(audio_file)
+}
+
+/// Atomically write an audio attachment, creating `Attachments/` if needed.
+pub fn write_audio(audio_file: &str, bytes: &[u8]) -> Result<(), String> {
+    validate_audio_file(audio_file)?;
+    let root = ensure_vault()?;
+    crate::storage::write_atomic(&audio_path(&root, audio_file), bytes)
+}
+
+/// Read an audio attachment's bytes.
+pub fn read_audio(audio_file: &str) -> Result<Vec<u8>, String> {
+    validate_audio_file(audio_file)?;
+    let root = vault_root()?;
+    std::fs::read(audio_path(&root, audio_file)).map_err(|e| format!("read vault audio: {e}"))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -257,6 +288,25 @@ mod tests {
         let body = "\nLeading blank line body";
         let md = render_note(&meta_for_note(), "a.mp3", body);
         assert_eq!(note_body(&md), body);
+    }
+
+    #[test]
+    fn write_and_read_audio_roundtrip() {
+        let tmp = tempfile::tempdir().unwrap();
+        unsafe {
+            std::env::set_var("ARISO_ROOT", tmp.path());
+        }
+        write_audio("2026-06-02 Standup.mp3", b"mp3bytes").unwrap();
+        assert_eq!(read_audio("2026-06-02 Standup.mp3").unwrap(), b"mp3bytes");
+        unsafe {
+            std::env::remove_var("ARISO_ROOT");
+        }
+    }
+
+    #[test]
+    fn audio_file_rejects_traversal() {
+        assert!(write_audio("../evil.mp3", b"x").is_err());
+        assert!(write_audio("a/b.mp3", b"x").is_err());
     }
 
     #[test]

--- a/src/views/SettingsView.vue
+++ b/src/views/SettingsView.vue
@@ -135,6 +135,11 @@
             </button>
           </div>
         </div>
+        <p class="setting-hint">
+          Your notes and recordings are saved as a local Obsidian vault at
+          <code>~/.ariso/vault</code>. If you sync that folder (iCloud, Obsidian
+          Sync, etc.), those notes and audio leave this device.
+        </p>
       </div>
     </section>
 


### PR DESCRIPTION
## Local-backend Obsidian vault

Stores **local (offline) backend** meeting notes and audio in an Obsidian-compatible vault at `~/.ariso/vault`, so users can open and edit their notes in Obsidian (or any editor). The vault is the single canonical home — no mirror. Cloud/Ariso recordings are untouched.

Design spec: `docs/superpowers/specs/2026-07-03-local-backend-vault-design.md`.

### What changed
- **New `src-tauri/src/vault.rs`** owns all vault I/O: paths, atomic writes, front-matter render/parse, note lookup by `oats_id`, and a (dormant) cascade-delete helper.
- **Audio's only home is the vault** — `vault/Attachments/<basename>.mp3`. New recordings write no `recording.mp3` under `~/.ariso`. `meta.json` gains `audio_file` (the id→attachment pointer) and `notes_written`.
- **Notes generate into the vault** — `vault/<basename>.md` with `oats_id` front-matter and an `![[Attachments/…]]` embed. The transcript (`transcript.md`), `segments.json`, and `meta.json` stay private in `~/.ariso`.
- **Pipeline rewired** — fresh/append/retry/save-failed-clip read/write audio via the vault (append crash-safety preserved; retry reuses the existing attachment, no orphans); retry-notes replaces the vault note.
- **Commands resolve vault-first with a legacy `~/.ariso` fallback** for pre-feature recordings (play audio, read/open note, `has_note`/`has_audio`). No new Tauri capability — audio still flows as IPC bytes.
- **Vault bootstrapped at startup**; a privacy note in Settings warns that syncing the vault sends notes + audio off-device.

### Migration
No backfill: existing recordings keep working from their old `~/.ariso` location via fallback; only new recordings use the vault.

### Testing
- Rust: **209 passed / 0 failed**; `cargo build` warning-clean. New unit + integration tests cover vault I/O, sanitization/traversal guards, the audio-migration paths, retry idempotency, and the vault/legacy resolution.
- Frontend: `SettingsView` 34/34. (Pre-existing `LibraryView`/`UpdateView` failures on `main` are unrelated — this branch's only frontend change is a 5-line `SettingsView.vue` addition.)
- Not run here: the manual Obsidian round-trip smoke test (record → open `~/.ariso/vault` in Obsidian → edit → confirm in app → delete → confirm respected).

### Known follow-ups (non-blocking)
- `save_failed_clip` best-effort error path can leave a meta-less dir / a phantom `audio_file` on double-failure.
- Legacy `ari-note.md`/vault note reads dropped the `MAX_TEXT_BYTES` guard (transcript path retains it).
- `scan_vault` reads full note bodies to parse the front-matter head (a head slice would reduce cost; scan-cost optimization is already deferred in the spec).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Local recordings can now be stored in an Obsidian-compatible vault at `~/.ariso/vault`, with notes and audio attachments.
  * Notes now open from the vault when available (including embedded audio links); playback uses vault audio when present.
* **Bug Fixes**
  * Improved fallback to legacy files when vault artifacts aren’t available.
  * Better status accuracy for whether notes/audio exist, including deletion reflecting vault changes.
* **Documentation**
  * Updated settings hint to explain that syncing the vault will move notes and audio off the device.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->