### PR TITLE
fix(library): show attendees dropdown in meeting detail

### DIFF
--- a/src/views/MeetingDetailView.test.ts
+++ b/src/views/MeetingDetailView.test.ts
@@ -550,6 +550,28 @@ describe('MeetingDetailView attendees dropdown', () => {
     await wrapper.find('.attendees-overlay').trigger('click');
     expect(wrapper.find('.attendees-menu').exists()).toBe(false);
   });
+
+  it('closes the dropdown when Escape is pressed', async () => {
+    const wrapper = await mountWith(withParticipants());
+
+    await wrapper.find('.attendees-trigger').trigger('click');
+    expect(wrapper.find('.attendees-menu').exists()).toBe(true);
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    await wrapper.vm.$nextTick();
+    expect(wrapper.find('.attendees-menu').exists()).toBe(false);
+  });
+
+  it('ignores Escape while the dropdown is closed', async () => {
+    const wrapper = await mountWith(withParticipants());
+    expect(wrapper.find('.attendees-menu').exists()).toBe(false);
+
+    // No listener is registered while closed, so this is a no-op (and must
+    // not throw).
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    await wrapper.vm.$nextTick();
+    expect(wrapper.find('.attendees-menu').exists()).toBe(false);
+  });
 });
 
 describe('MeetingDetailView audio player', () => {

--- a/src/views/MeetingDetailView.test.ts
+++ b/src/views/MeetingDetailView.test.ts
@@ -507,6 +507,51 @@ describe('MeetingDetailView inline title editing', () => {
   });
 });
 
+describe('MeetingDetailView attendees dropdown', () => {
+  const withParticipants = () =>
+    detail({
+      participants: [
+        { name: 'Ada Lovelace', email: 'ada@example.com', role: 'host', self: true },
+        { name: 'Alan Turing', email: 'alan@example.com', role: 'attendee' },
+        { name: 'Grace Hopper', email: 'grace@example.com', role: 'attendee' },
+        { name: 'Katherine Johnson', email: 'katherine@example.com', role: 'attendee' },
+        { name: 'Edsger Dijkstra', email: 'edsger@example.com', role: 'attendee' },
+      ],
+    });
+
+  it('opens a dropdown listing every attendee when the avatars are clicked', async () => {
+    const wrapper = await mountWith(withParticipants());
+
+    // Collapsed: no dropdown yet, and attendees past the visible avatars
+    // (here the 5th, behind the "+1" chip) aren't shown by name anywhere.
+    expect(wrapper.find('.attendees-menu').exists()).toBe(false);
+    expect(wrapper.text()).not.toContain('Edsger Dijkstra');
+
+    await wrapper.find('.attendees-trigger').trigger('click');
+
+    const menu = wrapper.find('.attendees-menu');
+    expect(menu.exists()).toBe(true);
+    // Every attendee is listed — including the one hidden behind "+1".
+    expect(menu.findAll('.attendee-row')).toHaveLength(5);
+    expect(menu.text()).toContain('Ada Lovelace');
+    expect(menu.text()).toContain('Edsger Dijkstra');
+    expect(menu.text()).toContain('ada@example.com');
+    expect(menu.text()).toContain('host');
+    // The current user is marked.
+    expect(menu.text()).toContain('(me)');
+  });
+
+  it('closes the dropdown when the overlay is clicked', async () => {
+    const wrapper = await mountWith(withParticipants());
+
+    await wrapper.find('.attendees-trigger').trigger('click');
+    expect(wrapper.find('.attendees-menu').exists()).toBe(true);
+
+    await wrapper.find('.attendees-overlay').trigger('click');
+    expect(wrapper.find('.attendees-menu').exists()).toBe(false);
+  });
+});
+
 describe('MeetingDetailView audio player', () => {
   beforeEach(() => {
     URL.createObjectURL = vi.fn(() => 'blob:test');

--- a/src/views/MeetingDetailView.vue
+++ b/src/views/MeetingDetailView.vue
@@ -70,17 +70,55 @@
           <span class="dur">{{ durationLabel }}</span>
         </div>
         <div v-if="detail.participants.length" class="meta-item attendees">
-          <span class="avatars">
-            <span
-              v-for="(p, i) in detail.participants.slice(0, 4)"
-              :key="i"
-              class="avatar"
-              :style="{ background: avatarColor(i) }"
-              :title="p.name || p.email || ''"
-            >{{ initials(p.name || p.email) }}</span>
-            <span v-if="detail.participants.length > 4" class="avatar avatar--more">+{{ detail.participants.length - 4 }}</span>
-          </span>
-          <span class="attendees-label">{{ detail.participants.length }} Attendees</span>
+          <button
+            ref="attendeesBtn"
+            type="button"
+            class="attendees-trigger"
+            aria-haspopup="true"
+            :aria-expanded="showAttendees"
+            title="Show attendees"
+            @click="onAttendeesClick"
+          >
+            <span class="avatars">
+              <span
+                v-for="(p, i) in detail.participants.slice(0, 4)"
+                :key="i"
+                class="avatar"
+                :style="{ background: avatarColor(i) }"
+              >{{ initials(p.name || p.email) }}</span>
+              <span v-if="detail.participants.length > 4" class="avatar avatar--more">+{{ detail.participants.length - 4 }}</span>
+            </span>
+            <span class="attendees-label">{{ detail.participants.length }} Attendees</span>
+            <svg viewBox="0 0 24 24" class="ic attendees-caret" :class="{ open: showAttendees }" aria-hidden="true"><path d="M19 9l-7 7-7-7" /></svg>
+          </button>
+
+          <!-- Attendees dropdown. Fixed-positioned (like the share popover)
+               so it escapes the card's `overflow: hidden`; the full-screen
+               overlay closes it on any outside click. -->
+          <template v-if="showAttendees">
+            <div class="attendees-overlay" @click="showAttendees = false" />
+            <div class="attendees-menu" :style="attendeesMenuStyle" role="menu">
+              <div class="attendees-menu-head">Attendees</div>
+              <ul class="attendees-list">
+                <li
+                  v-for="(p, i) in detail.participants"
+                  :key="i"
+                  class="attendee-row"
+                >
+                  <span class="avatar avatar--sm" :style="{ background: avatarColor(i) }">{{ initials(p.name || p.email) }}</span>
+                  <span class="attendee-info">
+                    <span class="attendee-name">{{ p.name || p.email || 'Guest' }}<span v-if="p.self" class="attendee-me"> (me)</span></span>
+                    <span v-if="p.email && p.name" class="attendee-email">{{ p.email }}</span>
+                  </span>
+                  <span
+                    v-if="p.role"
+                    class="attendee-role"
+                    :class="{ 'attendee-role--host': p.role === 'host' }"
+                  >{{ p.role }}</span>
+                </li>
+              </ul>
+            </div>
+          </template>
         </div>
         <span v-if="detail.meetingType" class="chip">
           <span class="chip-hash">#</span>{{ formatType(detail.meetingType) }}
@@ -357,6 +395,27 @@ const titleError = computed<string | null>(() => {
 const showShare = ref(false);
 const shareBtn = ref<HTMLButtonElement | null>(null);
 const shareAnchor = ref<{ bottom: number; right: number } | null>(null);
+
+// Attendees dropdown. The card clips overflow, so the menu is fixed-
+// positioned and anchored to the trigger's rect (captured on open),
+// mirroring the share popover.
+const showAttendees = ref(false);
+const attendeesBtn = ref<HTMLButtonElement | null>(null);
+const attendeesAnchor = ref<{ bottom: number; left: number } | null>(null);
+
+function onAttendeesClick(): void {
+  const rect = attendeesBtn.value?.getBoundingClientRect();
+  attendeesAnchor.value = rect ? { bottom: rect.bottom, left: rect.left } : null;
+  showAttendees.value = !showAttendees.value;
+}
+
+const attendeesMenuStyle = computed<Record<string, string>>(() => {
+  const a = attendeesAnchor.value;
+  const width = 260;
+  if (!a) return { position: 'fixed', top: '120px', left: '24px', width: `${width}px` };
+  const left = Math.max(8, Math.min(a.left, window.innerWidth - width - 8));
+  return { position: 'fixed', top: `${a.bottom + 6}px`, left: `${left}px`, width: `${width}px` };
+});
 
 const isHost = computed(() =>
   (detail.value?.participants ?? []).some((p) => p.role === 'host' && p.self)
@@ -1199,7 +1258,23 @@ const durationLabel = computed<string | null>(() => {
 .meta-item { display: flex; align-items: center; gap: 4px; color: #6f6f6f; }
 .meta-item .ic { width: 15px; height: 15px; }
 .dur { color: #1c1c1c; font-size: 14px; }
-.attendees { gap: 0; }
+.attendees { gap: 0; position: relative; }
+.attendees-trigger { display: flex; align-items: center; gap: 0; background: none; border: none; padding: 0; margin: 0; font: inherit; color: inherit; cursor: pointer; }
+.attendees-trigger:hover { opacity: 0.85; }
+.attendees-caret { width: 14px; height: 14px; margin-left: 4px; color: #9b9b9b; transition: transform 0.15s; }
+.attendees-caret.open { transform: rotate(180deg); }
+.attendees-overlay { position: fixed; inset: 0; z-index: 60; }
+.attendees-menu { z-index: 61; background: #fff; border: 1px solid #e5e6e3; border-radius: 10px; box-shadow: 0 6px 18px rgba(0, 0, 0, 0.12); overflow: hidden; }
+.attendees-menu-head { padding: 10px 14px; font-size: 12px; font-weight: 600; color: #6f6f6f; border-bottom: 1px solid #e5e6e3; }
+.attendees-list { list-style: none; margin: 0; padding: 6px; max-height: 260px; overflow-y: auto; display: flex; flex-direction: column; gap: 2px; }
+.attendee-row { display: flex; align-items: center; gap: 8px; padding: 6px 8px; border-radius: 8px; }
+.attendee-row:hover { background: #f7f6f4; }
+.attendee-info { display: flex; flex-direction: column; min-width: 0; flex: 1; }
+.attendee-name { font-size: 13px; color: #1f1f1f; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.attendee-me { color: #9b9b9b; }
+.attendee-email { font-size: 11px; color: #9b9b9b; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.attendee-role { font-size: 10px; text-transform: capitalize; color: #6f6f6f; background: #ecebe8; border-radius: 999px; padding: 2px 8px; flex-shrink: 0; }
+.attendee-role--host { color: #6c63c0; background: rgba(108, 99, 192, 0.1); }
 .avatars { display: flex; align-items: center; }
 .avatar { width: 23px; height: 23px; border-radius: 50%; display: flex; align-items: center; justify-content: center; color: #fff; font-size: 9px; font-weight: 600; border: 2px solid #f7f6f4; margin-left: -5px; }
 .avatar:first-child { margin-left: 0; }

--- a/src/views/MeetingDetailView.vue
+++ b/src/views/MeetingDetailView.vue
@@ -94,10 +94,11 @@
 
           <!-- Attendees dropdown. Fixed-positioned (like the share popover)
                so it escapes the card's `overflow: hidden`; the full-screen
-               overlay closes it on any outside click. -->
+               overlay closes it on any outside click, and Escape closes it
+               from the keyboard. -->
           <template v-if="showAttendees">
             <div class="attendees-overlay" @click="showAttendees = false" />
-            <div class="attendees-menu" :style="attendeesMenuStyle" role="menu">
+            <div class="attendees-menu" :style="attendeesMenuStyle">
               <div class="attendees-menu-head">Attendees</div>
               <ul class="attendees-list">
                 <li
@@ -408,6 +409,17 @@ function onAttendeesClick(): void {
   attendeesAnchor.value = rect ? { bottom: rect.bottom, left: rect.left } : null;
   showAttendees.value = !showAttendees.value;
 }
+
+// Escape closes the dropdown regardless of where focus sits. The window
+// listener only lives while the dropdown is open.
+function onAttendeesKeydown(e: KeyboardEvent): void {
+  if (e.key === 'Escape') showAttendees.value = false;
+}
+watch(showAttendees, (open) => {
+  if (open) window.addEventListener('keydown', onAttendeesKeydown);
+  else window.removeEventListener('keydown', onAttendeesKeydown);
+});
+onBeforeUnmount(() => window.removeEventListener('keydown', onAttendeesKeydown));
 
 const attendeesMenuStyle = computed<Record<string, string>>(() => {
   const a = attendeesAnchor.value;

--- a/src/views/MeetingDetailView.vue
+++ b/src/views/MeetingDetailView.vue
@@ -713,6 +713,8 @@ async function load(item: MeetingListItem | null): Promise<void> {
   editingTitle.value = false;
   savingTitle.value = false;
   showShare.value = false;
+  showAttendees.value = false;
+  attendeesAnchor.value = null;
   transcript.value = null;
   transcriptLoaded.value = false;
   loadingTranscript.value = false;


### PR DESCRIPTION
## What

The meeting detail meta band showed attendee avatars and a count but no way to see who they are. This makes the band a clickable trigger that opens an **Attendees dropdown** listing every participant (name, email, role, and a "(me)" marker).

## How

- Trigger is a real `<button>` (`aria-haspopup`/`aria-expanded`, rotating caret).
- Dropdown is `position: fixed`, anchored to the trigger rect — same pattern as `ShareMeetingPopover` — so it escapes the card's `overflow: hidden`.
- Full-screen overlay closes it on outside click.
- Reuses existing `initials()` / `avatarColor()` / `.avatar--sm`.

## Test

`npx vitest run src/views/MeetingDetailView.test.ts` — 54 passed. Added 2 tests: dropdown lists all attendees (incl. those behind the "+N" chip) and overlay-click closes it.

Fixes #143

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an interactive attendees dropdown to meeting details.
  * Users can now open a full attendee list from the meeting header, including avatars, names (with guest fallback), and role badges.
  * The trigger shows the total attendee count and supports improved expand/collapse behavior with responsive dropdown positioning.

* **Bug Fixes**
  * Clicking outside the attendee menu now closes it as expected.

* **Tests**
  * Added coverage for opening the attendees menu, rendering the full attendee list, and closing it via the overlay.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->