### PR TITLE
fix: close open meeting when switching backend

### DIFF
--- a/src/composables/useBackend.ts
+++ b/src/composables/useBackend.ts
@@ -10,6 +10,12 @@ import { arisoTruthy } from './autoJoin';
 
 export type BackendId = 'ariso' | 'local';
 
+// Cross-window signal that the active backend setting changed. The switch lives
+// in the Settings window but only writes the shared store, so windows showing
+// backend-specific state (the Library's meeting list/detail) listen for this to
+// drop stale selections and reload against the new backend's corpus.
+export const BACKEND_CHANGED_EVENT = 'backend://changed';
+
 export interface Readiness {
   ready: boolean;
   reason?: 'signed-out' | 'model-missing' | 'unsupported-platform';

--- a/src/views/LibraryView.test.ts
+++ b/src/views/LibraryView.test.ts
@@ -601,6 +601,27 @@ describe('LibraryView', () => {
     expect(wrapper.findAll('.meeting-item').every((r) => r.attributes('aria-pressed') === 'false')).toBe(true);
   });
 
+  it('closes the open meeting and reloads when the backend changes', async () => {
+    listMeetings.mockResolvedValue([
+      item({ id: 'a', title: 'Standup' }),
+      item({ id: 'b', title: 'Planning' }),
+    ]);
+    const wrapper = mount(LibraryView);
+    await flushPromises();
+    // A meeting from the previous backend is open in the detail pane.
+    expect(wrapper.find('.meeting-item').attributes('aria-pressed')).toBe('true');
+    expect(wrapper.find('.up-next').exists()).toBe(false);
+
+    // Switching backends (from the Settings window) must close that meeting,
+    // returning the detail to the neutral Up Next state, and reload the list.
+    emitEvent('backend://changed', {});
+    await flushPromises();
+
+    expect(listMeetings).toHaveBeenCalledTimes(2);
+    expect(wrapper.find('.up-next').exists()).toBe(true);
+    expect(wrapper.findAll('.meeting-item').every((r) => r.attributes('aria-pressed') === 'false')).toBe(true);
+  });
+
   it('shows a distinct error message (not the empty state) when loading fails', async () => {
     listMeetings.mockRejectedValue(new Error('boom'));
     const wrapper = mount(LibraryView);

--- a/src/views/LibraryView.vue
+++ b/src/views/LibraryView.vue
@@ -177,7 +177,7 @@ import { ref, computed, watch, onMounted, onUnmounted } from 'vue';
 import { invoke } from '@tauri-apps/api/core';
 import { listen, type UnlistenFn } from '@tauri-apps/api/event';
 import { getAllWebviewWindows } from '@tauri-apps/api/webviewWindow';
-import { getActiveBackend, timestampTitle, type Backend, type MeetingListItem } from '../composables/useBackend';
+import { getActiveBackend, timestampTitle, BACKEND_CHANGED_EVENT, type Backend, type MeetingListItem } from '../composables/useBackend';
 import { timestampFromLocalRecordingId } from '../composables/localRecordingId';
 import {
   groupMeetingsByDate,
@@ -735,6 +735,7 @@ let clockTimer: number | undefined;
 let unlistenRecordingStarted: UnlistenFn | null = null;
 let unlistenRecordingReveal: UnlistenFn | null = null;
 let unlistenVaultChanged: UnlistenFn | null = null;
+let unlistenBackendChanged: UnlistenFn | null = null;
 
 // Recover the attached meeting for a recording that started before this
 // library window existed. The `recording://started` event is one-shot, so a
@@ -773,6 +774,17 @@ onMounted(() => {
   }).then((un) => {
     unlistenVaultChanged = un;
   });
+  // Switching backends (in Settings) changes the whole meeting corpus. Close
+  // any meeting held open from the previous backend — returning the detail to
+  // the neutral Up Next state — and reload against the new backend.
+  void listen(BACKEND_CHANGED_EVENT, () => {
+    selectedItem.value = null;
+    userSelectedMeetingId.value = null;
+    pinnedMeetings.value = new Map();
+    void loadMeetings();
+  }).then((un) => {
+    unlistenBackendChanged = un;
+  });
   clockTimer = window.setInterval(() => {
     now.value = new Date();
   }, 30_000);
@@ -787,6 +799,7 @@ onUnmounted(() => {
   unlistenRecordingStarted?.();
   unlistenRecordingReveal?.();
   unlistenVaultChanged?.();
+  unlistenBackendChanged?.();
 });
 </script>
 

--- a/src/views/SettingsView.test.ts
+++ b/src/views/SettingsView.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { mount, flushPromises, enableAutoUnmount } from '@vue/test-utils';
 
 const getAllWebviewWindows = vi.fn(() => Promise.resolve([] as { label: string }[]));
+const emit = vi.fn((..._a: unknown[]) => Promise.resolve());
 const getBackendSetting = vi.fn(() => Promise.resolve('ariso' as const));
 const setBackendSetting = vi.fn((_b: unknown) => Promise.resolve());
 const hasPromptedLocalModels = vi.fn(() => Promise.resolve(false));
@@ -35,6 +36,7 @@ vi.mock('@tauri-apps/api/event', () => ({
     listeners.set(name, cb);
     return Promise.resolve(() => listeners.delete(name));
   },
+  emit: (...args: unknown[]) => emit(...args),
 }));
 vi.mock('../tauri', () => ({
   AUTH_SIGNED_IN_EVENT: 'auth://signed-in',
@@ -224,6 +226,17 @@ describe('SettingsView first-time local models prompt', () => {
 
     expect(wrapper.find('.download-confirm').exists()).toBe(true);
     expect(wrapper.text()).toContain('Download on-device models');
+  });
+
+  it('broadcasts a backend-changed event so other windows can react', async () => {
+    // Already-prompted so the switch runs clean without the download modal.
+    hasPromptedLocalModels.mockResolvedValue(true);
+    const wrapper = mount(SettingsView);
+    await flushPromises();
+
+    await switchToLocal(wrapper);
+
+    expect(emit).toHaveBeenCalledWith('backend://changed');
   });
 
   it('downloads both models and persists the flag on confirm', async () => {

--- a/src/views/SettingsView.vue
+++ b/src/views/SettingsView.vue
@@ -396,7 +396,8 @@
 
 <script setup lang="ts">
 import { ref, computed, watch, nextTick, onMounted, onUnmounted } from 'vue';
-import { listen, type UnlistenFn } from '@tauri-apps/api/event';
+import { emit, listen, type UnlistenFn } from '@tauri-apps/api/event';
+import { BACKEND_CHANGED_EVENT } from '../composables/useBackend';
 import { getAllWebviewWindows } from '@tauri-apps/api/webviewWindow';
 import { AUTH_SIGNED_IN_EVENT, auth, api, updater, getBackendSetting, setBackendSetting, hasPromptedLocalModels, setPromptedLocalModels, local, getVaultDir, setVaultDir, pickVaultFolder, type ModelStatus } from '../tauri';
 import { shouldPromptDownload, rowStatusText, pendingInstalls, modelBannerVisible, type Busy } from './settingsDownload';
@@ -595,6 +596,11 @@ async function selectBackend(next: 'ariso' | 'local') {
   if (next === backend.value) return;
   backend.value = next;
   await setBackendSetting(next);
+  // Tell other windows (the Library) the active backend changed so they drop
+  // any meeting held open from the previous backend and reload.
+  void emit(BACKEND_CHANGED_EVENT).catch((err) => {
+    console.warn('Failed to broadcast backend change', err);
+  });
   // Native orchestrators (tray next-meeting, notifications) re-evaluate
   // their backend/session gates via the bootstrap window's SYNC listener.
   void emitNotificationsSync().catch((err) => {
@@ -632,6 +638,9 @@ async function cancelDownloadModels() {
   // prompted flag, so a later switch to Local will ask again.
   backend.value = 'ariso';
   await setBackendSetting('ariso');
+  void emit(BACKEND_CHANGED_EVENT).catch((err) => {
+    console.warn('Failed to broadcast backend change', err);
+  });
 }
 
 async function onInstallStt() {


### PR DESCRIPTION
Switching backends (Ariso ↔ on-device) in Settings left a stale meeting from the previous backend open in the Library detail pane. The switch only wrote the shared store with no cross-window signal.

Mirroring the existing `vault://changed` pattern: Settings now emits a `backend://changed` event on switch, and the Library closes the open meeting (returning to the neutral Up Next state) and reloads against the new backend.

- `useBackend.ts` — shared `BACKEND_CHANGED_EVENT`
- `SettingsView.vue` — emit on switch (and on the download-cancel revert)
- `LibraryView.vue` — listen, clear selection/pinned, reload

Tests added for both the emit and the close-on-switch behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Switching the active backend now notifies other open windows so they can refresh to the new data source.
  * Library views automatically clear any selected meeting and reload the meeting list after a backend change.

* **Bug Fixes**
  * Prevents stale meeting selections and pinned items from persisting after changing backends.
  * Added coverage to ensure backend changes are broadcast and handled correctly across the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->