### PR TITLE
feat: continue an existing meeting when Start recording is clicked with a meeting open

### DIFF
--- a/docs/superpowers/specs/2026-07-05-recording-start-new-vs-continue-design.md
+++ b/docs/superpowers/specs/2026-07-05-recording-start-new-vs-continue-design.md
@@ -1,0 +1,166 @@
+# Start recording: New vs. Continue the open meeting
+
+**Date:** 2026-07-05
+**Status:** Design approved, pending spec review
+**Issue:** #174
+
+## Problem
+
+When a meeting is rendered in the detail pane and the user clicks **Start
+recording**, the app immediately starts a recording with no way to say "this is a
+continuation of the meeting I'm looking at." The user wants an explicit choice at
+that moment: **start a new recording** or **continue recording the same meeting**.
+
+The backends differ in how "continue" works, so the UX differs per backend:
+
+- **Ariso (cloud):** attaching a new session to an existing meeting id already
+  works (`start_recording_window({ meetingId })`); each session becomes another
+  `audioClip` on the meeting. The gap is a UI to deliberately pick the open meeting.
+- **Local (offline):** the backend only *auto*-appends a new recording to the
+  previous one when it starts within a 5-minute wall-clock window
+  (`most_recent_appendable`, `APPEND_WINDOW_SECONDS = 5*60`). There is no way for
+  the user to deliberately continue an older local recording. This needs new
+  backend work.
+
+## Behavior
+
+The trigger is: **a meeting is open in the detail pane AND the user clicks Start
+recording.** When no meeting is open, behavior is unchanged from today.
+
+### Local backend
+Show a two-button dialog:
+
+- **Continue "‹meeting title›"** (default) — the new recording session appends to
+  that existing local recording, regardless of how much time has passed.
+- **New recording** — a fresh ad-hoc recording (identical to today's behavior).
+- Dismiss / cancel — do nothing.
+
+### Ariso backend
+Open the existing meeting picker (`/#/meeting-picker`), but with the open meeting
+featured as the pre-selected default — **even if it is a past meeting not in
+today's scheduled list** (decision confirmed during brainstorming). The picker
+still lists other today meetings ("View all") and offers "Record a new meeting".
+Selecting the featured meeting calls the existing
+`start_recording_window({ meetingId })`, attaching a new session (audio clip) to
+that meeting.
+
+## Architecture
+
+### Frontend
+
+**New: `src/views/RecordingStartChoiceDialog.vue`**
+Modeled on `AriJoinConfirmDialog.vue`. Props `{ open: boolean; meetingTitle: string }`,
+emits `continue` / `new` / `cancel`. Same overlay/card/`role="dialog"` conventions
+as the existing confirm dialogs. Default/focused button is **Continue**.
+
+**New: `src/composables/useRecordingStartChoice.ts`**
+Promise driver mirroring `useAriJoinConfirm.ts`, but three-way instead of boolean:
+
+```ts
+open: Ref<boolean>
+meetingTitle: Ref<string>
+requestChoice(title: string): Promise<'continue' | 'new' | null>  // null = cancelled
+choose(kind: 'continue' | 'new'): void
+cancel(): void
+```
+
+**New: `src/composables/decideStartRecording.ts` (pure helper)**
+Keep the branch decision out of the giant `LibraryView.vue` (its Vitest coverage is
+brittle). A pure function that, given `{ backendUsesPicker: boolean; openMeeting: {...} | null }`,
+returns one of:
+
+- `{ kind: 'default' }` — no meeting open: fall through to today's
+  `decideRecordingAction` path unchanged.
+- `{ kind: 'ariso-picker'; defaultMeetingId; defaultMeetingTitle }`
+- `{ kind: 'local-choice'; meetingTitle; localRecordingId }`
+
+**`src/views/LibraryView.vue` — `startRecording()`**
+Wire the helper:
+
+- `default` → existing behavior (`decideRecordingAction` → picker / attach / ad-hoc).
+- `ariso-picker` → `invoke('open_meeting_picker', { defaultMeetingId, defaultMeetingTitle })`.
+- `local-choice` → `await recordingStartChoice.requestChoice(title)`:
+  - `'continue'` → `invoke('start_recording_window', { localAppendId: localRecordingId })`
+  - `'new'` → `invoke('start_recording_window', {})` (ad-hoc, unchanged)
+  - `null` → do nothing.
+
+The "open meeting" is the `item` currently passed to `MeetingDetailView`. For local
+meetings, `item.id` **is** the on-disk local recording id (the string
+`most_recent_appendable`/`append_recording_core` use). For Ariso meetings we pass
+the numeric meeting id and the title. *(Implementation must confirm the Ariso
+numeric meeting-id field available on the open detail item.)*
+
+**`src/views/MeetingPickerView.vue`**
+On mount, read `defaultMeetingId` / `defaultMeetingTitle` from the route query
+(`useRoute().query` / `window.location.hash`). When present, feature that meeting as
+the default choice — synthesizing a featured entry from the passed id+title if it is
+not in the fetched today list — instead of the client-side `pickDefaultMeeting`
+heuristic. Selecting it uses the existing `start_recording_window({ meetingId })`.
+
+**`src/views/WaveformView.vue`**
+Read a new `localAppendId` route-query param. When present:
+- set `effectiveLocalRecordingId` to it directly (so the recorder strip docks to the
+  right library row from the start; skip the `recordingIdForStart` resolve), and
+- pass it through to `finalizeRecording` as the append target.
+
+### Backend (Rust)
+
+**Local force-append — inject the target at finalize time.**
+The finalize path is entirely `created_at`-driven today; that is the correct seam.
+
+- `commands.rs` `start_recording_window(app, meeting_id: Option<i64>)` →
+  add `local_append_id: Option<String>`; thread into
+  `open_waveform_window(app, meeting_id, local_append_id, auto)` and append it to the
+  waveform URL query (same pattern as `meetingId`). `local_append_id` is a **string**
+  local recording id, orthogonal to the numeric Ariso `meeting_id`.
+- `tauri.ts` `local.finalizeRecording(...)` and `useBackend.ts`
+  `LocalBackend.finalizeRecording(...)` — add `appendTo?: string`.
+- `transcribe.rs` `local_finalize_recording(audio, title, created_at, duration_seconds)`
+  → add `append_to: Option<String>`; forward to `finalize_core`.
+- `transcribe.rs` `finalize_core(...)` — when `append_to` is `Some(id)`, skip
+  `most_recent_appendable` and call `append_recording_core(root, &id, ...)` directly.
+  `append_recording_core` already re-validates the target is still `Done` with audio
+  and falls back to `fresh_recording_core` otherwise, so a stale/invalid id degrades
+  safely. When `None`, behavior is unchanged (existing 5-minute auto-append).
+
+**Ariso picker default.**
+- `commands.rs` `open_meeting_picker(app)` → add
+  `default_meeting_id: Option<i64>, default_meeting_title: Option<String>`; thread
+  into `open_meeting_picker_window` and append to the `/#/meeting-picker` URL query
+  (use the existing query-building pattern, e.g. `waveform_url` helper). The tray
+  entry point (`tray.rs`) keeps calling with `None` and is unaffected.
+
+## Error handling / edge cases
+
+- **Stale local id (recording deleted or mid-processing):** handled by
+  `append_recording_core`'s existing re-validation → falls back to a fresh recording
+  rather than erroring.
+- **Cancel / dismiss:** no recording starts; no state changes.
+- **No meeting open:** dialog/picker-default logic is skipped entirely; existing
+  behavior preserved.
+- **Ariso default not in today's list:** picker synthesizes the featured entry from
+  the passed id+title; no extra network fetch required.
+
+## Testing
+
+**Rust (unit, in `transcribe.rs`/`storage.rs` test modules):**
+- `finalize_core` with `append_to = Some(existing_done_id)` appends to that id even
+  when the 5-minute window would not (start far outside the window).
+- `finalize_core` with `append_to = Some(invalid_id)` falls back to a fresh recording.
+- `finalize_core` with `append_to = None` preserves current auto-append behavior
+  (regression guard).
+
+**Frontend (Vitest, on the small units — not the brittle views):**
+- `decideStartRecording` returns the right branch for each
+  (backend, open-meeting) combination.
+- `useRecordingStartChoice.requestChoice` resolves to
+  `continue` / `new` / `null` for the three outcomes.
+- `RecordingStartChoiceDialog` emits `continue` / `new` / `cancel` on the
+  corresponding actions and renders the meeting title.
+
+## Out of scope
+
+- No change to the automatic 5-minute local append behavior when no meeting is open.
+- No new "pick any past local meeting from a list" UI — continue applies only to the
+  meeting currently open in the detail pane.
+- No change to how audio clips are rendered in `MeetingDetailView`.

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -527,17 +527,26 @@ pub async fn create_onboarding_window(app: tauri::AppHandle) -> Result<(), Strin
     Ok(())
 }
 
-/// Build the waveform window's route, appending the optional `auto` and
-/// `pillHidden` query flags. Kept pure so the flag wiring is unit-testable.
-fn waveform_url(meeting_id: Option<i64>, auto: bool, pill_hidden: bool) -> String {
+/// Build the waveform window's route, appending the optional `localAppendId`
+/// value plus the `auto` and `pillHidden` query flags. Kept pure so the wiring
+/// is unit-testable.
+fn waveform_url(
+    meeting_id: Option<i64>,
+    auto: bool,
+    pill_hidden: bool,
+    local_append_id: Option<&str>,
+) -> String {
     let mut url = match meeting_id {
         Some(id) => format!("/#/waveform?meetingId={id}"),
         None => "/#/waveform".to_string(),
     };
-    let mut push = |flag: &str| {
+    let mut push = |part: &str| {
         url.push_str(if url.contains('?') { "&" } else { "?" });
-        url.push_str(flag);
+        url.push_str(part);
     };
+    if let Some(id) = local_append_id {
+        push(&format!("localAppendId={id}"));
+    }
     if auto {
         push("auto=1");
     }
@@ -554,6 +563,7 @@ fn waveform_url(meeting_id: Option<i64>, auto: bool, pill_hidden: bool) -> Strin
 pub(crate) fn open_waveform_window(
     app: &tauri::AppHandle,
     meeting_id: Option<i64>,
+    local_append_id: Option<String>,
     auto: bool,
 ) -> Result<(), String> {
     use tauri::{Manager, WebviewUrl, WebviewWindowBuilder};
@@ -569,7 +579,7 @@ pub(crate) fn open_waveform_window(
     // recorder UI, so the pill never flashes over it. The window is still
     // created visible for getUserMedia; only its painting is suppressed.
     let pill_hidden = !crate::recorder_pill::should_show_now(app);
-    let url = waveform_url(meeting_id, auto, pill_hidden);
+    let url = waveform_url(meeting_id, auto, pill_hidden, local_append_id.as_deref());
     let win = WebviewWindowBuilder::new(app, "waveform", WebviewUrl::App(url.into()))
         .title("")
         // Fixed size: room for the expanded pill plus its CSS shadow. The pill
@@ -675,11 +685,12 @@ async fn ensure_recording_allowed(app: &tauri::AppHandle) -> bool {
 pub async fn start_recording_window(
     app: tauri::AppHandle,
     meeting_id: Option<i64>,
+    local_append_id: Option<String>,
 ) -> Result<(), String> {
     if !ensure_recording_allowed(&app).await {
         return Err("sign-in required".to_string());
     }
-    open_waveform_window(&app, meeting_id, false)
+    open_waveform_window(&app, meeting_id, local_append_id, false)
 }
 
 /// Show/focus the meeting-picker window, building it if absent. Shared by the
@@ -1270,14 +1281,23 @@ mod tests {
 
     #[test]
     fn waveform_url_appends_flags_with_correct_separators() {
-        assert_eq!(waveform_url(None, false, false), "/#/waveform");
-        assert_eq!(waveform_url(Some(42), false, false), "/#/waveform?meetingId=42");
-        // First flag uses `?`, the second uses `&`.
-        assert_eq!(waveform_url(None, true, true), "/#/waveform?auto=1&pillHidden=1");
-        assert_eq!(waveform_url(None, false, true), "/#/waveform?pillHidden=1");
+        assert_eq!(waveform_url(None, false, false, None), "/#/waveform");
+        assert_eq!(waveform_url(Some(42), false, false, None), "/#/waveform?meetingId=42");
+        assert_eq!(waveform_url(None, true, false, None), "/#/waveform?auto=1");
+        assert_eq!(waveform_url(None, true, true, None), "/#/waveform?auto=1&pillHidden=1");
+        assert_eq!(waveform_url(None, false, true, None), "/#/waveform?pillHidden=1");
         assert_eq!(
-            waveform_url(Some(7), true, true),
+            waveform_url(Some(7), true, true, None),
             "/#/waveform?meetingId=7&auto=1&pillHidden=1"
+        );
+        // Local continue: the append target id rides on the URL like the flags.
+        assert_eq!(
+            waveform_url(None, false, false, Some("2026-06-02T10-00-00Z")),
+            "/#/waveform?localAppendId=2026-06-02T10-00-00Z"
+        );
+        assert_eq!(
+            waveform_url(None, true, false, Some("abc")),
+            "/#/waveform?localAppendId=abc&auto=1"
         );
     }
 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -696,7 +696,10 @@ pub async fn start_recording_window(
 /// Show/focus the meeting-picker window, building it if absent. Shared by the
 /// tray (Ariso path) and the `open_meeting_picker` command so both open the
 /// picker identically.
-pub(crate) fn open_meeting_picker_window(app: &tauri::AppHandle) -> Result<(), String> {
+pub(crate) fn open_meeting_picker_window(
+    app: &tauri::AppHandle,
+    default_meeting_id: Option<i64>,
+) -> Result<(), String> {
     use tauri::{WebviewUrl, WebviewWindowBuilder};
 
     if let Some(picker) = app.get_webview_window("meeting-picker") {
@@ -704,7 +707,11 @@ pub(crate) fn open_meeting_picker_window(app: &tauri::AppHandle) -> Result<(), S
         let _ = picker.set_focus();
         return Ok(());
     }
-    WebviewWindowBuilder::new(app, "meeting-picker", WebviewUrl::App("/#/meeting-picker".into()))
+    let route = match default_meeting_id {
+        Some(id) => format!("/#/meeting-picker?defaultMeetingId={id}"),
+        None => "/#/meeting-picker".to_string(),
+    };
+    WebviewWindowBuilder::new(app, "meeting-picker", WebviewUrl::App(route.into()))
         .title("Select a meeting")
         .inner_size(400.0, 500.0)
         .resizable(false)
@@ -718,11 +725,14 @@ pub(crate) fn open_meeting_picker_window(app: &tauri::AppHandle) -> Result<(), S
 /// Open (or focus) the meeting-picker window. Invoked by the library's
 /// start-recording button for picker-using backends.
 #[tauri::command]
-pub async fn open_meeting_picker(app: tauri::AppHandle) -> Result<(), String> {
+pub async fn open_meeting_picker(
+    app: tauri::AppHandle,
+    default_meeting_id: Option<i64>,
+) -> Result<(), String> {
     if !ensure_recording_allowed(&app).await {
         return Err("sign-in required".to_string());
     }
-    open_meeting_picker_window(&app)
+    open_meeting_picker_window(&app, default_meeting_id)
 }
 
 /// PUT binary data to a presigned URL (bypasses CORS via native HTTP client)

--- a/src-tauri/src/mic_monitor.rs
+++ b/src-tauri/src/mic_monitor.rs
@@ -331,7 +331,9 @@ async fn run_loop(app: AppHandle) {
                             let app_main = app2.clone();
                             let _ = app2.run_on_main_thread(move || {
                                 if let Err(e) =
-                                    crate::commands::open_waveform_window(&app_main, None, true)
+                                    crate::commands::open_waveform_window(
+                                        &app_main, None, None, true,
+                                    )
                                 {
                                     eprintln!("mic-monitor: failed to open recorder window: {e}");
                                 }

--- a/src-tauri/src/transcribe.rs
+++ b/src-tauri/src/transcribe.rs
@@ -215,7 +215,15 @@ pub async fn finalize_core_with_target(
     append_to: Option<String>,
 ) -> Result<(FinalizeResult, JoinHandle<()>), String> {
     if let Some(target_id) = append_to {
-        return append_recording_core(root, &target_id, audio, title, created_at, duration_seconds).await;
+        // Defense-in-depth: an explicit append target is externally influenced
+        // (round-trips through the recorder window URL). Reject ids that could
+        // escape the recordings dir before joining to a path — mirrors
+        // validate_recording_id use in retry_transcription_core. Fall back to a
+        // fresh recording (audio is never lost) rather than erroring.
+        if storage::validate_recording_id(&target_id).is_ok() {
+            return append_recording_core(root, &target_id, audio, title, created_at, duration_seconds).await;
+        }
+        return fresh_recording_core(root, audio, title, created_at, duration_seconds).await;
     }
     match storage::most_recent_appendable(root, &created_at)? {
         Some(target_id) => {
@@ -1191,6 +1199,31 @@ mod tests {
         let (r, h) = finalize_core_with_target(
             tmp.path(), b"bbb".to_vec(), "T".into(), "2026-06-02T10:01:00.000Z".into(), 15,
             Some("2026-01-01T00-00-00Z".into()),
+        ).await.unwrap();
+        h.await.unwrap();
+        unsafe { std::env::remove_var("ARISO_STT_BIN"); }
+
+        assert_eq!(r.id, "2026-06-02T10-01-00Z");
+        assert_eq!(r.status, RecordingStatus::Done);
+        let dir = crate::storage::recordings_dir(tmp.path()).join(&r.id);
+        assert_eq!(crate::vault::read_audio(
+            crate::storage::read_meta(&dir).unwrap().audio_file.as_ref().unwrap()).unwrap(), b"bbb");
+        unsafe { std::env::remove_var("ARISO_ROOT"); }
+    }
+
+    #[tokio::test]
+    async fn forced_append_rejects_invalid_target_id_and_falls_back_to_fresh() {
+        let tmp = tempfile::tempdir().unwrap();
+        let stub = clip_stub(tmp.path());
+        unsafe { std::env::set_var("ARISO_STT_BIN", &stub); }
+        unsafe { std::env::set_var("ARISO_ROOT", tmp.path()); }
+
+        // A traversal-shaped target id must never be joined to a path; it
+        // degrades to a fresh recording keyed by the clip's own created_at,
+        // same as an explicit target that fails validate_recording_id.
+        let (r, h) = finalize_core_with_target(
+            tmp.path(), b"bbb".to_vec(), "T".into(), "2026-06-02T10:01:00.000Z".into(), 15,
+            Some("../evil".into()),
         ).await.unwrap();
         h.await.unwrap();
         unsafe { std::env::remove_var("ARISO_STT_BIN"); }

--- a/src-tauri/src/transcribe.rs
+++ b/src-tauri/src/transcribe.rs
@@ -199,6 +199,24 @@ pub async fn finalize_core(
     created_at: String,
     duration_seconds: u64,
 ) -> Result<(FinalizeResult, JoinHandle<()>), String> {
+    finalize_core_with_target(root, audio, title, created_at, duration_seconds, None).await
+}
+
+/// Like [`finalize_core`], but an explicit `append_to` forces the clip to append
+/// to that recording id, bypassing the time-window auto-append decision (used by
+/// the "Continue this meeting" flow). `append_recording_core` still re-validates
+/// the target is `Done` with audio and falls back to a fresh recording otherwise.
+pub async fn finalize_core_with_target(
+    root: &Path,
+    audio: Vec<u8>,
+    title: String,
+    created_at: String,
+    duration_seconds: u64,
+    append_to: Option<String>,
+) -> Result<(FinalizeResult, JoinHandle<()>), String> {
+    if let Some(target_id) = append_to {
+        return append_recording_core(root, &target_id, audio, title, created_at, duration_seconds).await;
+    }
     match storage::most_recent_appendable(root, &created_at)? {
         Some(target_id) => {
             append_recording_core(root, &target_id, audio, title, created_at, duration_seconds).await
@@ -581,11 +599,12 @@ pub async fn local_finalize_recording(
     title: String,
     created_at: String,
     duration_seconds: u64,
+    append_to: Option<String>,
 ) -> Result<FinalizeResult, String> {
     let root = storage::ariso_root()?;
     // Drop the notes JoinHandle: notes are best-effort and continue running
     // in the background, writing their outcome to meta.json directly.
-    finalize_core(&root, audio, title, created_at, duration_seconds)
+    finalize_core_with_target(&root, audio, title, created_at, duration_seconds, append_to)
         .await
         .map(|(res, _notes)| res)
 }
@@ -1120,6 +1139,68 @@ mod tests {
         let count = std::fs::read_dir(crate::storage::recordings_dir(tmp.path())).unwrap()
             .filter(|e| e.as_ref().unwrap().path().is_dir()).count();
         assert_eq!(count, 2);
+    }
+
+    #[tokio::test]
+    async fn forced_append_outside_window_appends_to_target() {
+        let tmp = tempfile::tempdir().unwrap();
+        let stub = clip_stub(tmp.path());
+        unsafe { std::env::set_var("ARISO_STT_BIN", &stub); }
+        unsafe { std::env::set_var("ARISO_ROOT", tmp.path()); }
+
+        // First recording: 30s, ends 10:00:30.
+        let (r1, h1) = finalize_core(
+            tmp.path(), b"aaa".to_vec(), "T".into(), "2026-06-02T10:00:00.000Z".into(), 30,
+        ).await.unwrap();
+        h1.await.unwrap();
+
+        // Second recording 20 minutes later — WELL outside the 5-min auto window —
+        // but with an explicit append target, it must still append to r1.
+        let (r2, h2) = finalize_core_with_target(
+            tmp.path(), b"bbb".to_vec(), "T2".into(), "2026-06-02T10:20:00.000Z".into(), 15,
+            Some(r1.id.clone()),
+        ).await.unwrap();
+        h2.await.unwrap();
+        unsafe { std::env::remove_var("ARISO_STT_BIN"); }
+
+        assert_eq!(r2.id, r1.id, "forced append must merge into the target");
+        let dir = crate::storage::recordings_dir(tmp.path()).join(&r1.id);
+        let seg = crate::storage::read_segments(&dir).unwrap().unwrap();
+        assert_eq!(seg.segments.len(), 2, "both clips stitched");
+        let meta = crate::storage::read_meta(&dir).unwrap();
+        assert_eq!(meta.duration_seconds, 45);
+        assert_eq!(
+            crate::vault::read_audio(meta.audio_file.as_ref().unwrap()).unwrap(),
+            b"aaabbb",
+        );
+        let count = std::fs::read_dir(crate::storage::recordings_dir(tmp.path())).unwrap()
+            .filter(|e| e.as_ref().unwrap().path().is_dir()).count();
+        assert_eq!(count, 1, "no second recording directory");
+        unsafe { std::env::remove_var("ARISO_ROOT"); }
+    }
+
+    #[tokio::test]
+    async fn forced_append_to_missing_target_falls_back_to_fresh() {
+        let tmp = tempfile::tempdir().unwrap();
+        let stub = clip_stub(tmp.path());
+        unsafe { std::env::set_var("ARISO_STT_BIN", &stub); }
+        unsafe { std::env::set_var("ARISO_ROOT", tmp.path()); }
+
+        // No such target on disk → append_recording_core re-validates and falls
+        // back to a fresh recording keyed by the clip's own created_at.
+        let (r, h) = finalize_core_with_target(
+            tmp.path(), b"bbb".to_vec(), "T".into(), "2026-06-02T10:01:00.000Z".into(), 15,
+            Some("2026-01-01T00-00-00Z".into()),
+        ).await.unwrap();
+        h.await.unwrap();
+        unsafe { std::env::remove_var("ARISO_STT_BIN"); }
+
+        assert_eq!(r.id, "2026-06-02T10-01-00Z");
+        assert_eq!(r.status, RecordingStatus::Done);
+        let dir = crate::storage::recordings_dir(tmp.path()).join(&r.id);
+        assert_eq!(crate::vault::read_audio(
+            crate::storage::read_meta(&dir).unwrap().audio_file.as_ref().unwrap()).unwrap(), b"bbb");
+        unsafe { std::env::remove_var("ARISO_ROOT"); }
     }
 
     #[tokio::test]

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -102,7 +102,7 @@ pub fn create_tray(app: &AppHandle) -> tauri::Result<()> {
                                     return;
                                 }
                                 let _ = crate::commands::open_waveform_window(
-                                    &app_main, None, false,
+                                    &app_main, None, None, false,
                                 );
                             });
                             return;
@@ -157,6 +157,7 @@ pub fn create_tray(app: &AppHandle) -> tauri::Result<()> {
                             let _ = crate::commands::open_waveform_window(
                                 &app_main,
                                 Some(meeting_id),
+                                None,
                                 false,
                             );
                         });

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -120,7 +120,7 @@ pub fn create_tray(app: &AppHandle) -> tauri::Result<()> {
                                 let _ = app_main.emit("tray://show-sign-in-prompt", ());
                                 return;
                             }
-                            let _ = crate::commands::open_meeting_picker_window(&app_main);
+                            let _ = crate::commands::open_meeting_picker_window(&app_main, None);
                         });
                     });
                 }

--- a/src/composables/decideStartRecording.test.ts
+++ b/src/composables/decideStartRecording.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { decideStartRecording } from './decideStartRecording';
+
+describe('decideStartRecording', () => {
+  it('returns default when no meeting is deliberately open', () => {
+    expect(decideStartRecording({ usesPicker: true, openMeeting: null })).toEqual({ kind: 'default' });
+    expect(decideStartRecording({ usesPicker: false, openMeeting: null })).toEqual({ kind: 'default' });
+  });
+
+  it('local backend with an open meeting → choice dialog for that recording', () => {
+    expect(
+      decideStartRecording({
+        usesPicker: false,
+        openMeeting: { id: '2026-06-02T10-00-00Z', title: 'Standup', numericId: undefined },
+      })
+    ).toEqual({ kind: 'local-choice', meetingTitle: 'Standup', localRecordingId: '2026-06-02T10-00-00Z' });
+  });
+
+  it('ariso backend with a numeric open meeting → picker defaulted to it', () => {
+    expect(
+      decideStartRecording({
+        usesPicker: true,
+        openMeeting: { id: '50', title: 'Sync', numericId: 50 },
+      })
+    ).toEqual({ kind: 'ariso-picker', defaultMeetingId: 50 });
+  });
+
+  it('ariso backend with a non-numeric open meeting → picker with no default', () => {
+    expect(
+      decideStartRecording({
+        usesPicker: true,
+        openMeeting: { id: 'draft', title: 'Draft', numericId: undefined },
+      })
+    ).toEqual({ kind: 'ariso-picker', defaultMeetingId: null });
+  });
+});

--- a/src/composables/decideStartRecording.ts
+++ b/src/composables/decideStartRecording.ts
@@ -1,0 +1,33 @@
+// Decide what the Library "Start recording" button does when a meeting is
+// deliberately open in the detail pane. Pure and side-effect free so the
+// branching is unit-tested without mounting the view or stubbing Tauri.
+
+export type StartRecordingPlan =
+  | { kind: 'default' }
+  | { kind: 'ariso-picker'; defaultMeetingId: number | null }
+  | { kind: 'local-choice'; meetingTitle: string; localRecordingId: string };
+
+export interface StartRecordingInput {
+  /** Whether the active backend chooses meetings via the picker (Ariso). */
+  usesPicker: boolean;
+  /** The meeting the user deliberately opened, else null. `numericId` is the
+   *  backend meeting id for Ariso rows (undefined when the id isn't numeric). */
+  openMeeting: { id: string; title: string; numericId: number | undefined } | null;
+}
+
+export function decideStartRecording(input: StartRecordingInput): StartRecordingPlan {
+  // No deliberately-open meeting: keep today's start behavior (decideRecordingAction).
+  if (!input.openMeeting) return { kind: 'default' };
+
+  // Ariso: open the picker featuring the open meeting as the default choice.
+  if (input.usesPicker) {
+    return { kind: 'ariso-picker', defaultMeetingId: input.openMeeting.numericId ?? null };
+  }
+
+  // Local: offer Continue-this-recording vs New.
+  return {
+    kind: 'local-choice',
+    meetingTitle: input.openMeeting.title,
+    localRecordingId: input.openMeeting.id,
+  };
+}

--- a/src/composables/parseDefaultMeetingId.test.ts
+++ b/src/composables/parseDefaultMeetingId.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest';
+import { parseDefaultMeetingId } from './parseDefaultMeetingId';
+
+describe('parseDefaultMeetingId', () => {
+  it('reads a numeric defaultMeetingId from the hash query', () => {
+    expect(parseDefaultMeetingId('#/meeting-picker?defaultMeetingId=50')).toBe(50);
+    expect(parseDefaultMeetingId('#/meeting-picker?foo=1&defaultMeetingId=7')).toBe(7);
+  });
+  it('returns null when absent or not a positive integer', () => {
+    expect(parseDefaultMeetingId('#/meeting-picker')).toBeNull();
+    expect(parseDefaultMeetingId('#/meeting-picker?defaultMeetingId=abc')).toBeNull();
+    expect(parseDefaultMeetingId('')).toBeNull();
+  });
+});

--- a/src/composables/parseDefaultMeetingId.test.ts
+++ b/src/composables/parseDefaultMeetingId.test.ts
@@ -10,5 +10,6 @@ describe('parseDefaultMeetingId', () => {
     expect(parseDefaultMeetingId('#/meeting-picker')).toBeNull();
     expect(parseDefaultMeetingId('#/meeting-picker?defaultMeetingId=abc')).toBeNull();
     expect(parseDefaultMeetingId('')).toBeNull();
+    expect(parseDefaultMeetingId('#/meeting-picker?defaultMeetingId=0')).toBeNull();
   });
 });

--- a/src/composables/parseDefaultMeetingId.ts
+++ b/src/composables/parseDefaultMeetingId.ts
@@ -6,7 +6,7 @@ export function parseDefaultMeetingId(hash: string): number | null {
   if (qIndex < 0) return null;
   const params = new URLSearchParams(hash.slice(qIndex + 1));
   const raw = params.get('defaultMeetingId');
-  if (raw == null || !/^\d+$/.test(raw)) return null;
+  if (raw == null || !/^[1-9]\d*$/.test(raw)) return null;
   const n = Number(raw);
   return Number.isSafeInteger(n) ? n : null;
 }

--- a/src/composables/parseDefaultMeetingId.ts
+++ b/src/composables/parseDefaultMeetingId.ts
@@ -1,0 +1,12 @@
+// Read the picker's `defaultMeetingId` from a location hash like
+// `#/meeting-picker?defaultMeetingId=50`. Router-free so the picker (which does
+// not use vue-router) stays testable via window.location.hash.
+export function parseDefaultMeetingId(hash: string): number | null {
+  const qIndex = hash.indexOf('?');
+  if (qIndex < 0) return null;
+  const params = new URLSearchParams(hash.slice(qIndex + 1));
+  const raw = params.get('defaultMeetingId');
+  if (raw == null || !/^\d+$/.test(raw)) return null;
+  const n = Number(raw);
+  return Number.isSafeInteger(n) ? n : null;
+}

--- a/src/composables/useBackend.ts
+++ b/src/composables/useBackend.ts
@@ -20,6 +20,9 @@ export interface RecordingMeta {
   endAt: string;
   durationSeconds: number;
   meetingId?: number;
+  /** Local "Continue this meeting": append into this existing recording id,
+   *  bypassing the 5-minute auto-append window. */
+  localAppendId?: string;
 }
 
 export interface FinalizeResult {
@@ -398,7 +401,8 @@ export class LocalBackend implements Backend {
       bytes,
       timestampTitle(createdAt),
       createdAt,
-      meta.durationSeconds
+      meta.durationSeconds,
+      meta.localAppendId
     );
     return { backend: 'local', ...res };
   }

--- a/src/composables/useRecordingStartChoice.test.ts
+++ b/src/composables/useRecordingStartChoice.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { useRecordingStartChoice } from './useRecordingStartChoice';
+
+describe('useRecordingStartChoice', () => {
+  it('opens on request and resolves to the chosen kind', async () => {
+    const c = useRecordingStartChoice();
+    const p = c.requestChoice('Standup');
+    expect(c.open.value).toBe(true);
+    expect(c.meetingTitle.value).toBe('Standup');
+    c.choose('continue');
+    await expect(p).resolves.toBe('continue');
+    expect(c.open.value).toBe(false);
+  });
+
+  it('resolves to "new" and to null on cancel', async () => {
+    const c = useRecordingStartChoice();
+    const p1 = c.requestChoice('A');
+    c.choose('new');
+    await expect(p1).resolves.toBe('new');
+    const p2 = c.requestChoice('B');
+    c.cancel();
+    await expect(p2).resolves.toBeNull();
+  });
+
+  it('supersedes an in-flight request with null', async () => {
+    const c = useRecordingStartChoice();
+    const p1 = c.requestChoice('A');
+    const p2 = c.requestChoice('B');
+    await expect(p1).resolves.toBeNull();
+    c.choose('continue');
+    await expect(p2).resolves.toBe('continue');
+  });
+});

--- a/src/composables/useRecordingStartChoice.ts
+++ b/src/composables/useRecordingStartChoice.ts
@@ -1,0 +1,45 @@
+import { ref, type Ref } from 'vue';
+
+export type StartChoice = 'continue' | 'new';
+
+/**
+ * Drives a single "New vs Continue" choice dialog. `requestChoice(title)` opens
+ * the dialog and resolves to the user's choice (or null if cancelled/superseded).
+ * One prompt is live at a time — a new request supersedes any in-flight one
+ * (resolving it null). Mirrors `useAriJoinConfirm`, but three-way.
+ */
+export function useRecordingStartChoice(): {
+  open: Ref<boolean>;
+  meetingTitle: Ref<string>;
+  requestChoice(title: string): Promise<StartChoice | null>;
+  choose(kind: StartChoice): void;
+  cancel(): void;
+} {
+  const open = ref(false);
+  const meetingTitle = ref('');
+  let resolver: ((v: StartChoice | null) => void) | null = null;
+
+  function settle(value: StartChoice | null): void {
+    open.value = false;
+    const r = resolver;
+    resolver = null;
+    r?.(value);
+  }
+
+  function requestChoice(title: string): Promise<StartChoice | null> {
+    settle(null); // supersede any in-flight prompt
+    meetingTitle.value = title;
+    open.value = true;
+    return new Promise<StartChoice | null>((resolve) => {
+      resolver = resolve;
+    });
+  }
+
+  return {
+    open,
+    meetingTitle,
+    requestChoice,
+    choose: (kind: StartChoice) => settle(kind),
+    cancel: () => settle(null),
+  };
+}

--- a/src/tauri.finalize.test.ts
+++ b/src/tauri.finalize.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const invoke = vi.fn(() => Promise.resolve({ backend: 'local', id: 'x', title: 't', status: 'done' }));
+vi.mock('@tauri-apps/api/core', () => ({ invoke: (...a: unknown[]) => invoke(...a) }));
+
+import { local } from './tauri';
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('local.finalizeRecording', () => {
+  it('forwards appendTo to the local_finalize_recording command', async () => {
+    await local.finalizeRecording([1, 2], 'Title', '2026-06-02T10:00:00Z', 12, '2026-06-01T09-00-00Z');
+    expect(invoke).toHaveBeenCalledWith('local_finalize_recording', {
+      audio: [1, 2],
+      title: 'Title',
+      createdAt: '2026-06-02T10:00:00Z',
+      durationSeconds: 12,
+      appendTo: '2026-06-01T09-00-00Z',
+    });
+  });
+
+  it('omits appendTo (undefined) for a normal new recording', async () => {
+    await local.finalizeRecording([1], 'T', '2026-06-02T10:00:00Z', 5);
+    expect(invoke).toHaveBeenCalledWith('local_finalize_recording', {
+      audio: [1], title: 'T', createdAt: '2026-06-02T10:00:00Z', durationSeconds: 5, appendTo: undefined,
+    });
+  });
+});

--- a/src/tauri.ts
+++ b/src/tauri.ts
@@ -210,13 +210,15 @@ export const local = {
     audio: number[],
     title: string,
     createdAt: string,
-    durationSeconds: number
+    durationSeconds: number,
+    appendTo?: string
   ): Promise<LocalFinalizeResult> {
     return invoke<LocalFinalizeResult>('local_finalize_recording', {
       audio,
       title,
       createdAt,
       durationSeconds,
+      appendTo,
     });
   },
   listRecordings(): Promise<RecordingSummary[]> {

--- a/src/views/LibraryView.test.ts
+++ b/src/views/LibraryView.test.ts
@@ -723,7 +723,7 @@ describe('LibraryView', () => {
     expect(invoke).toHaveBeenCalledWith('open_meeting_picker', {});
   });
 
-  it('Today view records a deliberately selected today meeting (override beats the live one)', async () => {
+  it('Today view opens the picker defaulted to a deliberately selected today meeting', async () => {
     backendId.mockReturnValue('ariso');
     usesMeetingPicker.mockReturnValue(true);
     const start = new Date(Date.now() - 30 * 60_000).toISOString();
@@ -744,8 +744,8 @@ describe('LibraryView', () => {
     await flushPromises();
     await wrapper.get('.add-btn').trigger('click');
     await flushPromises();
-    expect(invoke).toHaveBeenCalledWith('start_recording_window', { meetingId: 50 });
-    expect(invoke).not.toHaveBeenCalledWith('start_recording_window', { meetingId: 99 });
+    expect(invoke).toHaveBeenCalledWith('open_meeting_picker', { defaultMeetingId: 50 });
+    expect(invoke).not.toHaveBeenCalledWith('start_recording_window', { meetingId: 50 });
   });
 
   it('falls back to the meeting picker when the selected scheduled meeting id is not numeric', async () => {
@@ -1212,5 +1212,66 @@ describe('LibraryView', () => {
 
     expect(wrapper.text()).not.toContain('Ari is scheduled to join this meeting');
     expect(invoke).toHaveBeenCalledWith('start_recording_window', { meetingId: 7 });
+  });
+
+  it('local: deliberately opening a meeting then Start offers Continue, which appends', async () => {
+    backendId.mockReturnValue('local');
+    usesMeetingPicker.mockReturnValue(false);
+    listMeetings.mockResolvedValue([
+      item({ id: '2026-06-02T10-00-00Z', title: 'Standup' }),
+      item({ id: '2026-06-01T09-00-00Z', title: 'Older' }),
+    ]);
+    const wrapper = mountWithDetailStub();
+    await flushPromises();
+
+    // Deliberately select the first meeting (a user click, not the auto-select).
+    const target = wrapper.findAll('.meeting-item').find((r) => r.text().includes('Standup'))!;
+    await target.trigger('click');
+    await flushPromises();
+
+    await wrapper.get('.add-btn').trigger('click');
+    await flushPromises();
+    // Dialog appears; no recording started yet.
+    expect(wrapper.find('.rec-choice').exists()).toBe(true);
+    expect(invoke).not.toHaveBeenCalledWith('start_recording_window', expect.anything());
+
+    await wrapper.find('.rec-choice__continue').trigger('click');
+    await flushPromises();
+    expect(invoke).toHaveBeenCalledWith('start_recording_window', {
+      localAppendId: '2026-06-02T10-00-00Z',
+    });
+  });
+
+  it('local: choosing New from the dialog starts an ad-hoc recording', async () => {
+    backendId.mockReturnValue('local');
+    usesMeetingPicker.mockReturnValue(false);
+    listMeetings.mockResolvedValue([item({ id: '2026-06-02T10-00-00Z', title: 'Standup' })]);
+    const wrapper = mountWithDetailStub();
+    await flushPromises();
+    const target = wrapper.findAll('.meeting-item').find((r) => r.text().includes('Standup'))!;
+    await target.trigger('click');
+    await flushPromises();
+    await wrapper.get('.add-btn').trigger('click');
+    await flushPromises();
+    await wrapper.find('.rec-choice__new').trigger('click');
+    await flushPromises();
+    expect(invoke).toHaveBeenCalledWith('start_recording_window', {});
+  });
+
+  it('ariso: deliberately opening a meeting then Start opens the picker defaulted to it', async () => {
+    backendId.mockReturnValue('ariso');
+    usesMeetingPicker.mockReturnValue(true);
+    listMeetings.mockResolvedValue([
+      item({ id: '42', title: 'Daily Plan', files: undefined }),
+      item({ id: '7', title: 'Other Sync', files: undefined }),
+    ]);
+    const wrapper = mountWithDetailStub();
+    await flushPromises();
+    const target = wrapper.findAll('.meeting-item').find((r) => r.text().includes('Daily Plan'))!;
+    await target.trigger('click');
+    await flushPromises();
+    await wrapper.get('.add-btn').trigger('click');
+    await flushPromises();
+    expect(invoke).toHaveBeenCalledWith('open_meeting_picker', { defaultMeetingId: 42 });
   });
 });

--- a/src/views/LibraryView.vue
+++ b/src/views/LibraryView.vue
@@ -162,6 +162,13 @@
       @confirm="ariConfirm.confirm"
       @cancel="ariConfirm.cancel"
     />
+    <RecordingStartChoiceDialog
+      :open="recordingStartChoice.open.value"
+      :meeting-title="recordingStartChoice.meetingTitle.value"
+      @continue="recordingStartChoice.choose('continue')"
+      @new="recordingStartChoice.choose('new')"
+      @cancel="recordingStartChoice.cancel"
+    />
   </div>
 </template>
 
@@ -189,6 +196,9 @@ import { decideRecordingAction } from '../composables/decideRecordingAction';
 import { shouldConfirmAriJoin } from '../composables/autoJoin';
 import { useAriJoinConfirm } from '../composables/useAriJoinConfirm';
 import AriJoinConfirmDialog from './AriJoinConfirmDialog.vue';
+import { decideStartRecording } from '../composables/decideStartRecording';
+import { useRecordingStartChoice } from '../composables/useRecordingStartChoice';
+import RecordingStartChoiceDialog from './RecordingStartChoiceDialog.vue';
 
 const meetings = ref<MeetingListItem[]>([]);
 const loading = ref(true);
@@ -200,6 +210,7 @@ const selectedItem = ref<MeetingListItem | null>(null);
 // selections must not override Today's "record the live meeting" behavior.
 const userSelectedMeetingId = ref<string | null>(null);
 const ariConfirm = useAriJoinConfirm();
+const recordingStartChoice = useRecordingStartChoice();
 const activeBackend = ref<Backend | null>(null);
 const searchPaletteOpen = ref(false);
 type MeetingDetailViewExposed = InstanceType<typeof MeetingDetailView> & {
@@ -556,6 +567,42 @@ async function startRecording(): Promise<void> {
   try {
     const backend = await getActiveBackend();
     const usesPicker = backend.usesMeetingPicker;
+
+    // The gate only applies to a meeting the user DELIBERATELY opened — an
+    // auto-selected-on-mount row must not trigger it, so Today's "record the
+    // live meeting" behavior is preserved.
+    const open =
+      selectedItem.value && userSelectedMeetingId.value === selectedItem.value.id
+        ? selectedItem.value
+        : null;
+
+    const plan = decideStartRecording({
+      usesPicker,
+      openMeeting: open
+        ? { id: open.id, title: open.title, numericId: numericMeetingId(open) }
+        : null,
+    });
+
+    if (plan.kind === 'ariso-picker') {
+      // Ariso: open the picker with the open meeting featured as default.
+      const args = plan.defaultMeetingId != null ? { defaultMeetingId: plan.defaultMeetingId } : {};
+      await invoke('open_meeting_picker', args);
+      return;
+    }
+
+    if (plan.kind === 'local-choice') {
+      const choice = await recordingStartChoice.requestChoice(plan.meetingTitle);
+      if (choice === 'continue') {
+        await invoke('start_recording_window', { localAppendId: plan.localRecordingId });
+        setRecording(true);
+      } else if (choice === 'new') {
+        await invoke('start_recording_window', {});
+        setRecording(true);
+      }
+      return;
+    }
+
+    // plan.kind === 'default': no deliberately-open meeting — today's behavior.
     const selectedTodayId =
       usesPicker &&
       activeView.value === 'today' &&

--- a/src/views/MeetingPickerView.test.ts
+++ b/src/views/MeetingPickerView.test.ts
@@ -5,12 +5,14 @@ import { mount, flushPromises, enableAutoUnmount } from '@vue/test-utils';
 const invoke = vi.fn(() => Promise.resolve());
 const listScheduledMeetings = vi.fn(() => Promise.resolve([] as unknown[]));
 const createAudioMeeting = vi.fn(() => Promise.resolve({ meetingId: 77 }));
+const getMeetingNotes = vi.fn(() => Promise.resolve({ id: 5, title: 'Past Sync', start_at: '2026-06-01T09:00:00Z' }));
 
 vi.mock('@tauri-apps/api/core', () => ({ invoke: (...a: unknown[]) => invoke(...a) }));
 vi.mock('../composables/useMeetingApi', () => ({
   useMeetingApi: () => ({
     listScheduledMeetings: (...a: unknown[]) => listScheduledMeetings(...a),
     createAudioMeeting: (...a: unknown[]) => createAudioMeeting(...a),
+    getMeetingNotes: (...a: unknown[]) => getMeetingNotes(...a),
   }),
 }));
 
@@ -153,5 +155,26 @@ describe('MeetingPickerView — Ari-join gate', () => {
 
     expect(wrapper.text()).not.toContain('Ari is scheduled to join this meeting');
     expect(invoke).toHaveBeenCalledWith('start_recording_window', { meetingId: 7 });
+  });
+});
+
+describe('MeetingPickerView — forced default from the Library', () => {
+  it('features the default meeting from the hash and records it on click', async () => {
+    listScheduledMeetings.mockResolvedValue([]);
+    getMeetingNotes.mockResolvedValue({ id: 5, title: 'Past Sync', start_at: '2026-06-01T09:00:00Z' });
+    const prevHash = window.location.hash;
+    window.location.hash = '#/meeting-picker?defaultMeetingId=5';
+    try {
+      const wrapper = mount(MeetingPickerView);
+      await flushPromises();
+      expect(getMeetingNotes).toHaveBeenCalledWith(5);
+      expect(wrapper.text()).toContain('Continue meeting');
+      expect(wrapper.text()).toContain('Past Sync');
+      await wrapper.find('.meeting-row').trigger('click');
+      await flushPromises();
+      expect(invoke).toHaveBeenCalledWith('start_recording_window', { meetingId: 5 });
+    } finally {
+      window.location.hash = prevHash;
+    }
   });
 });

--- a/src/views/MeetingPickerView.test.ts
+++ b/src/views/MeetingPickerView.test.ts
@@ -177,4 +177,32 @@ describe('MeetingPickerView — forced default from the Library', () => {
       window.location.hash = prevHash;
     }
   });
+
+  it('"View all" shows the full list instead of a blank screen, and "View less" returns to Continue meeting', async () => {
+    listScheduledMeetings.mockResolvedValue([
+      { id: 9, title: 'Other Meeting', start_at: new Date().toISOString() },
+    ]);
+    getMeetingNotes.mockResolvedValue({ id: 5, title: 'Past Sync', start_at: '2026-06-01T09:00:00Z' });
+    const prevHash = window.location.hash;
+    window.location.hash = '#/meeting-picker?defaultMeetingId=5';
+    try {
+      const wrapper = mount(MeetingPickerView);
+      await flushPromises();
+      expect(wrapper.text()).toContain('Continue meeting');
+
+      await byText(wrapper, 'View all ▾')!.trigger('click');
+      await flushPromises();
+      expect(wrapper.find('.meeting-list').exists()).toBe(true);
+      expect(wrapper.text()).toContain('Other Meeting');
+      expect(wrapper.text()).not.toContain('Continue meeting');
+
+      await byText(wrapper, 'View less ▴')!.trigger('click');
+      await flushPromises();
+      expect(wrapper.text()).toContain('Continue meeting');
+      expect(wrapper.text()).toContain('Past Sync');
+      expect(wrapper.find('.meeting-list').exists()).toBe(false);
+    } finally {
+      window.location.hash = prevHash;
+    }
+  });
 });

--- a/src/views/MeetingPickerView.vue
+++ b/src/views/MeetingPickerView.vue
@@ -13,22 +13,17 @@
     </div>
 
     <template v-else-if="state === 'list'">
-      <!-- Featured default: the meeting the Library asked us to feature (the
-           meeting open in its detail pane), possibly a past meeting. -->
-      <template v-if="forcedDefault && !showAll">
-        <p class="section-label">Continue meeting</p>
-        <button class="meeting-row" :disabled="isChoosing" @click="choose(forcedDefault.id)">
-          <span class="meeting-title">{{ forcedDefault.title || 'Untitled meeting' }}</span>
-          <span class="meeting-time">{{ formatTime(forcedDefault.start_at) }}</span>
-        </button>
-        <button class="link-btn" type="button" @click="showAll = !showAll">
-          {{ showAll ? 'View less ▴' : 'View all ▾' }}
-        </button>
-      </template>
-
-      <template v-if="!forcedDefault">
-        <!-- Collapsed default: a single featured meeting (or a prompt) -->
-        <template v-if="!showAll">
+      <!-- Collapsed default: the forced "Continue" meeting (from the Library),
+           else the heuristic pick. -->
+      <template v-if="!showAll">
+        <template v-if="forcedDefault">
+          <p class="section-label">Continue meeting</p>
+          <button class="meeting-row" :disabled="isChoosing" @click="choose(forcedDefault.id)">
+            <span class="meeting-title">{{ forcedDefault.title || 'Untitled meeting' }}</span>
+            <span class="meeting-time">{{ formatTime(forcedDefault.start_at) }}</span>
+          </button>
+        </template>
+        <template v-else>
           <p v-if="defaultMeeting.kind !== 'none'" class="section-label">
             {{ defaultMeeting.kind === 'current' ? 'Happening now' : 'Up next' }}
           </p>
@@ -43,21 +38,21 @@
           </button>
           <p v-else class="section-label">No meeting happening now</p>
         </template>
-
-        <!-- Expanded: full flat list of today's meetings -->
-        <ul v-else class="meeting-list">
-          <li v-for="m in meetings" :key="m.id">
-            <button class="meeting-row" :disabled="isChoosing" @click="choose(m.id)">
-              <span class="meeting-title">{{ m.title || 'Untitled meeting' }}</span>
-              <span class="meeting-time">{{ formatTime(m.start_at) }}</span>
-            </button>
-          </li>
-        </ul>
-
-        <button class="link-btn" type="button" @click="showAll = !showAll">
-          {{ showAll ? 'View less ▴' : 'View all ▾' }}
-        </button>
       </template>
+
+      <!-- Expanded: full flat list of today's meetings (shared by both cases) -->
+      <ul v-else class="meeting-list">
+        <li v-for="m in meetings" :key="m.id">
+          <button class="meeting-row" :disabled="isChoosing" @click="choose(m.id)">
+            <span class="meeting-title">{{ m.title || 'Untitled meeting' }}</span>
+            <span class="meeting-time">{{ formatTime(m.start_at) }}</span>
+          </button>
+        </li>
+      </ul>
+
+      <button class="link-btn" type="button" @click="showAll = !showAll">
+        {{ showAll ? 'View less ▴' : 'View all ▾' }}
+      </button>
     </template>
 
     <div class="new-meeting">
@@ -241,13 +236,19 @@ onMounted(async () => {
     }
   } catch (err) {
     console.error('Failed to load scheduled meetings:', err);
-    // A forced default still lets the user continue that meeting even if the
-    // today-list fetch failed.
-    if (forcedId != null && forcedDefault.value) {
-      state.value = 'list';
-    } else {
-      state.value = 'error';
+    if (forcedId != null) {
+      // Still let the user continue the intended meeting even if the today-list
+      // fetch failed.
+      try {
+        const notes = await meetingApi.getMeetingNotes(forcedId);
+        forcedDefault.value = { id: forcedId, title: notes.title ?? '', start_at: notes.start_at };
+        state.value = 'list';
+        return;
+      } catch (e) {
+        console.error('Failed to resolve default meeting for picker', e);
+      }
     }
+    state.value = 'error';
   }
 });
 </script>

--- a/src/views/MeetingPickerView.vue
+++ b/src/views/MeetingPickerView.vue
@@ -13,36 +13,51 @@
     </div>
 
     <template v-else-if="state === 'list'">
-      <!-- Collapsed default: a single featured meeting (or a prompt) -->
-      <template v-if="!showAll">
-        <p v-if="defaultMeeting.kind !== 'none'" class="section-label">
-          {{ defaultMeeting.kind === 'current' ? 'Happening now' : 'Up next' }}
-        </p>
-        <button
-          v-if="defaultMeeting.featured"
-          class="meeting-row"
-          :disabled="isChoosing"
-          @click="choose(defaultMeeting.featured.id)"
-        >
-          <span class="meeting-title">{{ defaultMeeting.featured.title || 'Untitled meeting' }}</span>
-          <span class="meeting-time">{{ formatTime(defaultMeeting.featured.start_at) }}</span>
+      <!-- Featured default: the meeting the Library asked us to feature (the
+           meeting open in its detail pane), possibly a past meeting. -->
+      <template v-if="forcedDefault && !showAll">
+        <p class="section-label">Continue meeting</p>
+        <button class="meeting-row" :disabled="isChoosing" @click="choose(forcedDefault.id)">
+          <span class="meeting-title">{{ forcedDefault.title || 'Untitled meeting' }}</span>
+          <span class="meeting-time">{{ formatTime(forcedDefault.start_at) }}</span>
         </button>
-        <p v-else class="section-label">No meeting happening now</p>
+        <button class="link-btn" type="button" @click="showAll = !showAll">
+          {{ showAll ? 'View less ▴' : 'View all ▾' }}
+        </button>
       </template>
 
-      <!-- Expanded: full flat list of today's meetings -->
-      <ul v-else class="meeting-list">
-        <li v-for="m in meetings" :key="m.id">
-          <button class="meeting-row" :disabled="isChoosing" @click="choose(m.id)">
-            <span class="meeting-title">{{ m.title || 'Untitled meeting' }}</span>
-            <span class="meeting-time">{{ formatTime(m.start_at) }}</span>
+      <template v-if="!forcedDefault">
+        <!-- Collapsed default: a single featured meeting (or a prompt) -->
+        <template v-if="!showAll">
+          <p v-if="defaultMeeting.kind !== 'none'" class="section-label">
+            {{ defaultMeeting.kind === 'current' ? 'Happening now' : 'Up next' }}
+          </p>
+          <button
+            v-if="defaultMeeting.featured"
+            class="meeting-row"
+            :disabled="isChoosing"
+            @click="choose(defaultMeeting.featured.id)"
+          >
+            <span class="meeting-title">{{ defaultMeeting.featured.title || 'Untitled meeting' }}</span>
+            <span class="meeting-time">{{ formatTime(defaultMeeting.featured.start_at) }}</span>
           </button>
-        </li>
-      </ul>
+          <p v-else class="section-label">No meeting happening now</p>
+        </template>
 
-      <button class="link-btn" type="button" @click="showAll = !showAll">
-        {{ showAll ? 'View less ▴' : 'View all ▾' }}
-      </button>
+        <!-- Expanded: full flat list of today's meetings -->
+        <ul v-else class="meeting-list">
+          <li v-for="m in meetings" :key="m.id">
+            <button class="meeting-row" :disabled="isChoosing" @click="choose(m.id)">
+              <span class="meeting-title">{{ m.title || 'Untitled meeting' }}</span>
+              <span class="meeting-time">{{ formatTime(m.start_at) }}</span>
+            </button>
+          </li>
+        </ul>
+
+        <button class="link-btn" type="button" @click="showAll = !showAll">
+          {{ showAll ? 'View less ▴' : 'View all ▾' }}
+        </button>
+      </template>
     </template>
 
     <div class="new-meeting">
@@ -92,6 +107,7 @@ import { computed, nextTick, onMounted, ref } from 'vue';
 import { invoke } from '@tauri-apps/api/core';
 import { useMeetingApi, type ScheduledMeeting } from '../composables/useMeetingApi';
 import { pickDefaultMeeting } from '../composables/pickDefaultMeeting';
+import { parseDefaultMeetingId } from '../composables/parseDefaultMeetingId';
 import { arisoTruthy, shouldConfirmAriJoin } from '../composables/autoJoin';
 import { useAriJoinConfirm } from '../composables/useAriJoinConfirm';
 import AriJoinConfirmDialog from './AriJoinConfirmDialog.vue';
@@ -109,6 +125,11 @@ const titleDraft = ref('');
 const createError = ref<string | null>(null);
 const titleInput = ref<HTMLInputElement | null>(null);
 const now = new Date();
+
+// A meeting the Library asked us to feature as the default choice (the meeting
+// open in its detail pane). May be a PAST meeting not in today's list, so its
+// title/time are resolved from getMeetingNotes when the list doesn't carry it.
+const forcedDefault = ref<{ id: number; title: string; start_at: string } | null>(null);
 
 const defaultMeeting = computed(() => pickDefaultMeeting(meetings.value, now));
 
@@ -182,9 +203,32 @@ async function startNewMeeting(): Promise<void> {
 }
 
 onMounted(async () => {
+  const forcedId = parseDefaultMeetingId(window.location.hash);
   try {
     const { startDate, endDate } = todayBoundsLocal();
     const result = await meetingApi.listScheduledMeetings(startDate, endDate);
+    meetings.value = result;
+
+    if (forcedId != null) {
+      // Prefer the already-fetched today entry; else fetch the (possibly past)
+      // meeting's title + start so we can feature it.
+      const inList = result.find((m) => m.id === forcedId);
+      if (inList) {
+        forcedDefault.value = { id: inList.id, title: inList.title ?? '', start_at: inList.start_at };
+      } else {
+        try {
+          const notes = await meetingApi.getMeetingNotes(forcedId);
+          forcedDefault.value = { id: forcedId, title: notes.title ?? '', start_at: notes.start_at };
+        } catch (e) {
+          console.error('Failed to resolve default meeting for picker', e);
+        }
+      }
+      // With a forced default we always show the list surface (never the
+      // empty→prompt dead-end), so Continue + "Record a new meeting" both show.
+      state.value = 'list';
+      return;
+    }
+
     if (result.length === 0) {
       // No meetings to choose from — go straight to creating one. The optional
       // title prompt becomes the whole UI instead of a dead-end message.
@@ -193,12 +237,17 @@ onMounted(async () => {
       await nextTick();
       titleInput.value?.focus();
     } else {
-      meetings.value = result;
       state.value = 'list';
     }
   } catch (err) {
     console.error('Failed to load scheduled meetings:', err);
-    state.value = 'error';
+    // A forced default still lets the user continue that meeting even if the
+    // today-list fetch failed.
+    if (forcedId != null && forcedDefault.value) {
+      state.value = 'list';
+    } else {
+      state.value = 'error';
+    }
   }
 });
 </script>

--- a/src/views/RecordingStartChoiceDialog.test.ts
+++ b/src/views/RecordingStartChoiceDialog.test.ts
@@ -1,0 +1,30 @@
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach } from 'vitest';
+import { mount, enableAutoUnmount } from '@vue/test-utils';
+import RecordingStartChoiceDialog from './RecordingStartChoiceDialog.vue';
+
+enableAutoUnmount(afterEach);
+
+describe('RecordingStartChoiceDialog', () => {
+  it('renders the meeting title and emits continue / new / cancel', async () => {
+    const wrapper = mount(RecordingStartChoiceDialog, {
+      props: { open: true, meetingTitle: 'Weekly Sync' },
+    });
+    expect(wrapper.text()).toContain('Weekly Sync');
+
+    await wrapper.find('.rec-choice__continue').trigger('click');
+    await wrapper.find('.rec-choice__new').trigger('click');
+    await wrapper.find('.rec-choice__cancel').trigger('click');
+
+    expect(wrapper.emitted('continue')).toHaveLength(1);
+    expect(wrapper.emitted('new')).toHaveLength(1);
+    expect(wrapper.emitted('cancel')).toHaveLength(1);
+  });
+
+  it('renders nothing when closed', () => {
+    const wrapper = mount(RecordingStartChoiceDialog, {
+      props: { open: false, meetingTitle: 'X' },
+    });
+    expect(wrapper.find('.rec-choice').exists()).toBe(false);
+  });
+});

--- a/src/views/RecordingStartChoiceDialog.vue
+++ b/src/views/RecordingStartChoiceDialog.vue
@@ -64,7 +64,39 @@ defineEmits<{ (e: 'continue'): void; (e: 'new'): void; (e: 'cancel'): void }>();
   justify-content: flex-end;
   gap: 8px;
 }
-.rec-choice__actions button {
+
+/* Button design mirrors Settings' `.primary-btn` / `.secondary-btn` — the app's
+   canonical pill buttons. These classes are scoped per-view in this codebase, so
+   they must be (re)defined here rather than inherited globally. */
+.primary-btn {
+  font-size: 13px;
+  padding: 6px 14px;
+  border-radius: 999px;
+  border: none;
+  background: #1c1c1c;
+  color: white;
+  font-weight: 500;
+  font-family: inherit;
   cursor: pointer;
+}
+.secondary-btn {
+  font-size: 13px;
+  padding: 5px 14px;
+  border-radius: 999px;
+  border: 1px solid #d6d6d6;
+  background: #ffffff;
+  box-shadow: 2px 2px 0 #e7e5e2;
+  color: #1c1c1c;
+  font-family: inherit;
+  cursor: pointer;
+  transition: transform 0.1s, box-shadow 0.1s;
+}
+.secondary-btn:hover:not(:disabled) {
+  box-shadow: 1px 1px 0 #e7e5e2;
+  transform: translate(1px, 1px);
+}
+.secondary-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
 }
 </style>

--- a/src/views/RecordingStartChoiceDialog.vue
+++ b/src/views/RecordingStartChoiceDialog.vue
@@ -14,9 +14,9 @@
       </p>
       <div class="rec-choice__actions">
         <button class="secondary-btn rec-choice__cancel" @click="$emit('cancel')">Cancel</button>
-        <button class="secondary-btn rec-choice__new" @click="$emit('new')">New recording</button>
+        <button class="secondary-btn rec-choice__new" @click="$emit('new')">Start new recording</button>
         <button class="primary-btn rec-choice__continue" @click="$emit('continue')">
-          Continue meeting
+          Continue recording
         </button>
       </div>
     </div>
@@ -63,5 +63,8 @@ defineEmits<{ (e: 'continue'): void; (e: 'new'): void; (e: 'cancel'): void }>();
   display: flex;
   justify-content: flex-end;
   gap: 8px;
+}
+.rec-choice__actions button {
+  cursor: pointer;
 }
 </style>

--- a/src/views/RecordingStartChoiceDialog.vue
+++ b/src/views/RecordingStartChoiceDialog.vue
@@ -14,9 +14,9 @@
       </p>
       <div class="rec-choice__actions">
         <button class="secondary-btn rec-choice__cancel" @click="$emit('cancel')">Cancel</button>
-        <button class="secondary-btn rec-choice__new" @click="$emit('new')">Start new recording</button>
+        <button class="secondary-btn rec-choice__new" @click="$emit('new')">Start new</button>
         <button class="primary-btn rec-choice__continue" @click="$emit('continue')">
-          Continue recording
+          Continue
         </button>
       </div>
     </div>

--- a/src/views/RecordingStartChoiceDialog.vue
+++ b/src/views/RecordingStartChoiceDialog.vue
@@ -1,0 +1,67 @@
+<template>
+  <div
+    v-if="open"
+    class="rec-choice"
+    role="dialog"
+    aria-modal="true"
+    aria-labelledby="rec-choice-title"
+    @click.self="$emit('cancel')"
+  >
+    <div class="rec-choice__card">
+      <h2 id="rec-choice-title" class="rec-choice__title">Start recording</h2>
+      <p class="rec-choice__body">
+        Continue recording "{{ meetingTitle || 'this meeting' }}", or start a new recording?
+      </p>
+      <div class="rec-choice__actions">
+        <button class="secondary-btn rec-choice__cancel" @click="$emit('cancel')">Cancel</button>
+        <button class="secondary-btn rec-choice__new" @click="$emit('new')">New recording</button>
+        <button class="primary-btn rec-choice__continue" @click="$emit('continue')">
+          Continue meeting
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+defineProps<{ open: boolean; meetingTitle: string }>();
+defineEmits<{ (e: 'continue'): void; (e: 'new'): void; (e: 'cancel'): void }>();
+</script>
+
+<style scoped>
+.rec-choice {
+  position: fixed;
+  inset: 0;
+  z-index: 100;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.35);
+  padding: 24px;
+}
+.rec-choice__card {
+  background: #ffffff;
+  border: 1px solid #e5e6e3;
+  border-radius: 12px;
+  padding: 20px;
+  max-width: 380px;
+  box-shadow: 2px 2px 0 #e7e5e2;
+}
+.rec-choice__title {
+  font-size: 16px;
+  font-weight: 700;
+  margin: 0 0 8px;
+  color: #1c1c1c;
+}
+.rec-choice__body {
+  font-size: 13px;
+  color: #6f6f6f;
+  margin: 0 0 16px;
+  line-height: 1.5;
+}
+.rec-choice__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+</style>

--- a/src/views/WaveformView.vue
+++ b/src/views/WaveformView.vue
@@ -154,6 +154,11 @@ const effectiveMeetingId = ref<number | null>(
     ? Number(meetingIdQuery)
     : null,
 );
+const localAppendIdRaw = route.query.localAppendId;
+// When the user chose "Continue this meeting", the Library passes the target
+// local recording id here so finalize appends to it regardless of elapsed time.
+const localAppendId =
+  typeof localAppendIdRaw === 'string' && localAppendIdRaw.length > 0 ? localAppendIdRaw : null;
 const isAuto = route.query.auto === '1';
 // Born hidden when the meetings window is the visible UI: the window must still
 // exist (and stay visible to WebKit so getUserMedia resolves), but the pill
@@ -238,6 +243,11 @@ watch(
     const token = ++idResolveToken;
     if (!startAt || backendId !== 'local') {
       effectiveLocalRecordingId.value = null;
+      return;
+    }
+    if (localAppendId) {
+      // Explicit continue: skip the time-window resolve and dock to the target.
+      effectiveLocalRecordingId.value = localAppendId;
       return;
     }
     try {
@@ -474,6 +484,7 @@ async function handleStop() {
       durationSeconds:
         (prevMeta?.durationSeconds ?? 0) + recorder.durationSeconds.value,
       meetingId: prevMeta?.meetingId ?? effectiveMeetingId.value ?? undefined,
+      localAppendId: prevMeta?.localAppendId ?? localAppendId ?? undefined,
     };
     await runFinalize();
   } else {


### PR DESCRIPTION
<img width="568" height="356" alt="Screenshot 2026-07-06 at 10 45 12" src="https://github.com/user-attachments/assets/e75a14e4-95cf-4b8f-bca8-7c2d2babfb43" />

## Summary

When the user clicks **Start recording** with a meeting deliberately open in the detail pane, they can now choose to **continue that meeting** instead of always starting a new recording:

- **Local (offline) backend** — a two-button dialog: **Continue "‹title›"** (default) appends the new session to that existing local recording, or **New recording** (ad-hoc, unchanged). Continue works even long after the recording ended, force-appending past the normal 5-minute auto-append window.
- **Ariso (cloud) backend** — opens the existing meeting picker with that meeting featured as the default choice (labeled "Continue meeting"), resolving a past meeting's title/time via `getMeetingNotes`. Selecting it attaches a new session (audio clip) to that meeting.

When no meeting is **deliberately** selected, behavior is unchanged — the gate never fires for an auto-selected-on-mount row, so the Today "record the live meeting" flow is preserved.

Closes #174.

## How it works

**Local continue** threads a `localAppendId` end-to-end: `LibraryView.startRecording` → `start_recording_window({ localAppendId })` → waveform window URL → `WaveformView` reads `route.query.localAppendId` → `stoppedMeta` → `local.finalizeRecording(appendTo)` → Rust `local_finalize_recording(append_to)` → new `finalize_core_with_target`, which force-appends via `append_recording_core` (bypassing the time-window auto-append). `finalize_core` keeps its original 5-arg signature and delegates with `None`, so all existing callers/tests are untouched. The append-target id is validated (`validate_recording_id`) before it's joined to a path, falling back to a fresh recording on an invalid id so audio is never lost.

**Ariso default** adds a `defaultMeetingId` param to the `open_meeting_picker` command / picker URL; the picker features that meeting and records it via the existing `start_recording_window({ meetingId })` path.

Branch decision logic lives in small pure, unit-tested units (`decideStartRecording`, `useRecordingStartChoice`, `parseDefaultMeetingId`) that sidestep the heavy-view test surface.

Design + plan: `docs/superpowers/specs/2026-07-05-recording-start-new-vs-continue-design.md`.

## Testing

- **Rust**: full suite 218 passed / 0 failed (incl. new `forced_append_outside_window_appends_to_target`, `forced_append_to_missing_target_falls_back_to_fresh`, `forced_append_rejects_invalid_target_id_and_falls_back_to_fresh`).
- **Frontend (feature specs)**: 23 passed across `decideStartRecording`, `useRecordingStartChoice`, `parseDefaultMeetingId`, `RecordingStartChoiceDialog`, `tauri.finalize`, `MeetingPickerView`. `LibraryView.test.ts` gets one renamed test (deliberately-selected Ariso meeting now opens the picker defaulted to it) plus three new tests (local continue/new, Ariso default) — all passing.

> Note: `LibraryView.test.ts` has 6 pre-existing failures (incomplete `../tauri` mock + jsdom/TipTap gaps) that also fail on `main` — confirmed unrelated to this branch.

## Review

Developed task-by-task with per-task spec+quality review and a final whole-branch review. The one Important finding (unvalidated append-target path) was fixed and re-reviewed. Remaining known minors (non-blocking): a now-unreachable `selectedTodayId` computation left verbatim in the default branch; a failed forced-continue clip retries as a standalone recording (rare, no data loss); missing doc-comment params; picker URL not refreshed if the picker window is already open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Start recording” choice dialog to continue an existing meeting recording or start a new one.
  * The meeting picker can now open pre-filled with a forced default meeting from the URL.
  * Local recordings can now “continue” by explicitly appending to the selected recording, with the correct docking behavior.
* **Bug Fixes**
  * Improved resume/append handling for missing, invalid, or stale targets by safely falling back to a fresh recording.
* **Tests**
  * Added/expanded unit and UI coverage for the new start/continue and forced-default flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->