### PR TITLE
feat(local): regenerate default note title from AI notes (#208)

### DIFF
--- a/docs/superpowers/specs/2026-07-06-local-notes-title-generation-design.md
+++ b/docs/superpowers/specs/2026-07-06-local-notes-title-generation-design.md
@@ -1,0 +1,176 @@
+# Local AI-notes title generation (offline mode)
+
+**Issue:** [#208](https://github.com/ariso-ai/oats/issues/208)
+**Date:** 2026-07-06
+**Backend scope:** Local / offline only. Cloud (Ariso) mode is untouched.
+
+## Problem
+
+In offline mode a local recording is created with a default, timestamp-based title
+(`timestampTitle()` in `src/composables/useBackend.ts`, e.g. `"Mon Jul 6 @ 959AM"`). After
+AI notes are generated on-device, that placeholder title is still there — the vault note
+reads as unfinished even though we now have enough content to name it well.
+
+We want the note title to be regenerated to something relevant **when AI notes are
+generated**, but only when the title is still the untouched default. If the user has
+renamed the recording, their title must be preserved.
+
+## Goal
+
+When local AI notes finish generating:
+
+- If the recording's title is still the pristine auto-generated default → replace it with a
+  concise, relevant title produced on-device.
+- If the user has renamed the recording → leave the title exactly as-is.
+- Regenerate **at most once** — only while the title is the untouched default. Once we
+  replace it (or the user renames), the title is no longer "default" and is never rewritten
+  automatically again.
+
+Everything runs on-device; nothing leaves the Mac (offline privacy guarantee intact).
+
+## Approach
+
+The local `ariso-stt` sidecar (`src-tauri/ariso-stt`, a Swift package built into
+`src-tauri/binaries/ariso-stt-aarch64-apple-darwin`) owns the on-device LLM. Its `notes`
+subcommand loads a Gemma-3-1b model and emits meeting notes. We extend that same subcommand
+to **also** produce a title, reusing the already-loaded model, and the Rust app applies the
+title only when the current title is the default.
+
+## Design
+
+### 1. Sidecar (`ariso-stt`, Swift) — `notes` emits a title alongside the notes
+
+`Sources/ariso-stt/main.swift`.
+
+Today the `notes` branch writes raw Markdown to stdout. Change it to emit a small JSON
+object so the notes body and the title stay cleanly separated (rather than smuggling the
+title into the Markdown, which is written verbatim into the vault note):
+
+```json
+{ "title": "Vault storage backend testing", "notes": "## Summary\n…" }
+```
+
+Implementation:
+
+- After `generateNotes()` returns the notes Markdown, run a **second, cheap LLM turn on the
+  same already-loaded `ModelContainer`** (no second `loadNotesModel` — the load is the
+  expensive part) to produce a title from the *generated notes* (already distilled, tighter
+  than the raw transcript).
+- Title prompt constraints: a short, specific title; plain text only; Title Case;
+  roughly ≤ 40 characters; no surrounding quotes, no Markdown, no trailing punctuation, no
+  `"Meeting Notes:"`-style prefixes; use only facts present in the notes.
+- Sanitize the model output in Swift: strip code fences / quotes / newlines, collapse
+  internal whitespace, trim. If the result is empty after sanitizing, emit `"title": ""`.
+- Encode `{ title, notes }` with `JSONEncoder` and write to stdout. `notes` is the existing
+  fence-stripped Markdown; `title` is the sanitized string (possibly empty).
+
+The `transcribe` (default) path and its JSON output are unchanged.
+
+### 2. Rust — parse the new `notes` contract, tolerantly
+
+`src-tauri/src/transcribe.rs`.
+
+- Introduce `NotesOutput { title: Option<String>, notes: String }`.
+- `run_notes` returns `NotesOutput` instead of `String`.
+- **Tolerant parse:** attempt to decode stdout as the `{title, notes}` JSON object first; if
+  that fails, fall back to `NotesOutput { title: None, notes: <raw stdout trimmed> }`. This
+  keeps behavior safe if a mismatched/older binary emits plain Markdown, and lets the many
+  existing `notes` test stubs (which `echo` plain Markdown) keep passing with `title: None`
+  → no retitle. An empty/whitespace `title` from JSON normalizes to `None`.
+- Existing empty-notes handling stays keyed on `notes`.
+
+### 3. Rust — apply the title only if it is the default
+
+`src-tauri/src/storage.rs`, `src-tauri/src/transcribe.rs`, `src-tauri/src/commands.rs`.
+
+- Add `title_is_default: bool` to `RecordingMeta` with `#[serde(default)]` (defaults to
+  `false`). Pre-feature recordings already on disk deserialize with `false`, so they are
+  **never** auto-retitled — a safe migration.
+- Set `title_is_default: true` where a fresh local recording is created
+  (`fresh_recording_core`): the title there is the timestamp default passed down from
+  `finalize`. (Appended clips reuse the existing recording's meta and do not reset the flag.)
+- Set `title_is_default: false` in `rename_local_recording` (`commands.rs`) when the user
+  renames — their title is now intentional.
+- In `process_notes` (`transcribe.rs`), in the `Ok(notes)` arm, **after `vault::write_note`
+  succeeds**:
+  - If `meta.title_is_default` **and** `output.title` is `Some(new)` (non-empty) **and**
+    `new != meta.title`:
+    - Call `vault::rename_recording_artifacts(&meta.id, &meta.created_at, &audio_file, &new)`
+      (the same tested path the user-rename flow uses). It renames the note file + audio
+      attachment, rewrites front-matter `title:` and the embed, and returns the new
+      `audio_file`.
+    - On success: `meta.audio_file = Some(returned)`, `meta.title = new`,
+      `meta.title_is_default = false`.
+    - On error: log and keep the default title (the note itself is already written). This
+      retitle step is best-effort and must never turn a successful notes run into a failure.
+  - Then persist `meta` (this is the same `write_meta` that already stamps `notes_written`).
+
+Ordering rationale: `write_note` first (so notes success never depends on retitling), then
+rename. This reuses the existing, tested `rename_recording_artifacts` (with its collision
+handling and rollback) instead of inventing a new write ordering. The extra small note write
+it implies is negligible.
+
+The `retry_notes` / `retry_local_notes` paths flow through `process_notes`, so a retry on a
+recording whose title is still the default will also (re)generate a title — consistent with
+the "only while default" rule.
+
+### 4. Frontend
+
+No change required. Local recording progress is polled
+(`src/composables/useLocalRecordingProgress.ts` → `MeetingDetailView.vue`); when notes reach
+`ready` the view re-reads the recording and shows the new title. Verified during
+implementation.
+
+## Build / packaging
+
+- Editing `src-tauri/ariso-stt/Sources/**` invalidates the CI sidecar cache
+  (`.github/workflows/release.yaml` keys on `Sources/**` + `Package.resolved`), so the
+  release build rebuilds the binary automatically.
+- Locally, rebuild and stage the binary to test end-to-end:
+  ```bash
+  cd src-tauri/ariso-stt
+  xcodebuild build -scheme ariso-stt -configuration Release \
+    -destination 'generic/platform=macOS' -derivedDataPath .xcode -skipMacroValidation
+  cp .xcode/Build/Products/Release/ariso-stt ../binaries/ariso-stt-aarch64-apple-darwin
+  cp -R .xcode/Build/Products/Release/mlx-swift_Cmlx.bundle ../binaries/
+  ```
+
+## Testing
+
+### Rust (automated)
+
+- `run_notes`: parses the `{title, notes}` JSON; tolerant fallback to `{None, raw}` for
+  non-JSON stdout; empty/whitespace title → `None`.
+- `process_notes` via the `ARISO_STT_BIN` stub emitting `{title, notes}`:
+  - `title_is_default = true` → note written, `meta.title` updated to the generated title,
+    `title_is_default` cleared, and the vault note file renamed to the new-title basename.
+  - `title_is_default = false` → note written, title **unchanged**, file **not** renamed.
+  - Empty `title` (or `None`) → note written, title unchanged.
+  - Retitle failure is non-fatal: notes still count as written.
+- `title_is_default` lifecycle: set on `fresh_recording_core`; cleared by
+  `rename_local_recording`.
+
+Run the suite with the repo's macOS workaround:
+```bash
+DYLD_LIBRARY_PATH="/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift-5.5/macosx" \
+  cargo test --manifest-path src-tauri/Cargo.toml -- --test-threads=1
+```
+
+### Sidecar (manual)
+
+The Swift package has no test target (consistent with the repo). Verify by rebuilding the
+binary and running `notes` on a sample transcript, confirming stdout is
+`{ "title": …, "notes": … }` with a sensible, sanitized title.
+
+### End-to-end (manual)
+
+Record a short meeting in offline mode; after notes generate, confirm the recording's title
+changes from the timestamp default to a generated title and the vault `.md` file is renamed.
+Rename a recording first, then (re)generate notes, and confirm the user's title is preserved.
+
+## Non-goals
+
+- No title generation for cloud (Ariso) mode.
+- No re-titling of recordings the user has already renamed.
+- No repeated re-titling once a generated (or user) title is in place.
+- No new user-facing setting or UI to toggle this behavior.

--- a/src-tauri/ariso-stt/Sources/ariso-stt/main.swift
+++ b/src-tauri/ariso-stt/Sources/ariso-stt/main.swift
@@ -149,8 +149,7 @@ func loadNotesModel(modelsURL: URL) async throws -> ModelContainer {
 }
 
 /// Run the notes model on `transcript` and return the full Markdown notes.
-func generateNotes(transcript: String, modelsURL: URL) async throws -> String {
-    let container = try await loadNotesModel(modelsURL: modelsURL)
+func generateNotes(container: ModelContainer, transcript: String) async throws -> String {
     // System instructions describe the format in prose — with NO copyable
     // placeholder lines — so a small model writes real content instead of
     // echoing the template (which it did when the format was a fill-in scaffold).
@@ -178,6 +177,71 @@ func generateNotes(transcript: String, modelsURL: URL) async throws -> String {
             repetitionPenalty: 1.15, repetitionContextSize: 64))
     let raw = try await session.respond(to: "Transcript:\n\(transcript)")
     return stripCodeFence(raw)
+}
+
+/// A meeting-notes result: the Markdown notes plus a short generated title.
+struct NotesResult: Codable {
+    let title: String
+    let notes: String
+}
+
+/// Generate a short, plain-text title from already-generated notes, reusing the
+/// loaded model container. Returns "" if nothing usable comes back.
+func generateTitle(container: ModelContainer, notes: String) async throws -> String {
+    let instructions = """
+        You write a short title for a meeting, given its notes.
+
+        Rules:
+        - Output ONLY the title text — no quotes, no Markdown, no preamble, no trailing punctuation.
+        - Keep it short and specific: at most 6 words and 40 characters.
+        - Use Title Case. Use only facts present in the notes; never invent names.
+        - Do not start with "Meeting", "Notes", "Summary", or a date.
+        """
+    let session = ChatSession(
+        container,
+        instructions: instructions,
+        generateParameters: GenerateParameters(
+            maxTokens: 32, temperature: 0.3,
+            repetitionPenalty: 1.15, repetitionContextSize: 64))
+    let raw = try await session.respond(to: "Notes:\n\(notes)")
+    return sanitizeTitle(raw)
+}
+
+/// Reduce a model's title output to one clean line: take the first non-empty
+/// non-fence line, strip surrounding quotes / leading Markdown markers, collapse
+/// whitespace, drop trailing sentence punctuation, and cap at 40 characters on a
+/// word boundary. Returns "" when nothing usable remains.
+func sanitizeTitle(_ raw: String) -> String {
+    let firstLine = raw
+        .replacingOccurrences(of: "\r\n", with: "\n")
+        .components(separatedBy: "\n")
+        .map { $0.trimmingCharacters(in: .whitespaces) }
+        .first(where: { !$0.isEmpty && !$0.hasPrefix("```") }) ?? ""
+    var s = firstLine
+    while let f = s.first, "#*->\"'`".contains(f) { s.removeFirst() }
+    s = s.trimmingCharacters(in: .whitespaces)
+    while let l = s.last, "\"'`".contains(l) { s.removeLast() }
+    s = s.split(whereSeparator: { $0 == " " || $0 == "\t" }).joined(separator: " ")
+    while let l = s.last, ".,;:".contains(l) { s.removeLast() }
+    s = s.trimmingCharacters(in: .whitespaces)
+    let maxChars = 40
+    if s.count > maxChars {
+        let capped = String(s.prefix(maxChars))
+        if let lastSpace = capped.lastIndex(of: " ") {
+            s = String(capped[..<lastSpace]).trimmingCharacters(in: .whitespaces)
+        } else {
+            s = capped
+        }
+    }
+    return s
+}
+
+/// Load the model once, generate notes, then a title from those notes.
+func generateNotesAndTitle(transcript: String, modelsURL: URL) async throws -> NotesResult {
+    let container = try await loadNotesModel(modelsURL: modelsURL)
+    let notes = try await generateNotes(container: container, transcript: transcript)
+    let title = try await generateTitle(container: container, notes: notes)
+    return NotesResult(title: title, notes: notes)
 }
 
 /// The small notes model often wraps its whole answer in a ```markdown … ```
@@ -217,8 +281,9 @@ if isNotes {
     }
     runToCompletion {
         do {
-            let notes = try await generateNotes(transcript: transcript, modelsURL: modelsURL)
-            FileHandle.standardOutput.write(Data(notes.utf8))
+            let result = try await generateNotesAndTitle(transcript: transcript, modelsURL: modelsURL)
+            let data = try JSONEncoder().encode(result)
+            FileHandle.standardOutput.write(data)
         } catch {
             fail("notes error: \(error)")
         }

--- a/src-tauri/ariso-stt/Sources/ariso-stt/main.swift
+++ b/src-tauri/ariso-stt/Sources/ariso-stt/main.swift
@@ -267,7 +267,7 @@ func sanitizeTitle(_ raw: String) -> String {
 func generateNotesAndTitle(transcript: String, modelsURL: URL) async throws -> NotesResult {
     let container = try await loadNotesModel(modelsURL: modelsURL)
     let notes = try await generateNotes(container: container, transcript: transcript)
-    let title = try await generateTitle(container: container, notes: notes)
+    let title = (try? await generateTitle(container: container, notes: notes)) ?? ""
     return NotesResult(title: title, notes: notes)
 }
 

--- a/src-tauri/ariso-stt/Sources/ariso-stt/main.swift
+++ b/src-tauri/ariso-stt/Sources/ariso-stt/main.swift
@@ -208,9 +208,10 @@ func generateTitle(container: ModelContainer, notes: String) async throws -> Str
 }
 
 /// Reduce a model's title output to one clean line: take the first non-empty
-/// non-fence line, strip surrounding quotes / leading Markdown markers, collapse
-/// whitespace, drop trailing sentence punctuation, and cap at 40 characters on a
-/// word boundary. Returns "" when nothing usable remains.
+/// non-fence line, strip surrounding quotes / Markdown markers (both ends),
+/// collapse whitespace, drop trailing sentence punctuation, strip a leading
+/// "Meeting"/"Notes"/"Summary" token, and cap at 40 characters on a word
+/// boundary. Returns "" when nothing usable remains.
 func sanitizeTitle(_ raw: String) -> String {
     let firstLine = raw
         .replacingOccurrences(of: "\r\n", with: "\n")
@@ -218,12 +219,38 @@ func sanitizeTitle(_ raw: String) -> String {
         .map { $0.trimmingCharacters(in: .whitespaces) }
         .first(where: { !$0.isEmpty && !$0.hasPrefix("```") }) ?? ""
     var s = firstLine
-    while let f = s.first, "#*->\"'`".contains(f) { s.removeFirst() }
+    // Strip the same marker set from BOTH ends so e.g. "**Budget Review**"
+    // fully unwraps (a leading-only strip would leave the trailing "**").
+    let markers = "#*->\"'`"
+    while let f = s.first, markers.contains(f) { s.removeFirst() }
     s = s.trimmingCharacters(in: .whitespaces)
-    while let l = s.last, "\"'`".contains(l) { s.removeLast() }
+    while let l = s.last, markers.contains(l) { s.removeLast() }
+    s = s.trimmingCharacters(in: .whitespaces)
     s = s.split(whereSeparator: { $0 == " " || $0 == "\t" }).joined(separator: " ")
     while let l = s.last, ".,;:".contains(l) { s.removeLast() }
     s = s.trimmingCharacters(in: .whitespaces)
+    // Deterministically drop a leading "Meeting"/"Notes"/"Summary" token (a
+    // stated title constraint the model sometimes violates), optionally
+    // followed by ":"/"-"/whitespace. Loop so "Meeting Notes: X" -> "X". Strip
+    // from the original-case `s` so the remainder keeps its casing.
+    let bannedPrefixes = ["meeting", "notes", "summary"]
+    var strippedPrefix = true
+    while strippedPrefix {
+        strippedPrefix = false
+        for prefix in bannedPrefixes where s.lowercased().hasPrefix(prefix) {
+            let rest = String(s.dropFirst(prefix.count))
+            // Only strip if the token is a whole word (next char isn't a letter
+            // or digit continuing it), so "Meetings Recap" is left untouched.
+            if let next = rest.first, next.isLetter || next.isNumber { continue }
+            var trimmed = rest
+            while let f = trimmed.first, f == ":" || f == "-" || f == " " || f == "\t" {
+                trimmed.removeFirst()
+            }
+            s = trimmed.trimmingCharacters(in: .whitespaces)
+            strippedPrefix = true
+            break
+        }
+    }
     let maxChars = 40
     if s.count > maxChars {
         let capped = String(s.prefix(maxChars))

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1144,6 +1144,8 @@ pub fn rename_local_recording(id: String, title: String) -> Result<(), String> {
     let dir = recording_dir(&id)?;
     let mut meta = crate::storage::read_meta(&dir)?;
     meta.title = title.to_string();
+    // A user rename makes the title intentional — never auto-retitle again.
+    meta.title_is_default = false;
     // Propagate the rename into the vault: rename the note file + audio
     // attachment to match the new title (preserving the note body), and store
     // the new attachment name. Legacy recordings (no `audio_file`) have their
@@ -1513,7 +1515,29 @@ mod tests {
             last_clip_end_at: None,
             audio_file: None,
             notes_written: None,
+            title_is_default: false,
         }
+    }
+
+    #[test]
+    fn rename_clears_title_is_default() {
+        // SAFETY: command tests run with --test-threads=1 (see plan conventions),
+        // so the process-wide ARISO_ROOT mutation below has no concurrent writer.
+        let tmp = tempfile::tempdir().unwrap();
+        unsafe { std::env::set_var("ARISO_ROOT", tmp.path()); }
+        let id = "2026-06-02T14-30-05Z";
+        let dir = crate::storage::create_recording_dir(&crate::vault::meta_root().unwrap(), id).unwrap();
+        let mut meta = test_meta(id);
+        meta.title_is_default = true;
+        meta.audio_file = None; // legacy path: skip vault propagation
+        crate::storage::write_meta(&dir, &meta).unwrap();
+
+        rename_local_recording(id.to_string(), "My Real Title".to_string()).unwrap();
+
+        let after = crate::storage::read_meta(&dir).unwrap();
+        unsafe { std::env::remove_var("ARISO_ROOT"); }
+        assert_eq!(after.title, "My Real Title");
+        assert!(!after.title_is_default);
     }
 
     #[test]
@@ -1773,6 +1797,7 @@ mod tests {
             last_clip_end_at: None,
             audio_file: None,
             notes_written: None,
+            title_is_default: false,
         };
         crate::storage::write_meta(&dir, &meta).unwrap();
         std::fs::write(dir.join("transcript.md"), b"t").unwrap();

--- a/src-tauri/src/storage.rs
+++ b/src-tauri/src/storage.rs
@@ -108,6 +108,13 @@ pub struct RecordingMeta {
     /// auto-regeneration guard); v1 does not branch on it.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub notes_written: Option<String>,
+    /// True while `title` is still the auto-generated default (the frontend
+    /// timestamp label). Set when a fresh recording is created; cleared when the
+    /// user renames it or when AI notes regenerate the title. Absent on
+    /// pre-feature meta.json (migrates to `false`, so those are never
+    /// auto-retitled).
+    #[serde(default)]
+    pub title_is_default: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -653,12 +660,22 @@ mod tests {
         assert_eq!(format_hms(2533.0), "00:42:13");
     }
 
+    #[test]
+    fn title_is_default_defaults_false_when_absent() {
+        // A pre-feature meta.json has no titleIsDefault field; it must migrate to false
+        // so existing recordings are never auto-retitled.
+        let json = r#"{"id":"x","title":"Old Title","createdAt":"2026-06-02T14:30:05.000Z","durationSeconds":12,"status":"done"}"#;
+        let meta: RecordingMeta = serde_json::from_str(json).unwrap();
+        assert!(!meta.title_is_default);
+    }
+
     fn meta_with(id: &str, created: &str) -> RecordingMeta {
         RecordingMeta {
             id: id.into(), title: format!("T {id}"), created_at: created.into(),
             duration_seconds: 1, status: RecordingStatus::Done, language: None,
             participants: vec![], model_version: None, error: None, notes_error: None,
             last_clip_end_at: None, audio_file: None, notes_written: None,
+            title_is_default: false,
         }
     }
 
@@ -834,6 +851,7 @@ mod tests {
             last_clip_end_at: None,
             audio_file: None,
             notes_written: None,
+            title_is_default: false,
         };
         let segments = vec![
             Segment { speaker: 0, text: "Hello there".into(), start: 3.0, end: 9.0 },
@@ -855,6 +873,7 @@ mod tests {
             duration_seconds: 0, status: RecordingStatus::Done, language: None,
             participants: vec![], model_version: None, error: None, notes_error: None,
             last_clip_end_at: None, audio_file: None, notes_written: None,
+            title_is_default: false,
         };
         let segments = vec![Segment { speaker: 5, text: "hi".into(), start: 0.0, end: 1.0 }];
         let md = render_markdown(&meta, &segments);
@@ -1035,6 +1054,7 @@ mod tests {
             last_clip_end_at: None,
             audio_file: None,
             notes_written: None,
+            title_is_default: false,
         };
         write_meta(&dir, &meta).unwrap();
         let read = read_meta(&dir).unwrap();

--- a/src-tauri/src/transcribe.rs
+++ b/src-tauri/src/transcribe.rs
@@ -278,6 +278,7 @@ async fn fresh_recording_core(
         last_clip_end_at: None,
         audio_file: Some(audio_file.clone()),
         notes_written: None,
+        title_is_default: true,
     };
     storage::write_meta(&dir, &meta)?;
 
@@ -379,6 +380,7 @@ fn save_failed_clip(
                 last_clip_end_at: None,
                 audio_file,
                 notes_written: None,
+                title_is_default: false,
             };
             let _ = storage::write_meta(&dir, &meta);
         }
@@ -870,6 +872,7 @@ mod tests {
             last_clip_end_at: None,
             audio_file: None,
             notes_written: None,
+            title_is_default: false,
         };
         storage::write_meta(&dir, &meta).unwrap();
 
@@ -906,6 +909,7 @@ mod tests {
             duration_seconds: 5, status: RecordingStatus::Failed, language: None,
             participants: vec![], model_version: None, error: None, notes_error: None,
             last_clip_end_at: None, audio_file: None, notes_written: None,
+            title_is_default: false,
         };
         storage::write_meta(&dir, &meta).unwrap();
 
@@ -929,6 +933,7 @@ mod tests {
             participants: vec![], model_version: None, error: None,
             notes_error: Some("prior notes failure".into()),
             last_clip_end_at: None, audio_file: None, notes_written: None,
+            title_is_default: false,
         };
         storage::write_meta(&dir, &meta).unwrap();
 
@@ -968,6 +973,7 @@ mod tests {
             duration_seconds: 5, status: RecordingStatus::Done, language: None,
             participants: vec![], model_version: None, error: None, notes_error: None,
             last_clip_end_at: None, audio_file: None, notes_written: None,
+            title_is_default: false,
         };
         storage::write_meta(&dir, &meta).unwrap();
 
@@ -1384,6 +1390,7 @@ mod tests {
             duration_seconds: 5, status: RecordingStatus::Done, language: None,
             participants: vec![], model_version: None, error: None, notes_error: None,
             last_clip_end_at: None, audio_file: None, notes_written: None,
+            title_is_default: false,
         };
         storage::write_meta(&dir, &meta).unwrap();
 
@@ -1410,6 +1417,7 @@ mod tests {
             duration_seconds: 5, status: RecordingStatus::Done, language: None,
             participants: vec![], model_version: None, error: None, notes_error: None,
             last_clip_end_at: None, audio_file: None, notes_written: None,
+            title_is_default: false,
         };
         storage::write_meta(&dir, &meta).unwrap();
 

--- a/src-tauri/src/transcribe.rs
+++ b/src-tauri/src/transcribe.rs
@@ -86,10 +86,33 @@ pub async fn run_transcribe(audio: &Path, models: &Path) -> Result<TranscriptRes
     })
 }
 
+/// Parsed output of `ariso-stt notes`: the Markdown notes plus an optional
+/// generated title. `title` is `None` when the sidecar emits no title (blank,
+/// or a non-JSON/older binary whose whole stdout is treated as the notes body).
+#[derive(Debug, Clone)]
+pub struct NotesOutput {
+    pub title: Option<String>,
+    pub notes: String,
+}
+
+/// JSON contract emitted by `ariso-stt notes`: `{ "title": ..., "notes": ... }`.
+#[derive(Deserialize)]
+struct NotesJson {
+    #[serde(default)]
+    title: String,
+    notes: String,
+}
+
+/// Trimmed title, or `None` when empty.
+fn normalize_title(raw: &str) -> Option<String> {
+    let t = raw.trim();
+    if t.is_empty() { None } else { Some(t.to_string()) }
+}
+
 /// Run the sidecar in notes mode and return the generated markdown (stdout).
 /// Bounded by [`NOTES_TIMEOUT`]; on timeout the child process is killed
 /// (via `kill_on_drop`) so a hung sidecar can't keep a caller pending.
-pub async fn run_notes(transcript: &Path, models: &Path) -> Result<String, String> {
+pub async fn run_notes(transcript: &Path, models: &Path) -> Result<NotesOutput, String> {
     let bin = sidecar_path()?;
     let mut cmd = Command::new(&bin);
     cmd.arg("notes")
@@ -115,7 +138,20 @@ pub async fn run_notes(transcript: &Path, models: &Path) -> Result<String, Strin
         let stderr = String::from_utf8_lossy(&output.stderr);
         return Err(format!("ariso-stt notes failed: {}", stderr.trim()));
     }
-    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let trimmed = stdout.trim();
+    // Tolerant parse: prefer the {title, notes} JSON contract; fall back to
+    // treating raw stdout as the notes body (non-JSON / older sidecar binary).
+    match serde_json::from_str::<NotesJson>(trimmed) {
+        Ok(j) => Ok(NotesOutput {
+            title: normalize_title(&j.title),
+            notes: j.notes.trim().to_string(),
+        }),
+        Err(_) => Ok(NotesOutput {
+            title: None,
+            notes: trimmed.to_string(),
+        }),
+    }
 }
 
 /// Whether the transcript's on-disk bytes differ between two reads. Used to
@@ -146,18 +182,18 @@ async fn process_notes(dir: PathBuf, models: PathBuf, mut meta: RecordingMeta) {
     match outcome {
         // Empty output is a silent failure: it would write a blank note with
         // notes_error unset, reading as success. Record it.
-        Ok(notes) if notes.trim().is_empty() => {
+        Ok(output) if output.notes.trim().is_empty() => {
             eprintln!("notes generation: empty output");
             meta.notes_error = Some("notes generation produced empty output".to_string());
             let _ = storage::write_meta(&dir, &meta);
         }
-        Ok(notes) => {
+        Ok(output) => {
             let audio_file = match &meta.audio_file {
                 Some(a) => a.clone(),
                 // Legacy recording with no vault audio: keep the old location so
                 // its note stays alongside its audio.
                 None => {
-                    if let Err(e) = storage::write_notes(&dir, &notes) {
+                    if let Err(e) = storage::write_notes(&dir, &output.notes) {
                         eprintln!("write notes: {e}");
                         meta.notes_error = Some(e);
                         let _ = storage::write_meta(&dir, &meta);
@@ -166,7 +202,7 @@ async fn process_notes(dir: PathBuf, models: PathBuf, mut meta: RecordingMeta) {
                 }
             };
             let basename = audio_file.strip_suffix(".mp3").unwrap_or(audio_file.as_str());
-            if let Err(e) = crate::vault::write_note(basename, &meta, &audio_file, &notes) {
+            if let Err(e) = crate::vault::write_note(basename, &meta, &audio_file, &output.notes) {
                 eprintln!("write vault note: {e}");
                 meta.notes_error = Some(e);
                 let _ = storage::write_meta(&dir, &meta);
@@ -637,6 +673,48 @@ mod tests {
         perms.set_mode(0o755);
         std::fs::set_permissions(&path, perms).unwrap();
         path
+    }
+
+    #[tokio::test]
+    async fn run_notes_parses_title_and_notes_json() {
+        let tmp = tempfile::tempdir().unwrap();
+        let stub = write_stub(
+            tmp.path(),
+            "echo '{\"title\":\"Budget Planning\",\"notes\":\"## Summary body\"}'",
+        );
+        unsafe { std::env::set_var("ARISO_STT_BIN", &stub); }
+        let transcript = tmp.path().join("transcript.md");
+        std::fs::write(&transcript, b"hi").unwrap();
+        let out = run_notes(&transcript, tmp.path()).await.unwrap();
+        unsafe { std::env::remove_var("ARISO_STT_BIN"); }
+        assert_eq!(out.title.as_deref(), Some("Budget Planning"));
+        assert_eq!(out.notes, "## Summary body");
+    }
+
+    #[tokio::test]
+    async fn run_notes_falls_back_to_raw_markdown() {
+        let tmp = tempfile::tempdir().unwrap();
+        let stub = write_stub(tmp.path(), "echo '# Notes'");
+        unsafe { std::env::set_var("ARISO_STT_BIN", &stub); }
+        let transcript = tmp.path().join("transcript.md");
+        std::fs::write(&transcript, b"hi").unwrap();
+        let out = run_notes(&transcript, tmp.path()).await.unwrap();
+        unsafe { std::env::remove_var("ARISO_STT_BIN"); }
+        assert_eq!(out.title, None);
+        assert_eq!(out.notes, "# Notes");
+    }
+
+    #[tokio::test]
+    async fn run_notes_blank_title_is_none() {
+        let tmp = tempfile::tempdir().unwrap();
+        let stub = write_stub(tmp.path(), "echo '{\"title\":\"   \",\"notes\":\"## Summary\"}'");
+        unsafe { std::env::set_var("ARISO_STT_BIN", &stub); }
+        let transcript = tmp.path().join("transcript.md");
+        std::fs::write(&transcript, b"hi").unwrap();
+        let out = run_notes(&transcript, tmp.path()).await.unwrap();
+        unsafe { std::env::remove_var("ARISO_STT_BIN"); }
+        assert_eq!(out.title, None);
+        assert_eq!(out.notes, "## Summary");
     }
 
     #[tokio::test]

--- a/src-tauri/src/transcribe.rs
+++ b/src-tauri/src/transcribe.rs
@@ -165,6 +165,29 @@ fn now_rfc3339() -> String {
     chrono::Utc::now().to_rfc3339()
 }
 
+/// If the recording still carries its auto-generated default title, replace it
+/// with the model-generated `title` and rename the vault artifacts to match.
+/// Best-effort: any failure leaves the (already-written) note under the default
+/// title. On success updates `meta.title`, `meta.audio_file`, and clears
+/// `title_is_default`. No-op when the title is user-set, blank, or unchanged.
+fn maybe_apply_generated_title(meta: &mut RecordingMeta, audio_file: &str, title: Option<String>) {
+    if !meta.title_is_default {
+        return;
+    }
+    let new_title = match title {
+        Some(t) if !t.trim().is_empty() && t.trim() != meta.title => t.trim().to_string(),
+        _ => return,
+    };
+    match crate::vault::rename_recording_artifacts(&meta.id, &meta.created_at, audio_file, &new_title) {
+        Ok(new_audio_file) => {
+            meta.audio_file = Some(new_audio_file);
+            meta.title = new_title;
+            meta.title_is_default = false;
+        }
+        Err(e) => eprintln!("title regeneration: rename artifacts: {e}"),
+    }
+}
+
 /// Best-effort notes generation: runs the sidecar and writes either the vault
 /// note or `meta.notes_error`. Failures here never affect the recording's
 /// `Done` status. A third outcome exists: if the transcript changes mid-run
@@ -208,6 +231,9 @@ async fn process_notes(dir: PathBuf, models: PathBuf, mut meta: RecordingMeta) {
                 let _ = storage::write_meta(&dir, &meta);
                 return;
             }
+            // Regenerate the note title from the notes, but only while the title
+            // is still the auto-generated default (never clobber a user rename).
+            maybe_apply_generated_title(&mut meta, &audio_file, output.title);
             meta.notes_error = None;
             meta.notes_written = Some(now_rfc3339());
             let _ = storage::write_meta(&dir, &meta);
@@ -1587,6 +1613,85 @@ mod tests {
         let attachments = crate::vault::attachments_dir(&crate::vault::vault_root().unwrap());
         let count = std::fs::read_dir(&attachments).unwrap().count();
         assert_eq!(count, 1, "retry must not orphan a duplicate attachment");
+        unsafe { std::env::remove_var("ARISO_ROOT"); }
+    }
+
+    #[test]
+    fn generated_title_skipped_when_not_default() {
+        let mut meta = RecordingMeta {
+            id: "2026-06-02T14-30-05Z".into(),
+            title: "User Title".into(),
+            created_at: "2026-06-02T14:30:05.000Z".into(),
+            duration_seconds: 12,
+            status: RecordingStatus::Done,
+            language: None,
+            participants: vec![],
+            model_version: None,
+            error: None,
+            notes_error: None,
+            last_clip_end_at: None,
+            audio_file: Some("2026-06-02 User Title.mp3".into()),
+            notes_written: None,
+            title_is_default: false,
+        };
+        maybe_apply_generated_title(&mut meta, "2026-06-02 User Title.mp3", Some("Generated".into()));
+        assert_eq!(meta.title, "User Title");
+        assert!(!meta.title_is_default);
+    }
+
+    #[test]
+    fn generated_title_skipped_when_blank() {
+        let mut meta = RecordingMeta {
+            id: "2026-06-02T14-30-05Z".into(),
+            title: "Mon Jul 6 @ 959AM".into(),
+            created_at: "2026-06-02T14:30:05.000Z".into(),
+            duration_seconds: 12,
+            status: RecordingStatus::Done,
+            language: None,
+            participants: vec![],
+            model_version: None,
+            error: None,
+            notes_error: None,
+            last_clip_end_at: None,
+            audio_file: Some("2026-06-02 default.mp3".into()),
+            notes_written: None,
+            title_is_default: true,
+        };
+        maybe_apply_generated_title(&mut meta, "2026-06-02 default.mp3", None);
+        assert_eq!(meta.title, "Mon Jul 6 @ 959AM");
+        assert!(meta.title_is_default);
+    }
+
+    #[tokio::test]
+    async fn notes_regenerate_default_title_and_rename_vault_note() {
+        let tmp = tempfile::tempdir().unwrap();
+        let asr = r#"{"language":"en","durationSeconds":12.0,"participants":[{"id":0,"label":"Speaker 1"}],"segments":[{"speaker":0,"text":"hi","start":0.0,"end":1.0}]}"#;
+        // notes subcommand emits the {title,notes} JSON; transcribe path emits ASR JSON.
+        let body = format!(
+            "if [ \"$1\" = notes ]; then echo '{{\"title\":\"Budget Planning\",\"notes\":\"## Summary body\"}}'; exit 0; fi\ncat <<'EOF'\n{asr}\nEOF"
+        );
+        let stub = write_stub(tmp.path(), &body);
+        unsafe { std::env::set_var("ARISO_STT_BIN", &stub); }
+        unsafe { std::env::set_var("ARISO_ROOT", tmp.path()); }
+
+        let (res, notes_handle) = finalize_core(
+            tmp.path(), b"audio".to_vec(),
+            "Mon Jul 6 @ 959AM".into(), "2026-06-02T14:30:05.000Z".into(), 12,
+        ).await.unwrap();
+        notes_handle.await.unwrap();
+        unsafe { std::env::remove_var("ARISO_STT_BIN"); }
+
+        let dir = crate::storage::recordings_dir(tmp.path()).join(&res.id);
+        let meta = read_meta(&dir).unwrap();
+        assert_eq!(meta.title, "Budget Planning");
+        assert!(!meta.title_is_default);
+        // The vault note file was renamed to the generated-title basename.
+        let vault = crate::vault::vault_root().unwrap();
+        assert!(
+            vault.join("2026-06-02 Budget Planning.md").exists(),
+            "expected renamed vault note; vault had: {:?}",
+            std::fs::read_dir(&vault).unwrap().map(|e| e.unwrap().file_name()).collect::<Vec<_>>()
+        );
         unsafe { std::env::remove_var("ARISO_ROOT"); }
     }
 }

--- a/src-tauri/src/transcribe.rs
+++ b/src-tauri/src/transcribe.rs
@@ -1662,6 +1662,29 @@ mod tests {
         assert!(meta.title_is_default);
     }
 
+    #[test]
+    fn generated_title_skipped_when_whitespace() {
+        let mut meta = RecordingMeta {
+            id: "2026-06-02T14-30-05Z".into(),
+            title: "Mon Jul 6 @ 959AM".into(),
+            created_at: "2026-06-02T14:30:05.000Z".into(),
+            duration_seconds: 12,
+            status: RecordingStatus::Done,
+            language: None,
+            participants: vec![],
+            model_version: None,
+            error: None,
+            notes_error: None,
+            last_clip_end_at: None,
+            audio_file: Some("2026-06-02 default.mp3".into()),
+            notes_written: None,
+            title_is_default: true,
+        };
+        maybe_apply_generated_title(&mut meta, "2026-06-02 default.mp3", Some("   ".to_string()));
+        assert_eq!(meta.title, "Mon Jul 6 @ 959AM");
+        assert!(meta.title_is_default);
+    }
+
     #[tokio::test]
     async fn notes_regenerate_default_title_and_rename_vault_note() {
         let tmp = tempfile::tempdir().unwrap();
@@ -1685,6 +1708,7 @@ mod tests {
         let meta = read_meta(&dir).unwrap();
         assert_eq!(meta.title, "Budget Planning");
         assert!(!meta.title_is_default);
+        assert_eq!(meta.audio_file.as_deref(), Some("2026-06-02 Budget Planning.mp3"));
         // The vault note file was renamed to the generated-title basename.
         let vault = crate::vault::vault_root().unwrap();
         assert!(

--- a/src-tauri/src/vault.rs
+++ b/src-tauri/src/vault.rs
@@ -580,7 +580,7 @@ mod tests {
                 crate::storage::Participant { id: 1, label: "Speaker 2".into() },
             ],
             model_version: None, error: None, notes_error: None, last_clip_end_at: None,
-            audio_file: None, notes_written: None,
+            audio_file: None, notes_written: None, title_is_default: false,
         }
     }
 


### PR DESCRIPTION
## Summary

Closes #208. In **local/offline** mode, the note title is now regenerated from the AI notes when they finish generating — but only while the title is still the auto-generated timestamp default. If the user renamed the recording, their title is preserved. Cloud (Ariso) mode is unchanged.

Everything runs on-device; no network calls are added.

## How it works

- **Sidecar (`ariso-stt`, Swift):** the `notes` command now runs a second, cheap LLM turn on the *already-loaded* model and emits `{ "title", "notes" }` JSON instead of raw Markdown. The generated title is sanitized in Swift (strips quotes/markdown markers, collapses whitespace, drops a leading `Meeting`/`Notes`/`Summary` prefix, caps at 40 chars on a word boundary).
- **Rust:** `run_notes` parses the new contract *tolerantly* — valid JSON → `{title, notes}`; any non-JSON stdout falls back to `{ title: None, notes: <raw> }`, so a version skew can't break notes generation.
- **Apply-only-if-default:** a new `title_is_default: bool` on `RecordingMeta` (`#[serde(default)]` → pre-feature `meta.json` migrates to `false`, never auto-retitled) is set `true` on a fresh recording and cleared on user rename. `process_notes` regenerates the title (reusing the existing, tested `vault::rename_recording_artifacts` path) only when the flag is set. It's best-effort: a retitle/rename failure never fails the notes run or loses notes.
- **Frontend:** no change — the local progress poller re-reads the recording when notes go `ready` and shows the new title.

## Testing

- Full Rust suite green: **233 passed, 2 ignored** (`cargo test`, macOS `--test-threads=1`).
- New Rust coverage: tolerant JSON parse + raw fallback + blank-title→`None`; `maybe_apply_generated_title` gating (not-default and whitespace-title no-ops); end-to-end `finalize → notes → title regenerated + vault note file renamed + `audio_file` updated`; `title_is_default` migration and rename-clears-flag.
- Sidecar verified manually (no Swift test target): rebuilt with `xcodebuild ... -scheme ariso-stt -configuration Release`, `notes` on a real transcript emits clean JSON with a sensible, prefix-free title.

## Notes for reviewers

- The `notes` stdout contract changed (raw Markdown → JSON); the tolerant Rust parser keeps this safe across binary/app version skew.
- The model-generated title reaches the filesystem only through `vault::sanitize_component`, which strips path separators / `..` / control chars — path safety is preserved (whole-branch security review confirmed).
- The sidecar binary is a gitignored build artifact; CI rebuilds it because `src-tauri/ariso-stt/Sources/**` changed.

Design spec: `docs/superpowers/specs/2026-07-06-local-notes-title-generation-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for AI-generated local note titles in offline mode, alongside meeting notes.
  * When a title is still the untouched default placeholder, the app can replace it once; custom user titles are preserved.

* **Bug Fixes**
  * Improved compatibility with older/unstructured note-generation output by falling back to the previous behavior when needed.
  * Renaming a local recording now correctly stops it from being treated as a default title going forward.

* **Documentation / Tests**
  * Added an offline title-generation design specification and updated/expanded related automated tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->