### PR TITLE
fix(search): time-box cmd-K search so it can't hang

### DIFF
--- a/src/views/LibrarySearchPalette.vue
+++ b/src/views/LibrarySearchPalette.vue
@@ -92,6 +92,30 @@ import type { MeetingListItem } from '../composables/useBackend';
 
 const minQueryLength = 2;
 const debounceMs = 180;
+// A search request must always reach a terminal state. The Ariso HTTP proxy has
+// no request timeout, so a slow/hung `/meetings` response would otherwise leave
+// the palette stuck on "Searching…" forever (issue #210). Bound the wait and
+// fall back to a clear error state instead.
+const searchTimeoutMs = 15000;
+
+class SearchTimeoutError extends Error {}
+
+// Reject with SearchTimeoutError if `promise` hasn't settled within `ms`.
+function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = window.setTimeout(() => reject(new SearchTimeoutError()), ms);
+    promise.then(
+      (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      (err) => {
+        clearTimeout(timer);
+        reject(err);
+      }
+    );
+  });
+}
 
 const props = defineProps<{
   open: boolean;
@@ -216,14 +240,14 @@ async function runSearch(term: string): Promise<void> {
   loading.value = true;
   error.value = null;
   try {
-    const next = await props.searchMeetings(term);
+    const next = await withTimeout(props.searchMeetings(term), searchTimeoutMs);
     if (requestId !== searchRequestId) return;
     results.value = next;
     activeIndex.value = 0;
   } catch (e) {
     if (requestId !== searchRequestId) return;
     console.error('Failed to search meetings', e);
-    error.value = 'Search failed.';
+    error.value = e instanceof SearchTimeoutError ? 'Search timed out. Try again.' : 'Search failed.';
     results.value = [];
   } finally {
     if (requestId === searchRequestId) loading.value = false;

--- a/src/views/LibraryView.test.ts
+++ b/src/views/LibraryView.test.ts
@@ -129,6 +129,9 @@ beforeEach(() => {
   searchMeetings.mockResolvedValue([]);
 });
 afterEach(() => {
+  // Restore real timers even if a fake-timer test failed before its own
+  // vi.useRealTimers() — otherwise leaked fake timers break later tests.
+  vi.useRealTimers();
   vi.unstubAllGlobals();
   vi.restoreAllMocks();
 });

--- a/src/views/LibraryView.test.ts
+++ b/src/views/LibraryView.test.ts
@@ -402,6 +402,39 @@ describe('LibraryView', () => {
     vi.useRealTimers();
   });
 
+  it('stops spinning and shows an error when a search request never settles', async () => {
+    vi.useFakeTimers();
+    backendId.mockReturnValue('ariso');
+    supportsSearch.mockReturnValue(true);
+    listMeetings.mockResolvedValue([item({ id: 'a', title: 'Existing' })]);
+    // A hung backend request: the promise never resolves or rejects, which is
+    // what left cmd-K stuck in a persistent "Searching…" state (issue #210).
+    searchMeetings.mockImplementation(() => new Promise(() => {}));
+
+    const wrapper = mount(LibraryView);
+    await flushPromises();
+    await wrapper.get('.search-trigger').trigger('click');
+    await flushPromises();
+    const input = document.body.querySelector<HTMLInputElement>('.palette-input')!;
+
+    input.value = 'note';
+    input.dispatchEvent(new Event('input'));
+    await vi.advanceTimersByTimeAsync(180);
+    await flushPromises();
+    // Loading progress shows briefly while the request is in flight.
+    expect(document.body.textContent).toContain('Searching');
+
+    // Once the search timeout elapses it must stop spinning and surface a clear
+    // error state instead of hanging on "Searching…" forever.
+    await vi.advanceTimersByTimeAsync(15000);
+    await flushPromises();
+    expect(document.body.textContent).not.toContain('Searching');
+    const errorRow = document.body.querySelector('.empty-row.error');
+    expect(errorRow).not.toBeNull();
+    expect(errorRow!.textContent).toContain('timed out');
+    vi.useRealTimers();
+  });
+
   it('selecting a search result closes the palette and opens that meeting', async () => {
     vi.useFakeTimers();
     backendId.mockReturnValue('ariso');


### PR DESCRIPTION
## Problem
cmd-K search could get stuck on "Searching…" forever. The palette shows that state for as long as `searchMeetings` is unsettled, and the Ariso `api_request` HTTP client has **no request timeout** — so a slow/hung `/meetings` response never returns and there's no error fallback. Fixes #210.

## Fix
Race the backend search against a **15s timeout** in `LibrarySearchPalette` (`withTimeout`). On timeout it rejects with `SearchTimeoutError`, surfacing *"Search timed out. Try again."* instead of an infinite spinner. The guard is backend-agnostic, so it protects both the Ariso (network) and local (disk) paths.

## Verification
- Regression test (RED→GREEN): a never-settling search now shows the timeout error instead of hanging.
- Backend search suites green (`LocalBackend`, `ArisoBackend`, `useMeetingApi`); `vite build` ✓.
- **Live end-to-end in the running app, both backends:**
  - Ariso: "Standup" → 40 results; nonsense query → "No results." (no spinner)
  - Local: "test" → 4 title matches; nonsense query → "No results." (no spinner)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Search now stops after a bounded wait if results take too long, preventing the interface from დარჩging in a permanent “Searching…” state.
  * Users now see a clearer timeout message when a search does not complete in time.
* **Tests**
  * Added coverage for stalled search requests to verify the timeout behavior and error display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->