### PR TITLE
Add OpenProse listing campaign

### DIFF
--- a/.agents/prose/src/oats-listing-campaign/index.prose.md
+++ b/.agents/prose/src/oats-listing-campaign/index.prose.md
@@ -1,0 +1,443 @@
+---
+name: oats-listing-campaign
+kind: function
+---
+
+# OATS Listing Campaign
+
+### Description
+
+OpenProse-native campaign for turning the OATS listing target research report
+into draft GitHub pull requests and a review report. This is intentionally a
+contract, not a JavaScript batch runner: the host embodies the OpenProse VM,
+fans out workers, adapts to each target repository, and records what happened.
+
+### Parameters
+
+- `research_report_path`: path to the source OATS listing target research report.
+  Default: `docs/outreach/oats-listing-target-research.md`.
+- `target_manifest_path`: path to the structured target manifest derived from
+  the report. Default: `docs/outreach/listing-targets.json`.
+- `oats_profile_path`: path to the canonical OATS listing profile. Default:
+  `docs/outreach/oats-listing-profile.md`.
+- `public_campaign_report_url`: URL to include in external pull request bodies.
+  Default: `https://github.com/ariso-ai/oats/blob/main/docs/outreach/listing-pr-batch-report.md`.
+- `phase`: optional campaign phase filter such as `exact-fit-pr-sprint`.
+- `target_selectors`: optional list of target ids, names, or `owner/repo` values.
+- `limit`: optional maximum number of selected GitHub list targets.
+- `dry_run`: boolean. Default: `true`. When true, do not fork, push, or create
+  pull requests; write a plan report only.
+- `draft_mode`: boolean. Default: `true`. Create draft pull requests when the
+  host is in live mode and GitHub supports drafts.
+- `review_report_path`: path for the local operator report that links draft PRs.
+  Default: `.outreach/listing-pr-runs/{run_id}/review.md`.
+
+### Returns
+
+- `selected_targets`: GitHub list targets chosen from the research report and
+  manifest, with placement hypotheses and fit reasons.
+- `deferred_targets`: report targets that are useful but not handled by GitHub
+  list PR workers in this run, grouped by topic, form, manual, and package work.
+- `pull_requests`: draft pull request receipts, each with target repo, branch,
+  URL, draft status, placement, changed files, and human PR description.
+- `skipped_targets`: targets the workers inspected but did not post to, with the
+  concrete blocker.
+- `review_report`: local Markdown report path and summary linking every created
+  draft PR.
+
+### Errors
+
+- `source_report_unavailable`: the research report or manifest cannot be read.
+- `github_auth_unavailable`: live mode was requested but GitHub authentication
+  or required GitHub tooling is unavailable.
+- `host_cannot_spawn_workers`: live mode was requested in a host that cannot
+  spawn isolated sessions for the target workers.
+
+### Invariants
+
+- `dry_run` is the default. Forking, pushing, and creating pull requests require
+  an explicit caller override.
+- Every external pull request is draft by default and links the public campaign
+  report.
+- Worker scratch stays in `.outreach/` or the OpenProse run workspace; no worker
+  commits generated run state into this repository.
+- Each target worker receives only the single target, the OATS profile, the
+  source-report excerpt or manifest row that justifies the attempt, and the
+  campaign report URL.
+- Each target worker must inspect the target repository's current README,
+  contribution guidance, existing entry style, and open pull requests before
+  editing.
+- Each target worker creates the smallest acceptable listing edit and leaves the
+  target repository unchanged when no honest placement exists.
+- Pull request descriptions must sound like a maintainer-to-maintainer note:
+  concise, specific, factual, and free of automation boilerplate.
+
+### Strategies
+
+- Be liberal when selecting GitHub list targets after the exact-fit split: if
+  OATS plausibly belongs in a Mac, menu bar, note-taking, transcription,
+  privacy, local-first, local-AI, Tauri, Rust, Vue, or open-source alternatives
+  list, include it unless the target's stated rules clearly exclude apps like
+  OATS.
+- Prioritize high-likelihood and high-fit targets first, but keep lower-likelihood
+  list targets visible as deferred or inspect-and-skip results rather than
+  silently dropping them.
+- Prefer existing list language over a fixed OATS blurb. Match section names,
+  link style, punctuation, sort order, description length, and contribution
+  templates from the target repository.
+- Use the repository URL `https://github.com/ariso-ai/oats` as the canonical link
+  unless a target explicitly prefers a website or app-store-style URL.
+- For draft PR bodies, write the short human version: what changed, why OATS fits
+  that list, and that the edit was kept to one listing entry.
+- If draft PR creation fails only because drafts are unsupported, retry as ready
+  only when the caller explicitly set `draft_mode` to false; otherwise record the
+  blocker and continue.
+- Record topic updates, forms, editorial submissions, and package PRs as follow-up
+  lanes in the final report; do not pretend they are GitHub list PRs.
+
+### Environment
+
+- `GH_TOKEN`: optional. Used only by host GitHub tooling when live mode creates
+  forks, pushes branches, or opens pull requests.
+
+### Tools
+
+- `cli:git`: clone, branch, diff, commit, and push target repositories in live
+  mode.
+- `cli:gh`: inspect GitHub repositories and create draft pull requests in live
+  mode.
+
+### Shape
+
+- `self`: read the research report and manifest, select postable GitHub list
+  targets, coordinate worker fan-out, merge worker receipts, and publish the
+  local review report.
+- `delegates`: target selection workers, one listing publisher worker per target,
+  and a report synthesizer.
+- `prohibited`: direct directory form submissions, GitHub topic edits, package
+  index packaging work, posting non-draft PRs unless explicitly requested, or
+  opening pull requests without recording a review report.
+
+### Execution
+
+```prose
+let preflight = call preflight_campaign
+  target_manifest_path: target_manifest_path
+  research_report_path: research_report_path
+  oats_profile_path: oats_profile_path
+  dry_run: dry_run
+
+let target_plan = call select_github_list_targets
+  research_report_path: research_report_path
+  target_manifest_path: target_manifest_path
+  phase: phase
+  target_selectors: target_selectors
+  limit: limit
+  liberal_selection: true
+
+if dry_run:
+  let dry_report = call write_campaign_report
+    mode: "dry-run"
+    selected_targets: target_plan.selected_targets
+    deferred_targets: target_plan.deferred_targets
+    pull_requests: []
+    skipped_targets: []
+    review_report_path: review_report_path
+    public_campaign_report_url: public_campaign_report_url
+
+  return {
+    selected_targets: target_plan.selected_targets,
+    deferred_targets: target_plan.deferred_targets,
+    pull_requests: [],
+    skipped_targets: [],
+    review_report: dry_report
+  }
+
+if preflight live mode is not ready:
+  throw "github_auth_unavailable"
+
+let worker_receipts = target_plan.selected_targets
+  | pmap:
+      call publish_listing_target
+        target: item
+        oats_profile_path: oats_profile_path
+        public_campaign_report_url: public_campaign_report_url
+        draft_mode: draft_mode
+
+let worker_results = call merge_worker_results
+  worker_receipts: worker_receipts
+
+let live_report = call write_campaign_report
+  mode: "live"
+  selected_targets: target_plan.selected_targets
+  deferred_targets: target_plan.deferred_targets
+  pull_requests: worker_results.pull_requests
+  skipped_targets: worker_results.skipped_targets
+  review_report_path: review_report_path
+  public_campaign_report_url: public_campaign_report_url
+
+return {
+  selected_targets: target_plan.selected_targets,
+  deferred_targets: target_plan.deferred_targets,
+  pull_requests: worker_results.pull_requests,
+  skipped_targets: worker_results.skipped_targets,
+  review_report: live_report
+}
+```
+
+## preflight_campaign
+
+### Parameters
+
+- `target_manifest_path`: path to the structured target manifest.
+- `research_report_path`: path to the source research report.
+- `oats_profile_path`: path to the OATS listing profile.
+- `dry_run`: boolean indicating whether live GitHub side effects are disabled.
+
+### Returns
+
+- `status`: `ready`, `dry-run-ready`, or `blocked`.
+- `notes`: concrete checks performed and any missing live-mode capability.
+
+### Strategies
+
+- In dry-run mode, require only readable local input files and a writable report
+  destination.
+- In live mode, require readable inputs, `git`, `gh`, authenticated GitHub
+  access, push capability to forks, and a host that can spawn isolated sessions.
+- Check only secret presence, never the value.
+
+## select_github_list_targets
+
+### Parameters
+
+- `research_report_path`: source research report to treat as the authority for
+  target provenance and fit rationale.
+- `target_manifest_path`: structured manifest derived from the research report.
+- `phase`: optional campaign phase filter.
+- `target_selectors`: optional ids, names, or `owner/repo` values.
+- `limit`: optional maximum target count.
+- `liberal_selection`: boolean; when true, include plausible post-split list
+  targets rather than only exact matches.
+
+### Returns
+
+- `selected_targets`: ordered GitHub list PR targets. Each entry includes id,
+  name, repo, URL, phase, priority, report evidence, fit rationale, placement
+  hypothesis, and worker prompt context.
+- `deferred_targets`: non-list-PR targets and any GitHub rows intentionally held
+  for another lane, grouped with next action.
+
+### Strategies
+
+- Read the source report first, then use the manifest for structure; if they
+  disagree, preserve the report's rationale and mark the manifest issue.
+- Select only targets whose submission kind is `github-pr` for publisher workers.
+- Include `package-pr` targets only in deferred packaging lanes.
+- Include `github-topic`, `form`, and `manual` targets only in deferred follow-up
+  lanes.
+- Sort by priority, then high acceptance likelihood, then exact audience fit.
+- When `phase` or `target_selectors` is provided, filter after the report/manifest
+  consistency pass.
+- When `limit` is provided, still count and summarize the omitted eligible targets.
+
+### Execution
+
+```prose
+agent target_scout:
+  model: sonnet
+  persist: project
+  prompt: """
+    You filter OATS listing targets from the source research report.
+
+    Be liberal after the exact-fit split: keep GitHub list repos when OATS
+    plausibly belongs as a Mac app, menu bar app, note-taking app, transcription
+    tool, privacy/local-first tool, local-AI app, Tauri app, Rust/Vue app, or
+    open-source alternative.
+
+    Return structured target rows, not prose-only notes. Preserve the report's
+    rationale and URL for each decision.
+  """
+  shape:
+    self: ["source-report filtering", "fit scoring", "deferred-lane grouping"]
+    prohibited: ["posting PRs", "editing repositories"]
+
+parallel:
+  let exact_fit_targets = session exact-fit-scout: target_scout
+    prompt: """
+      From the source report and manifest, select the exact-fit GitHub list PR
+      targets for Mac apps, menu bar apps, note-taking, meeting notes,
+      transcription, Whisper/ASR, local-first, privacy, and OATS alternatives.
+      Apply the phase, target selector, and limit only after preserving the full
+      eligible count.
+    """
+    context: { research_report_path, target_manifest_path, phase, target_selectors, limit }
+
+  let ecosystem_targets = session ecosystem-scout: target_scout
+    prompt: """
+      From the source report and manifest, select plausible ecosystem GitHub list
+      PR targets for Tauri, Rust, Vue, local AI, open-source apps, and broader
+      productivity or alternatives lists. Be liberal, but attach a fit caveat
+      when acceptance is medium or low.
+    """
+    context: { research_report_path, target_manifest_path, phase, target_selectors, limit }
+
+  let deferred_lanes = session deferred-lane-scout: target_scout
+    prompt: """
+      From the source report and manifest, group all GitHub topic, form, manual,
+      and package-PR targets into follow-up lanes. Do not include them in the
+      publisher-worker set.
+    """
+    context: { research_report_path, target_manifest_path, phase, target_selectors, limit }
+
+let merged_plan = session target-plan-merge: target_scout
+  prompt: """
+    Merge the scout outputs into one ordered campaign plan.
+    Deduplicate targets by GitHub repo, keep the most specific fit rationale,
+    sort by manifest priority and acceptance likelihood, then apply the caller
+    limit. Return selected_targets and deferred_targets.
+  """
+  context: { exact_fit_targets, ecosystem_targets, deferred_lanes, liberal_selection }
+
+return merged_plan
+```
+
+## publish_listing_target
+
+### Parameters
+
+- `target`: one selected GitHub list target with report evidence and manifest
+  metadata.
+- `oats_profile_path`: path to the canonical OATS listing profile.
+- `public_campaign_report_url`: public report URL to link from the pull request.
+- `draft_mode`: boolean indicating whether to create the pull request as draft.
+
+### Returns
+
+- `pull_requests`: zero or one draft PR receipt for the target.
+- `skipped_targets`: zero or one skip receipt for the target.
+
+### Invariants
+
+- The worker may edit only the cloned target repository, not this OATS repository.
+- The worker must not commit if it cannot name the exact section and entry format
+  that make OATS fit.
+- The commit message must be a valid Conventional Commit, preferably
+  `docs: add oats`.
+- The worker must record the exact changed files and the final entry text.
+
+### Shape
+
+- `self`: inspect one target repository, make one minimal listing edit, and open
+  one draft PR when appropriate.
+- `prohibited`: broad rewrites, adding badges/screenshots, modifying unrelated
+  sections, inventing claims about OATS, or opening multiple PRs for one target.
+
+### Execution
+
+```prose
+agent listing_publisher:
+  model: sonnet
+  persist: project
+  prompt: """
+    You are adding OATS to one public curated GitHub list.
+
+    Work like a human maintainer would:
+    - Inspect the current target repository before editing.
+    - Read the README, contribution guide, list sections, examples, and open pull
+      requests that may affect placement.
+    - Add one OATS entry in the most specific honest section.
+    - Match the target list's existing ordering, punctuation, link style, and
+      description length.
+    - Prefer the OATS GitHub URL unless the target requires a website URL.
+    - Use a factual short description from the OATS profile.
+    - If the list rules exclude OATS or no good section exists, do not edit; return
+      a skip receipt with the exact blocker.
+    - If you edit, commit with a Conventional Commit and create a concise draft PR
+      body that links the public campaign report.
+  """
+  shape:
+    self: ["repository inspection", "minimal list editing", "draft PR creation"]
+    prohibited: ["editing this OATS repo", "rewriting unrelated list content", "marketing copy"]
+
+let placement = session target-placement: listing_publisher
+  prompt: """
+    Inspect the target repository and decide whether OATS belongs.
+    Return: target repo, file path, section heading, ordering rule, exact entry
+    format, contribution constraints, and a yes/no placement decision.
+  """
+  context: { target, oats_profile_path, public_campaign_report_url }
+
+if placement says OATS should not be posted:
+  return {
+    pull_requests: [],
+    skipped_targets: [placement]
+  }
+
+let publication = session target-publication: listing_publisher
+  prompt: """
+    Make the smallest acceptable listing edit for OATS, commit it, push a branch,
+    and open the pull request.
+
+    Pull request body requirements:
+    - one short summary sentence
+    - one short fit paragraph specific to this target list
+    - link the public campaign report
+    - no automation disclosure unless the target requires it
+    - draft mode if supported and requested
+
+    Return the PR URL, draft status, branch, changed files, section used, final
+    entry text, commit message, and any caveats.
+  """
+  context: { target, placement, oats_profile_path, public_campaign_report_url, draft_mode }
+
+return publication
+```
+
+## merge_worker_results
+
+### Parameters
+
+- `worker_receipts`: ordered collection returned by `publish_listing_target`
+  workers.
+
+### Returns
+
+- `pull_requests`: flattened PR receipt collection.
+- `skipped_targets`: flattened skip receipt collection.
+- `failures`: worker failures that did not produce either receipt shape.
+
+### Strategies
+
+- Preserve input target order for successful and skipped receipts.
+- Treat malformed receipts as failures with the target id if it can be recovered.
+- Do not drop failures; the final report must make them reviewable.
+
+## write_campaign_report
+
+### Parameters
+
+- `mode`: `dry-run` or `live`.
+- `selected_targets`: targets selected for publisher workers.
+- `deferred_targets`: non-PR or held targets grouped by follow-up lane.
+- `pull_requests`: pull request receipts returned by workers.
+- `skipped_targets`: skip receipts returned by workers.
+- `review_report_path`: local report path requested by the caller.
+- `public_campaign_report_url`: public campaign report URL linked from PRs.
+
+### Returns
+
+- `review_report`: local Markdown report path, headline counts, draft PR links,
+  skipped targets, deferred lanes, and next recommended run.
+
+### Strategies
+
+- The report is for the OATS maintainer to review, so lead with draft PR links
+  and blockers rather than implementation details.
+- Include enough context for each PR to decide whether to review, revise, or close:
+  target, section, final entry text, worker caveats, and PR URL.
+- In dry-run mode, include target placement hypotheses and exact live-mode command
+  prompt, but do not imply PRs were created.
+- Keep the public campaign report URL separate from the local operator report:
+  external PRs link the public report, while the operator report links the draft
+  PRs.

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,11 @@
 dist/
 node_modules/
 output/
+.outreach/
+.agents/prose/deps/
+.agents/prose/dist/
+.agents/prose/runs/
+.agents/prose/.env
 src-tauri/target/
 src-tauri/binaries/
 src-tauri/ariso-stt/.build/

--- a/docs/outreach/listing-pr-batch-report.md
+++ b/docs/outreach/listing-pr-batch-report.md
@@ -1,0 +1,100 @@
+# oats listing PR batch report
+
+This report supports the draft PR batch for adding oats to public software lists
+and catalogs. External PR bodies should link here so maintainers can inspect the
+campaign scope, source manifest, and positioning in one place.
+
+## Scope
+
+- Source research identified 103 deduplicated listing targets.
+- The OpenProse campaign posts only GitHub PR-capable list targets.
+- GitHub topic updates, form submissions, editorial directories, and package
+  indexes that need deeper packaging work remain visible in the manifest but are
+  not silently treated as list PRs.
+
+## Target mix
+
+| Submission kind | Count | Handling |
+|---|---:|---|
+| GitHub list PR | 66 | OpenProse worker PRs, draft by default |
+| GitHub topic | 22 | Manual repo metadata update |
+| Form submission | 7 | Manual directory submission |
+| Manual/editorial | 5 | Manual review before outreach |
+| Package PR | 3 | Manual packaging pass |
+
+The source research report is
+[`docs/outreach/oats-listing-target-research.md`](oats-listing-target-research.md).
+The structured manifest derived from it is
+[`docs/outreach/listing-targets.json`](listing-targets.json).
+
+## OpenProse path
+
+The campaign lives at
+[`../../.agents/prose/src/oats-listing-campaign/index.prose.md`](../../.agents/prose/src/oats-listing-campaign/index.prose.md).
+It is native OpenProse Contract Markdown, so it should be run by a Prose Complete
+host that embodies `prose run`; it should not shell out to a `prose` binary.
+
+The contract does this:
+
+1. Read the source report and structured manifest.
+2. Fan out target-selection workers to keep GitHub list PR targets that plausibly
+   fit OATS, using a liberal post-split decision.
+3. Defer GitHub topics, forms, editorial directories, and package indexes into
+   follow-up lanes.
+4. In live mode, fan out one publisher worker per selected target. Each worker
+   inspects the target repository, finds the right section, makes one minimal
+   listing edit, commits with a Conventional Commit message, and opens a draft
+   PR when possible.
+5. Write a local operator report under `.outreach/listing-pr-runs/` with links
+   to the draft PRs, skipped targets, and deferred follow-ups.
+
+## Preferred prompt
+
+Use a dry run first:
+
+```text
+prose run .agents/prose/src/oats-listing-campaign/index.prose.md
+
+Parameters:
+- research_report_path: docs/outreach/oats-listing-target-research.md
+- target_manifest_path: docs/outreach/listing-targets.json
+- oats_profile_path: docs/outreach/oats-listing-profile.md
+- phase: exact-fit-pr-sprint
+- limit: 10
+- dry_run: true
+- draft_mode: true
+```
+
+After reviewing the dry-run report, run a small live batch:
+
+```text
+prose run .agents/prose/src/oats-listing-campaign/index.prose.md
+
+Parameters:
+- research_report_path: docs/outreach/oats-listing-target-research.md
+- target_manifest_path: docs/outreach/listing-targets.json
+- oats_profile_path: docs/outreach/oats-listing-profile.md
+- phase: exact-fit-pr-sprint
+- limit: 3
+- dry_run: false
+- draft_mode: true
+```
+
+## PR positioning
+
+oats should be proposed as an open-source macOS menu bar meeting-notes app with
+live transcription, speaker labels, AI summaries, and a fully offline on-device
+mode. The canonical listing profile lives in
+[`docs/outreach/oats-listing-profile.md`](oats-listing-profile.md).
+
+External PR descriptions should be short and human:
+
+```text
+Adds OATS to the [section] list.
+
+OATS fits here as an open-source macOS menu bar app for meeting transcription
+and AI notes, with an optional fully on-device mode for privacy-sensitive work.
+I kept the edit to one listing entry and matched the existing format.
+
+Campaign context: <public campaign report URL>
+```

--- a/docs/outreach/listing-targets.json
+++ b/docs/outreach/listing-targets.json
@@ -1,0 +1,2808 @@
+{
+  "$schema": "https://ariso.ai/schemas/oats-listing-targets.schema.json",
+  "generatedAt": "2026-07-07T00:00:00-04:00",
+  "source": {
+    "title": "OATS Listing Target Research Report",
+    "note": "Derived from the attached research report supplied to the Codex session on 2026-07-07."
+  },
+  "oats": {
+    "name": "oats",
+    "repository": "https://github.com/ariso-ai/oats",
+    "website": "https://ariso.ai",
+    "download": "https://github.com/ariso-ai/oats/releases/latest",
+    "license": "MIT",
+    "platform": "macOS 14+ on Apple Silicon",
+    "pitch": "oats is an open-source macOS menu bar app that records meetings, streams transcripts, labels speakers, and writes clean Markdown notes, with a free cloud backend or a fully offline on-device mode.",
+    "shortPitch": "Open-source macOS menu bar meeting-notes app with live transcription, speaker labels, AI summaries, and a fully offline on-device mode.",
+    "tags": [
+      "macos",
+      "meeting-notes",
+      "speech-to-text",
+      "transcription",
+      "ai-notes",
+      "local-first",
+      "privacy",
+      "menubar-app",
+      "apple-silicon",
+      "tauri",
+      "rust",
+      "vue"
+    ]
+  },
+  "targets": [
+    {
+      "id": "tauri-apps-awesome-tauri",
+      "name": "tauri-apps/awesome-tauri",
+      "url": "https://github.com/tauri-apps/awesome-tauri",
+      "sourceLabel": "GitHub",
+      "type": "awesome list",
+      "phase": "ecosystem-sprint",
+      "primaryAudience": "Tauri builders",
+      "intent": "ecosystem showcase",
+      "submission": {
+        "kind": "github-pr",
+        "method": "PR",
+        "githubRepo": "tauri-apps/awesome-tauri",
+        "draftPullRequest": true
+      },
+      "acceptance": {
+        "likelihood": "High",
+        "rationale": "exact framework fit"
+      },
+      "tags": [
+        "tauri",
+        "desktop-app",
+        "rust",
+        "macos"
+      ],
+      "geographicOrLanguageFocus": "Global / English",
+      "priority": 1
+    },
+    {
+      "id": "jaywcjlove-awesome-mac",
+      "name": "jaywcjlove/awesome-mac",
+      "url": "https://github.com/jaywcjlove/awesome-mac",
+      "sourceLabel": "GitHub",
+      "type": "awesome list",
+      "phase": "exact-fit-pr-sprint",
+      "primaryAudience": "Mac users",
+      "intent": "Mac app discovery",
+      "submission": {
+        "kind": "github-pr",
+        "method": "PR",
+        "githubRepo": "jaywcjlove/awesome-mac",
+        "draftPullRequest": true
+      },
+      "acceptance": {
+        "likelihood": "High",
+        "rationale": "strong Mac/deskop fit, PRs welcome"
+      },
+      "tags": [
+        "macos",
+        "productivity",
+        "menubar",
+        "open-source"
+      ],
+      "geographicOrLanguageFocus": "Global / English",
+      "priority": 2
+    },
+    {
+      "id": "serhii-londar-open-source-mac-os-apps",
+      "name": "serhii-londar/open-source-mac-os-apps",
+      "url": "https://github.com/serhii-londar/open-source-mac-os-apps",
+      "sourceLabel": "GitHub",
+      "type": "awesome list",
+      "phase": "exact-fit-pr-sprint",
+      "primaryAudience": "Mac OSS users",
+      "intent": "open-source Mac apps",
+      "submission": {
+        "kind": "github-pr",
+        "method": "PR",
+        "githubRepo": "serhii-londar/open-source-mac-os-apps",
+        "draftPullRequest": true
+      },
+      "acceptance": {
+        "likelihood": "High",
+        "rationale": "exact scope match"
+      },
+      "tags": [
+        "macos",
+        "open-source",
+        "productivity",
+        "notes"
+      ],
+      "geographicOrLanguageFocus": "Global / English",
+      "priority": 3
+    },
+    {
+      "id": "ichait-awesome-macos",
+      "name": "iCHAIT/awesome-macOS",
+      "url": "https://github.com/iCHAIT/awesome-macOS",
+      "sourceLabel": "GitHub",
+      "type": "awesome list",
+      "phase": "exact-fit-pr-sprint",
+      "primaryAudience": "Mac users",
+      "intent": "Mac software discovery",
+      "submission": {
+        "kind": "github-pr",
+        "method": "PR",
+        "githubRepo": "iCHAIT/awesome-macOS",
+        "draftPullRequest": true
+      },
+      "acceptance": {
+        "likelihood": "High",
+        "rationale": "Mac app list with contribution guide"
+      },
+      "tags": [
+        "macos",
+        "menubar",
+        "productivity",
+        "notes"
+      ],
+      "geographicOrLanguageFocus": "Global / English",
+      "priority": 4
+    },
+    {
+      "id": "phmullins-awesome-macos",
+      "name": "phmullins/awesome-macos",
+      "url": "https://github.com/phmullins/awesome-macos",
+      "sourceLabel": "GitHub",
+      "type": "awesome list",
+      "phase": "exact-fit-pr-sprint",
+      "primaryAudience": "Mac users",
+      "intent": "categorized Mac apps",
+      "submission": {
+        "kind": "github-pr",
+        "method": "PR",
+        "githubRepo": "phmullins/awesome-macos",
+        "draftPullRequest": true
+      },
+      "acceptance": {
+        "likelihood": "High",
+        "rationale": "broad Mac coverage"
+      },
+      "tags": [
+        "macos",
+        "productivity",
+        "communication",
+        "docs"
+      ],
+      "geographicOrLanguageFocus": "Global / English",
+      "priority": 5
+    },
+    {
+      "id": "viraat-awesome-mac-apps",
+      "name": "viraat/awesome-mac-apps",
+      "url": "https://github.com/viraat/awesome-mac-apps",
+      "sourceLabel": "GitHub",
+      "type": "awesome list",
+      "phase": "exact-fit-pr-sprint",
+      "primaryAudience": "Mac developers",
+      "intent": "free/open-source Mac apps",
+      "submission": {
+        "kind": "github-pr",
+        "method": "PR / issue",
+        "githubRepo": "viraat/awesome-mac-apps",
+        "draftPullRequest": true
+      },
+      "acceptance": {
+        "likelihood": "High",
+        "rationale": "open-source Mac apps focus"
+      },
+      "tags": [
+        "macos",
+        "open-source",
+        "productivity"
+      ],
+      "geographicOrLanguageFocus": "Global / English",
+      "priority": 6
+    },
+    {
+      "id": "jordanbaird-awesome-menubar",
+      "name": "jordanbaird/awesome-menubar",
+      "url": "https://github.com/jordanbaird/awesome-menubar",
+      "sourceLabel": "GitHub",
+      "type": "awesome list",
+      "phase": "exact-fit-pr-sprint",
+      "primaryAudience": "menubar-app users",
+      "intent": "menu bar app discovery",
+      "submission": {
+        "kind": "github-pr",
+        "method": "PR",
+        "githubRepo": "jordanbaird/awesome-menubar",
+        "draftPullRequest": true
+      },
+      "acceptance": {
+        "likelihood": "High",
+        "rationale": "exact UI pattern fit"
+      },
+      "tags": [
+        "menubar-app",
+        "macos",
+        "productivity"
+      ],
+      "geographicOrLanguageFocus": "Global / English",
+      "priority": 7
+    },
+    {
+      "id": "tborychowski-awesome-mac",
+      "name": "tborychowski/awesome-mac",
+      "url": "https://github.com/tborychowski/awesome-mac",
+      "sourceLabel": "GitHub",
+      "type": "awesome list",
+      "phase": "exact-fit-pr-sprint",
+      "primaryAudience": "Mac power users",
+      "intent": "personal Mac app curation",
+      "submission": {
+        "kind": "github-pr",
+        "method": "issue / PR",
+        "githubRepo": "tborychowski/awesome-mac",
+        "draftPullRequest": true
+      },
+      "acceptance": {
+        "likelihood": "Medium",
+        "rationale": "subjective list, but OATS fits"
+      },
+      "tags": [
+        "macos",
+        "ai",
+        "notes",
+        "productivity"
+      ],
+      "geographicOrLanguageFocus": "Global / English",
+      "priority": 8
+    },
+    {
+      "id": "antelle-my-awesome-mac-apps",
+      "name": "antelle/my-awesome-mac-apps",
+      "url": "https://github.com/antelle/my-awesome-mac-apps",
+      "sourceLabel": "GitHub",
+      "type": "awesome list",
+      "phase": "exact-fit-pr-sprint",
+      "primaryAudience": "Mac power users",
+      "intent": "curated Mac app picks",
+      "submission": {
+        "kind": "github-pr",
+        "method": "PR",
+        "githubRepo": "antelle/my-awesome-mac-apps",
+        "draftPullRequest": true
+      },
+      "acceptance": {
+        "likelihood": "Medium",
+        "rationale": "personal list, still accepts contributions"
+      },
+      "tags": [
+        "macos",
+        "productivity",
+        "notes"
+      ],
+      "geographicOrLanguageFocus": "Global / English",
+      "priority": 9
+    },
+    {
+      "id": "feep-awesome-apple-silicon",
+      "name": "feep/awesome-apple-silicon",
+      "url": "https://github.com/feep/awesome-apple-silicon",
+      "sourceLabel": "GitHub",
+      "type": "awesome list",
+      "phase": "exact-fit-pr-sprint",
+      "primaryAudience": "Apple Silicon users",
+      "intent": "Apple Silicon software resources",
+      "submission": {
+        "kind": "github-pr",
+        "method": "PR",
+        "githubRepo": "feep/awesome-apple-silicon",
+        "draftPullRequest": true
+      },
+      "acceptance": {
+        "likelihood": "High",
+        "rationale": "OATS requires Apple Silicon"
+      },
+      "tags": [
+        "apple-silicon",
+        "macos",
+        "native"
+      ],
+      "geographicOrLanguageFocus": "Global / English",
+      "priority": 10
+    },
+    {
+      "id": "smashism-awesome-macadmin-tools",
+      "name": "smashism/awesome-macadmin-tools",
+      "url": "https://github.com/smashism/awesome-macadmin-tools",
+      "sourceLabel": "GitHub",
+      "type": "awesome list",
+      "phase": "exact-fit-pr-sprint",
+      "primaryAudience": "Mac admins",
+      "intent": "Mac tooling discovery",
+      "submission": {
+        "kind": "github-pr",
+        "method": "PR",
+        "githubRepo": "smashism/awesome-macadmin-tools",
+        "draftPullRequest": true
+      },
+      "acceptance": {
+        "likelihood": "Low",
+        "rationale": "audience is admins, not end users"
+      },
+      "tags": [
+        "macos",
+        "utility",
+        "menubar"
+      ],
+      "geographicOrLanguageFocus": "Global / English",
+      "priority": 11
+    },
+    {
+      "id": "rust-unofficial-awesome-rust",
+      "name": "rust-unofficial/awesome-rust",
+      "url": "https://github.com/rust-unofficial/awesome-rust",
+      "sourceLabel": "GitHub",
+      "type": "awesome list",
+      "phase": "ecosystem-sprint",
+      "primaryAudience": "Rust developers",
+      "intent": "Rust project discovery",
+      "submission": {
+        "kind": "github-pr",
+        "method": "PR",
+        "githubRepo": "rust-unofficial/awesome-rust",
+        "draftPullRequest": true
+      },
+      "acceptance": {
+        "likelihood": "Medium",
+        "rationale": "broad, but OATS is a Rust app"
+      },
+      "tags": [
+        "rust",
+        "desktop-app",
+        "productivity"
+      ],
+      "geographicOrLanguageFocus": "Global / English",
+      "priority": 12
+    },
+    {
+      "id": "awesome-rust-com-awesome-rust",
+      "name": "awesome-rust-com/awesome-rust",
+      "url": "https://github.com/awesome-rust-com/awesome-rust",
+      "sourceLabel": "GitHub",
+      "type": "awesome list",
+      "phase": "ecosystem-sprint",
+      "primaryAudience": "Rust developers",
+      "intent": "Rust frameworks and software",
+      "submission": {
+        "kind": "github-pr",
+        "method": "PR",
+        "githubRepo": "awesome-rust-com/awesome-rust",
+        "draftPullRequest": true
+      },
+      "acceptance": {
+        "likelihood": "Medium",
+        "rationale": "broad but apps section exists"
+      },
+      "tags": [
+        "rust",
+        "application",
+        "macos"
+      ],
+      "geographicOrLanguageFocus": "Global / English",
+      "priority": 13
+    },
+    {
+      "id": "vuejs-awesome-vue",
+      "name": "vuejs/awesome-vue",
+      "url": "https://github.com/vuejs/awesome-vue",
+      "sourceLabel": "GitHub",
+      "type": "awesome list",
+      "phase": "ecosystem-sprint",
+      "primaryAudience": "Vue developers",
+      "intent": "Vue ecosystem discovery",
+      "submission": {
+        "kind": "github-pr",
+        "method": "PR",
+        "githubRepo": "vuejs/awesome-vue",
+        "draftPullRequest": true
+      },
+      "acceptance": {
+        "likelihood": "Medium",
+        "rationale": "broad framework list"
+      },
+      "tags": [
+        "vue",
+        "tauri-frontend",
+        "desktop-ui"
+      ],
+      "geographicOrLanguageFocus": "Global / English",
+      "priority": 14
+    },
+    {
+      "id": "sonicoder86-awesome-vue-3",
+      "name": "sonicoder86/awesome-vue-3",
+      "url": "https://github.com/sonicoder86/awesome-vue-3",
+      "sourceLabel": "GitHub",
+      "type": "awesome list",
+      "phase": "ecosystem-sprint",
+      "primaryAudience": "Vue 3 developers",
+      "intent": "Vue 3 tooling and examples",
+      "submission": {
+        "kind": "github-pr",
+        "method": "PR",
+        "githubRepo": "sonicoder86/awesome-vue-3",
+        "draftPullRequest": true
+      },
+      "acceptance": {
+        "likelihood": "Medium",
+        "rationale": "broad, but OATS uses Vue"
+      },
+      "tags": [
+        "vue3",
+        "desktop-ui",
+        "productivity"
+      ],
+      "geographicOrLanguageFocus": "Global / English",
+      "priority": 15
+    },
+    {
+      "id": "sudhakar3697-awesome-electron-alternatives",
+      "name": "sudhakar3697/awesome-electron-alternatives",
+      "url": "https://github.com/sudhakar3697/awesome-electron-alternatives",
+      "sourceLabel": "GitHub",
+      "type": "awesome list",
+      "phase": "ecosystem-sprint",
+      "primaryAudience": "desktop-app builders",
+      "intent": "Electron alternatives",
+      "submission": {
+        "kind": "github-pr",
+        "method": "PR",
+        "githubRepo": "sudhakar3697/awesome-electron-alternatives",
+        "draftPullRequest": true
+      },
+      "acceptance": {
+        "likelihood": "High",
+        "rationale": "Tauri app is an exact alt-to-Electron ecosystem fit"
+      },
+      "tags": [
+        "tauri",
+        "desktop-app",
+        "rust",
+        "performance"
+      ],
+      "geographicOrLanguageFocus": "Global / English",
+      "priority": 16
+    },
+    {
+      "id": "pluja-awesome-privacy",
+      "name": "pluja/awesome-privacy",
+      "url": "https://github.com/pluja/awesome-privacy",
+      "sourceLabel": "GitHub",
+      "type": "awesome list",
+      "phase": "exact-fit-pr-sprint",
+      "primaryAudience": "privacy-focused users",
+      "intent": "privacy-respecting services/tools",
+      "submission": {
+        "kind": "github-pr",
+        "method": "PR",
+        "githubRepo": "pluja/awesome-privacy",
+        "draftPullRequest": true
+      },
+      "acceptance": {
+        "likelihood": "High",
+        "rationale": "privacy/on-device positioning aligns closely"
+      },
+      "tags": [
+        "privacy",
+        "local-first",
+        "on-device"
+      ],
+      "geographicOrLanguageFocus": "Global / English",
+      "priority": 17
+    },
+    {
+      "id": "lissy93-awesome-privacy",
+      "name": "lissy93/awesome-privacy",
+      "url": "https://github.com/lissy93/awesome-privacy",
+      "sourceLabel": "GitHub",
+      "type": "awesome list",
+      "phase": "exact-fit-pr-sprint",
+      "primaryAudience": "privacy-focused users",
+      "intent": "privacy tools discovery",
+      "submission": {
+        "kind": "github-pr",
+        "method": "PR",
+        "githubRepo": "lissy93/awesome-privacy",
+        "draftPullRequest": true
+      },
+      "acceptance": {
+        "likelihood": "High",
+        "rationale": "strong privacy-first fit"
+      },
+      "tags": [
+        "privacy",
+        "macos",
+        "notes",
+        "local"
+      ],
+      "geographicOrLanguageFocus": "Global / English",
+      "priority": 18
+    },
+    {
+      "id": "ianonymous3000-awesome-privacy-tools",
+      "name": "iAnonymous3000/awesome-privacy-tools",
+      "url": "https://github.com/iAnonymous3000/awesome-privacy-tools",
+      "sourceLabel": "GitHub",
+      "type": "awesome list",
+      "phase": "exact-fit-pr-sprint",
+      "primaryAudience": "privacy users",
+      "intent": "privacy tool catalog",
+      "submission": {
+        "kind": "github-pr",
+        "method": "PR",
+        "githubRepo": "iAnonymous3000/awesome-privacy-tools",
+        "draftPullRequest": true
+      },
+      "acceptance": {
+        "likelihood": "High",
+        "rationale": "OATS’s privacy story is central"
+      },
+      "tags": [
+        "privacy",
+        "note-taking",
+        "local-first"
+      ],
+      "geographicOrLanguageFocus": "Global / English",
+      "priority": 19
+    },
+    {
+      "id": "janhq-awesome-local-ai",
+      "name": "janhq/awesome-local-ai",
+      "url": "https://github.com/janhq/awesome-local-ai",
+      "sourceLabel": "GitHub",
+      "type": "awesome list",
+      "phase": "exact-fit-pr-sprint",
+      "primaryAudience": "local-AI users",
+      "intent": "run AI locally",
+      "submission": {
+        "kind": "github-pr",
+        "method": "PR",
+        "githubRepo": "janhq/awesome-local-ai",
+        "draftPullRequest": true
+      },
+      "acceptance": {
+        "likelihood": "High",
+        "rationale": "OATS can run fully on-device"
+      },
+      "tags": [
+        "local-ai",
+        "on-device",
+        "privacy",
+        "macos"
+      ],
+      "geographicOrLanguageFocus": "Global / English",
+      "priority": 20
+    },
+    {
+      "id": "msb-msb-awesome-local-ai",
+      "name": "msb-msb/awesome-local-ai",
+      "url": "https://github.com/msb-msb/awesome-local-ai",
+      "sourceLabel": "GitHub",
+      "type": "awesome list",
+      "phase": "exact-fit-pr-sprint",
+      "primaryAudience": "local-AI users",
+      "intent": "consumer local AI resources",
+      "submission": {
+        "kind": "github-pr",
+        "method": "PR",
+        "githubRepo": "msb-msb/awesome-local-ai",
+        "draftPullRequest": true
+      },
+      "acceptance": {
+        "likelihood": "High",
+        "rationale": "privacy/local hardware angle matches"
+      },
+      "tags": [
+        "local-ai",
+        "on-device",
+        "apple-silicon"
+      ],
+      "geographicOrLanguageFocus": "Global / English",
+      "priority": 21
+    },
+    {
+      "id": "rafska-awesome-local-llm",
+      "name": "rafska/awesome-local-llm",
+      "url": "https://github.com/rafska/awesome-local-llm",
+      "sourceLabel": "GitHub",
+      "type": "awesome list",
+      "phase": "exact-fit-pr-sprint",
+      "primaryAudience": "local-LLM users",
+      "intent": "local model tools/platforms",
+      "submission": {
+        "kind": "github-pr",
+        "method": "PR",
+        "githubRepo": "rafska/awesome-local-llm",
+        "draftPullRequest": true
+      },
+      "acceptance": {
+        "likelihood": "Medium",
+        "rationale": "OATS is app-layer, not model infra"
+      },
+      "tags": [
+        "local-llm",
+        "local-ai",
+        "on-device"
+      ],
+      "geographicOrLanguageFocus": "Global / English",
+      "priority": 22
+    },
+    {
+      "id": "vince-lam-awesome-local-llms",
+      "name": "vince-lam/awesome-local-llms",
+      "url": "https://github.com/vince-lam/awesome-local-llms",
+      "sourceLabel": "GitHub",
+      "type": "awesome list",
+      "phase": "exact-fit-pr-sprint",
+      "primaryAudience": "local-LLM users",
+      "intent": "compare local-LLM projects",
+      "submission": {
+        "kind": "github-pr",
+        "method": "PR",
+        "githubRepo": "vince-lam/awesome-local-llms",
+        "draftPullRequest": true
+      },
+      "acceptance": {
+        "likelihood": "Medium",
+        "rationale": "infra-adjacent but still relevant"
+      },
+      "tags": [
+        "local-ai",
+        "privacy",
+        "on-device"
+      ],
+      "geographicOrLanguageFocus": "Global / English",
+      "priority": 23
+    },
+    {
+      "id": "awesome-selfhosted-awesome-selfhosted",
+      "name": "awesome-selfhosted/awesome-selfhosted",
+      "url": "https://github.com/awesome-selfhosted/awesome-selfhosted",
+      "sourceLabel": "GitHub",
+      "type": "awesome list",
+      "phase": "exact-fit-pr-sprint",
+      "primaryAudience": "self-hosting users",
+      "intent": "self-hosted software discovery",
+      "submission": {
+        "kind": "github-pr",
+        "method": "PR",
+        "githubRepo": "awesome-selfhosted/awesome-selfhosted",
+        "draftPullRequest": true
+      },
+      "acceptance": {
+        "likelihood": "Low",
+        "rationale": "OATS is desktop-first, not a hosted service"
+      },
+      "tags": [
+        "local-first",
+        "privacy",
+        "self-hosted-ish"
+      ],
+      "geographicOrLanguageFocus": "Global / English",
+      "priority": 24
+    },
+    {
+      "id": "haiiiiiyun-awesome-selfhosted-cn",
+      "name": "haiiiiiyun/awesome-selfhosted-cn",
+      "url": "https://github.com/haiiiiiyun/awesome-selfhosted-cn",
+      "sourceLabel": "GitHub",
+      "type": "awesome list",
+      "phase": "exact-fit-pr-sprint",
+      "primaryAudience": "Chinese self-hosting users",
+      "intent": "localized self-hosted catalog",
+      "submission": {
+        "kind": "github-pr",
+        "method": "PR",
+        "githubRepo": "haiiiiiyun/awesome-selfhosted-cn",
+        "draftPullRequest": true
+      },
+      "acceptance": {
+        "likelihood": "Low",
+        "rationale": "same mismatch as above"
+      },
+      "tags": [
+        "privacy",
+        "local",
+        "notes"
+      ],
+      "geographicOrLanguageFocus": "China / Chinese",
+      "priority": 25
+    },
+    {
+      "id": "alexanderop-awesome-local-first",
+      "name": "alexanderop/awesome-local-first",
+      "url": "https://github.com/alexanderop/awesome-local-first",
+      "sourceLabel": "GitHub",
+      "type": "awesome list",
+      "phase": "exact-fit-pr-sprint",
+      "primaryAudience": "local-first builders/users",
+      "intent": "local-first software catalog",
+      "submission": {
+        "kind": "github-pr",
+        "method": "PR",
+        "githubRepo": "alexanderop/awesome-local-first",
+        "draftPullRequest": true
+      },
+      "acceptance": {
+        "likelihood": "High",
+        "rationale": "exact architectural fit"
+      },
+      "tags": [
+        "local-first",
+        "privacy",
+        "offline",
+        "notes"
+      ],
+      "geographicOrLanguageFocus": "Global / English",
+      "priority": 26
+    },
+    {
+      "id": "schickling-awesome-local-first",
+      "name": "schickling/awesome-local-first",
+      "url": "https://github.com/schickling/awesome-local-first",
+      "sourceLabel": "GitHub",
+      "type": "awesome list",
+      "phase": "exact-fit-pr-sprint",
+      "primaryAudience": "local-first builders",
+      "intent": "local-first projects",
+      "submission": {
+        "kind": "github-pr",
+        "method": "PR",
+        "githubRepo": "schickling/awesome-local-first",
+        "draftPullRequest": true
+      },
+      "acceptance": {
+        "likelihood": "High",
+        "rationale": "exact fit"
+      },
+      "tags": [
+        "local-first",
+        "collaboration",
+        "notes"
+      ],
+      "geographicOrLanguageFocus": "Global / English",
+      "priority": 27
+    },
+    {
+      "id": "alantriesagain-awesome-local-first",
+      "name": "alantriesagain/awesome-local-first",
+      "url": "https://github.com/alantriesagain/awesome-local-first",
+      "sourceLabel": "GitHub",
+      "type": "awesome list",
+      "phase": "exact-fit-pr-sprint",
+      "primaryAudience": "local-first builders",
+      "intent": "local-first apps/resources",
+      "submission": {
+        "kind": "github-pr",
+        "method": "PR",
+        "githubRepo": "alantriesagain/awesome-local-first",
+        "draftPullRequest": true
+      },
+      "acceptance": {
+        "likelihood": "High",
+        "rationale": "direct fit"
+      },
+      "tags": [
+        "local-first",
+        "privacy",
+        "offline"
+      ],
+      "geographicOrLanguageFocus": "Global / English",
+      "priority": 28
+    },
+    {
+      "id": "zhongkechen-awesome-local-first",
+      "name": "zhongkechen/awesome-local-first",
+      "url": "https://github.com/zhongkechen/awesome-local-first",
+      "sourceLabel": "GitHub",
+      "type": "awesome list",
+      "phase": "exact-fit-pr-sprint",
+      "primaryAudience": "local-first builders",
+      "intent": "local-first software list",
+      "submission": {
+        "kind": "github-pr",
+        "method": "PR",
+        "githubRepo": "zhongkechen/awesome-local-first",
+        "draftPullRequest": true
+      },
+      "acceptance": {
+        "likelihood": "High",
+        "rationale": "exact fit"
+      },
+      "tags": [
+        "local-first",
+        "note-taking",
+        "privacy"
+      ],
+      "geographicOrLanguageFocus": "Global / English",
+      "priority": 29
+    },
+    {
+      "id": "sindresorhus-awesome-whisper",
+      "name": "sindresorhus/awesome-whisper",
+      "url": "https://github.com/sindresorhus/awesome-whisper",
+      "sourceLabel": "GitHub",
+      "type": "awesome list",
+      "phase": "exact-fit-pr-sprint",
+      "primaryAudience": "Whisper / ASR users",
+      "intent": "Whisper ecosystem discovery",
+      "submission": {
+        "kind": "github-pr",
+        "method": "PR",
+        "githubRepo": "sindresorhus/awesome-whisper",
+        "draftPullRequest": true
+      },
+      "acceptance": {
+        "likelihood": "High",
+        "rationale": "OATS directly uses transcription value prop"
+      },
+      "tags": [
+        "whisper",
+        "speech-to-text",
+        "transcription"
+      ],
+      "geographicOrLanguageFocus": "Global / English",
+      "priority": 30
+    },
+    {
+      "id": "danielrosehill-awesome-whisper-apps",
+      "name": "danielrosehill/Awesome-Whisper-Apps",
+      "url": "https://github.com/danielrosehill/Awesome-Whisper-Apps",
+      "sourceLabel": "GitHub",
+      "type": "awesome list",
+      "phase": "exact-fit-pr-sprint",
+      "primaryAudience": "speech-tool users",
+      "intent": "Whisper-powered app showcase",
+      "submission": {
+        "kind": "github-pr",
+        "method": "PR",
+        "githubRepo": "danielrosehill/Awesome-Whisper-Apps",
+        "draftPullRequest": true
+      },
+      "acceptance": {
+        "likelihood": "High",
+        "rationale": "app-layer match is excellent"
+      },
+      "tags": [
+        "whisper",
+        "transcription",
+        "meeting-notes"
+      ],
+      "geographicOrLanguageFocus": "Global / English",
+      "priority": 31
+    },
+    {
+      "id": "ancs21-awesome-openai-whisper",
+      "name": "ancs21/awesome-openai-whisper",
+      "url": "https://github.com/ancs21/awesome-openai-whisper",
+      "sourceLabel": "GitHub",
+      "type": "awesome list",
+      "phase": "exact-fit-pr-sprint",
+      "primaryAudience": "Whisper users",
+      "intent": "Whisper resources/apps",
+      "submission": {
+        "kind": "github-pr",
+        "method": "PR",
+        "githubRepo": "ancs21/awesome-openai-whisper",
+        "draftPullRequest": true
+      },
+      "acceptance": {
+        "likelihood": "High",
+        "rationale": "OATS is in-scope technically"
+      },
+      "tags": [
+        "whisper",
+        "speech-recognition",
+        "stt"
+      ],
+      "geographicOrLanguageFocus": "Global / English",
+      "priority": 32
+    },
+    {
+      "id": "miblue119-awesome-whisper-application",
+      "name": "MIBlue119/awesome-whisper-application",
+      "url": "https://github.com/MIBlue119/awesome-whisper-application",
+      "sourceLabel": "GitHub",
+      "type": "awesome list",
+      "phase": "exact-fit-pr-sprint",
+      "primaryAudience": "Whisper hackers",
+      "intent": "application examples",
+      "submission": {
+        "kind": "github-pr",
+        "method": "PR",
+        "githubRepo": "MIBlue119/awesome-whisper-application",
+        "draftPullRequest": true
+      },
+      "acceptance": {
+        "likelihood": "Medium",
+        "rationale": "smaller list, but direct fit"
+      },
+      "tags": [
+        "whisper",
+        "asr",
+        "meeting notes"
+      ],
+      "geographicOrLanguageFocus": "Global / English",
+      "priority": 33
+    },
+    {
+      "id": "primaprashant-awesome-voice-typing",
+      "name": "primaprashant/awesome-voice-typing",
+      "url": "https://github.com/primaprashant/awesome-voice-typing",
+      "sourceLabel": "GitHub",
+      "type": "awesome list",
+      "phase": "exact-fit-pr-sprint",
+      "primaryAudience": "dictation users",
+      "intent": "voice typing and STT tools",
+      "submission": {
+        "kind": "github-pr",
+        "method": "PR",
+        "githubRepo": "primaprashant/awesome-voice-typing",
+        "draftPullRequest": true
+      },
+      "acceptance": {
+        "likelihood": "High",
+        "rationale": "exact speech-to-text utility fit"
+      },
+      "tags": [
+        "voice-typing",
+        "speech-to-text",
+        "offline"
+      ],
+      "geographicOrLanguageFocus": "Global / English",
+      "priority": 34
+    },
+    {
+      "id": "zzw922cn-awesome-speech-recognition-speech-synthesis-papers",
+      "name": "zzw922cn/awesome-speech-recognition-speech-synthesis-papers",
+      "url": "https://github.com/zzw922cn/awesome-speech-recognition-speech-synthesis-papers",
+      "sourceLabel": "GitHub",
+      "type": "awesome list",
+      "phase": "exact-fit-pr-sprint",
+      "primaryAudience": "speech researchers",
+      "intent": "ASR/TTS paper roadmap",
+      "submission": {
+        "kind": "github-pr",
+        "method": "PR",
+        "githubRepo": "zzw922cn/awesome-speech-recognition-speech-synthesis-papers",
+        "draftPullRequest": true
+      },
+      "acceptance": {
+        "likelihood": "Low",
+        "rationale": "research list, not product-first"
+      },
+      "tags": [
+        "speech-recognition",
+        "asr"
+      ],
+      "geographicOrLanguageFocus": "Global / English",
+      "priority": 35
+    },
+    {
+      "id": "goldsmith-awesome-speech-recognition-papers",
+      "name": "goldsmith/awesome-speech-recognition-papers",
+      "url": "https://github.com/goldsmith/awesome-speech-recognition-papers",
+      "sourceLabel": "GitHub",
+      "type": "awesome list",
+      "phase": "exact-fit-pr-sprint",
+      "primaryAudience": "speech researchers",
+      "intent": "ASR roadmap",
+      "submission": {
+        "kind": "github-pr",
+        "method": "PR",
+        "githubRepo": "goldsmith/awesome-speech-recognition-papers",
+        "draftPullRequest": true
+      },
+      "acceptance": {
+        "likelihood": "Low",
+        "rationale": "paper list, low user acquisition value"
+      },
+      "tags": [
+        "asr",
+        "speech-recognition"
+      ],
+      "geographicOrLanguageFocus": "Global / English",
+      "priority": 36
+    },
+    {
+      "id": "wq2012-awesome-diarization",
+      "name": "wq2012/awesome-diarization",
+      "url": "https://github.com/wq2012/awesome-diarization",
+      "sourceLabel": "GitHub",
+      "type": "awesome list",
+      "phase": "exact-fit-pr-sprint",
+      "primaryAudience": "diarization researchers",
+      "intent": "speaker diarization resources",
+      "submission": {
+        "kind": "github-pr",
+        "method": "PR",
+        "githubRepo": "wq2012/awesome-diarization",
+        "draftPullRequest": true
+      },
+      "acceptance": {
+        "likelihood": "Medium",
+        "rationale": "speaker separation is adjacent to meeting notes"
+      },
+      "tags": [
+        "speaker-diarization",
+        "transcription"
+      ],
+      "geographicOrLanguageFocus": "Global / English",
+      "priority": 37
+    },
+    {
+      "id": "steven2358-awesome-generative-ai",
+      "name": "steven2358/awesome-generative-ai",
+      "url": "https://github.com/steven2358/awesome-generative-ai",
+      "sourceLabel": "GitHub",
+      "type": "awesome list",
+      "phase": "exact-fit-pr-sprint",
+      "primaryAudience": "AI builders",
+      "intent": "GenAI applications landscape",
+      "submission": {
+        "kind": "github-pr",
+        "method": "PR",
+        "githubRepo": "steven2358/awesome-generative-ai",
+        "draftPullRequest": true
+      },
+      "acceptance": {
+        "likelihood": "Medium",
+        "rationale": "broad AI list, but OATS is AI app"
+      },
+      "tags": [
+        "generative-ai",
+        "ai-notes"
+      ],
+      "geographicOrLanguageFocus": "Global / English",
+      "priority": 38
+    },
+    {
+      "id": "alvinreal-awesome-opensource-ai",
+      "name": "alvinreal/awesome-opensource-ai",
+      "url": "https://github.com/alvinreal/awesome-opensource-ai",
+      "sourceLabel": "GitHub",
+      "type": "awesome list",
+      "phase": "exact-fit-pr-sprint",
+      "primaryAudience": "open-source AI users",
+      "intent": "open-source AI projects",
+      "submission": {
+        "kind": "github-pr",
+        "method": "PR",
+        "githubRepo": "alvinreal/awesome-opensource-ai",
+        "draftPullRequest": true
+      },
+      "acceptance": {
+        "likelihood": "Medium",
+        "rationale": "OATS is an AI-enabled app"
+      },
+      "tags": [
+        "open-source-ai",
+        "local-ai",
+        "privacy"
+      ],
+      "geographicOrLanguageFocus": "Global / English",
+      "priority": 39
+    },
+    {
+      "id": "suncloudsmoon-awesome-open-source-ai",
+      "name": "suncloudsmoon/awesome-open-source-ai",
+      "url": "https://github.com/suncloudsmoon/awesome-open-source-ai",
+      "sourceLabel": "GitHub",
+      "type": "awesome list",
+      "phase": "exact-fit-pr-sprint",
+      "primaryAudience": "open-source AI users",
+      "intent": "useful AI tools and models",
+      "submission": {
+        "kind": "github-pr",
+        "method": "PR",
+        "githubRepo": "suncloudsmoon/awesome-open-source-ai",
+        "draftPullRequest": true
+      },
+      "acceptance": {
+        "likelihood": "Medium",
+        "rationale": "broad but relevant"
+      },
+      "tags": [
+        "open-source-ai",
+        "stt",
+        "tools"
+      ],
+      "geographicOrLanguageFocus": "Global / English",
+      "priority": 40
+    },
+    {
+      "id": "swiftsimplify-awesome-open-source-ai-tools",
+      "name": "swiftsimplify/awesome-open-source-ai-tools",
+      "url": "https://github.com/swiftsimplify/awesome-open-source-ai-tools",
+      "sourceLabel": "GitHub",
+      "type": "awesome list",
+      "phase": "exact-fit-pr-sprint",
+      "primaryAudience": "AI-tool seekers",
+      "intent": "open-source AI tools",
+      "submission": {
+        "kind": "github-pr",
+        "method": "PR",
+        "githubRepo": "swiftsimplify/awesome-open-source-ai-tools",
+        "draftPullRequest": true
+      },
+      "acceptance": {
+        "likelihood": "Medium",
+        "rationale": "broader than OATS, still plausible"
+      },
+      "tags": [
+        "ai-tools",
+        "note-taking",
+        "local-ai"
+      ],
+      "geographicOrLanguageFocus": "Global / English",
+      "priority": 41
+    },
+    {
+      "id": "tehtbl-awesome-note-taking",
+      "name": "tehtbl/awesome-note-taking",
+      "url": "https://github.com/tehtbl/awesome-note-taking",
+      "sourceLabel": "GitHub",
+      "type": "awesome list",
+      "phase": "exact-fit-pr-sprint",
+      "primaryAudience": "notes / PKM users",
+      "intent": "note-taking app discovery",
+      "submission": {
+        "kind": "github-pr",
+        "method": "PR / issue",
+        "githubRepo": "tehtbl/awesome-note-taking",
+        "draftPullRequest": true
+      },
+      "acceptance": {
+        "likelihood": "High",
+        "rationale": "exact category fit and active additions"
+      },
+      "tags": [
+        "note-taking",
+        "meeting-notes",
+        "ai-notes"
+      ],
+      "geographicOrLanguageFocus": "Global / English",
+      "priority": 42
+    },
+    {
+      "id": "nil0x42-awesome-hacker-note-taking",
+      "name": "nil0x42/awesome-hacker-note-taking",
+      "url": "https://github.com/nil0x42/awesome-hacker-note-taking",
+      "sourceLabel": "GitHub",
+      "type": "awesome list",
+      "phase": "exact-fit-pr-sprint",
+      "primaryAudience": "technical users",
+      "intent": "note-taking tools for technical work",
+      "submission": {
+        "kind": "github-pr",
+        "method": "PR",
+        "githubRepo": "nil0x42/awesome-hacker-note-taking",
+        "draftPullRequest": true
+      },
+      "acceptance": {
+        "likelihood": "Medium",
+        "rationale": "niche audience, but note-capture fit exists"
+      },
+      "tags": [
+        "note-taking",
+        "markdown",
+        "knowledge base"
+      ],
+      "geographicOrLanguageFocus": "Global / English",
+      "priority": 43
+    },
+    {
+      "id": "spsdco-notes",
+      "name": "spsdco/notes",
+      "url": "https://github.com/spsdco/notes",
+      "sourceLabel": "GitHub",
+      "type": "awesome list",
+      "phase": "exact-fit-pr-sprint",
+      "primaryAudience": "note-taking users",
+      "intent": "note-taking app list",
+      "submission": {
+        "kind": "github-pr",
+        "method": "PR",
+        "githubRepo": "spsdco/notes",
+        "draftPullRequest": true
+      },
+      "acceptance": {
+        "likelihood": "Medium",
+        "rationale": "older repo, but fit is direct"
+      },
+      "tags": [
+        "note-taking",
+        "markdown",
+        "productivity"
+      ],
+      "geographicOrLanguageFocus": "Global / English",
+      "priority": 44
+    },
+    {
+      "id": "knowfox-awesome-pkm",
+      "name": "knowfox/awesome-pkm",
+      "url": "https://github.com/knowfox/awesome-pkm",
+      "sourceLabel": "GitHub",
+      "type": "awesome list",
+      "phase": "exact-fit-pr-sprint",
+      "primaryAudience": "PKM users",
+      "intent": "tools for thought, PKM",
+      "submission": {
+        "kind": "github-pr",
+        "method": "PR",
+        "githubRepo": "knowfox/awesome-pkm",
+        "draftPullRequest": true
+      },
+      "acceptance": {
+        "likelihood": "Medium",
+        "rationale": "PKM adjacent, not purely meetings"
+      },
+      "tags": [
+        "pkm",
+        "note-taking",
+        "knowledge-management"
+      ],
+      "geographicOrLanguageFocus": "Global / English",
+      "priority": 45
+    },
+    {
+      "id": "doanhthong-awesome-pkm",
+      "name": "doanhthong/awesome-pkm",
+      "url": "https://github.com/doanhthong/awesome-pkm",
+      "sourceLabel": "GitHub",
+      "type": "awesome list",
+      "phase": "exact-fit-pr-sprint",
+      "primaryAudience": "PKM users",
+      "intent": "PKM and note-taking tools",
+      "submission": {
+        "kind": "github-pr",
+        "method": "PR",
+        "githubRepo": "doanhthong/awesome-pkm",
+        "draftPullRequest": true
+      },
+      "acceptance": {
+        "likelihood": "Medium",
+        "rationale": "strong conceptual fit"
+      },
+      "tags": [
+        "pkm",
+        "note-taking",
+        "second-brain"
+      ],
+      "geographicOrLanguageFocus": "Global / English",
+      "priority": 46
+    },
+    {
+      "id": "brettkromkamp-awesome-knowledge-management",
+      "name": "brettkromkamp/awesome-knowledge-management",
+      "url": "https://github.com/brettkromkamp/awesome-knowledge-management",
+      "sourceLabel": "GitHub",
+      "type": "awesome list",
+      "phase": "exact-fit-pr-sprint",
+      "primaryAudience": "KM / PKM users",
+      "intent": "knowledge management apps",
+      "submission": {
+        "kind": "github-pr",
+        "method": "PR",
+        "githubRepo": "brettkromkamp/awesome-knowledge-management",
+        "draftPullRequest": true
+      },
+      "acceptance": {
+        "likelihood": "Medium",
+        "rationale": "broad KM scope"
+      },
+      "tags": [
+        "knowledge-management",
+        "notes",
+        "ai-notes"
+      ],
+      "geographicOrLanguageFocus": "Global / English",
+      "priority": 47
+    },
+    {
+      "id": "githubkusi-awesome-knowledge-management-tools",
+      "name": "githubkusi/awesome-knowledge-management-tools",
+      "url": "https://github.com/githubkusi/awesome-knowledge-management-tools",
+      "sourceLabel": "GitHub",
+      "type": "awesome list",
+      "phase": "exact-fit-pr-sprint",
+      "primaryAudience": "KM users",
+      "intent": "compare KM tools",
+      "submission": {
+        "kind": "github-pr",
+        "method": "PR",
+        "githubRepo": "githubkusi/awesome-knowledge-management-tools",
+        "draftPullRequest": true
+      },
+      "acceptance": {
+        "likelihood": "Medium",
+        "rationale": "direct category alignment"
+      },
+      "tags": [
+        "knowledge-management",
+        "notes",
+        "markdown"
+      ],
+      "geographicOrLanguageFocus": "Global / English",
+      "priority": 48
+    },
+    {
+      "id": "jyguyomarch-awesome-productivity",
+      "name": "jyguyomarch/awesome-productivity",
+      "url": "https://github.com/jyguyomarch/awesome-productivity",
+      "sourceLabel": "GitHub",
+      "type": "awesome list",
+      "phase": "exact-fit-pr-sprint",
+      "primaryAudience": "productivity users",
+      "intent": "productivity resources and tools",
+      "submission": {
+        "kind": "github-pr",
+        "method": "PR",
+        "githubRepo": "jyguyomarch/awesome-productivity",
+        "draftPullRequest": true
+      },
+      "acceptance": {
+        "likelihood": "Medium",
+        "rationale": "broad productivity list"
+      },
+      "tags": [
+        "productivity",
+        "notes",
+        "collaboration"
+      ],
+      "geographicOrLanguageFocus": "Global / English",
+      "priority": 49
+    },
+    {
+      "id": "productivitydirectory-awesome-productivity-tools",
+      "name": "ProductivityDirectory/awesome-productivity-tools",
+      "url": "https://github.com/productivitydirectory/awesome-productivity-tools",
+      "sourceLabel": "GitHub",
+      "type": "awesome list",
+      "phase": "exact-fit-pr-sprint",
+      "primaryAudience": "productivity users",
+      "intent": "productivity software list",
+      "submission": {
+        "kind": "github-pr",
+        "method": "PR",
+        "githubRepo": "productivitydirectory/awesome-productivity-tools",
+        "draftPullRequest": true
+      },
+      "acceptance": {
+        "likelihood": "Medium",
+        "rationale": "fit is broad but reasonable"
+      },
+      "tags": [
+        "productivity",
+        "note-taking",
+        "ai"
+      ],
+      "geographicOrLanguageFocus": "Global / English",
+      "priority": 50
+    },
+    {
+      "id": "areknawo-awesome-productivity-software",
+      "name": "areknawo/awesome-productivity-software",
+      "url": "https://github.com/areknawo/awesome-productivity-software",
+      "sourceLabel": "GitHub",
+      "type": "awesome list",
+      "phase": "exact-fit-pr-sprint",
+      "primaryAudience": "productivity users",
+      "intent": "life-management and productivity apps",
+      "submission": {
+        "kind": "github-pr",
+        "method": "PR",
+        "githubRepo": "areknawo/awesome-productivity-software",
+        "draftPullRequest": true
+      },
+      "acceptance": {
+        "likelihood": "Medium",
+        "rationale": "category fit is clear"
+      },
+      "tags": [
+        "productivity",
+        "notes",
+        "meeting tools"
+      ],
+      "geographicOrLanguageFocus": "Global / English",
+      "priority": 51
+    },
+    {
+      "id": "mundimark-awesome-markdown",
+      "name": "mundimark/awesome-markdown",
+      "url": "https://github.com/mundimark/awesome-markdown",
+      "sourceLabel": "GitHub",
+      "type": "awesome list",
+      "phase": "exact-fit-pr-sprint",
+      "primaryAudience": "Markdown users",
+      "intent": "markdown tooling discovery",
+      "submission": {
+        "kind": "github-pr",
+        "method": "PR",
+        "githubRepo": "mundimark/awesome-markdown",
+        "draftPullRequest": true
+      },
+      "acceptance": {
+        "likelihood": "Medium",
+        "rationale": "if OATS exports / works with markdown story is emphasized"
+      },
+      "tags": [
+        "markdown",
+        "notes",
+        "editors"
+      ],
+      "geographicOrLanguageFocus": "Global / English",
+      "priority": 52
+    },
+    {
+      "id": "mundimark-awesome-markdown-editors",
+      "name": "mundimark/awesome-markdown-editors",
+      "url": "https://github.com/mundimark/awesome-markdown-editors",
+      "sourceLabel": "GitHub",
+      "type": "awesome list",
+      "phase": "exact-fit-pr-sprint",
+      "primaryAudience": "Markdown users",
+      "intent": "markdown editors/viewers",
+      "submission": {
+        "kind": "github-pr",
+        "method": "PR",
+        "githubRepo": "mundimark/awesome-markdown-editors",
+        "draftPullRequest": true
+      },
+      "acceptance": {
+        "likelihood": "Low",
+        "rationale": "only if OATS’s markdown workflow is foregrounded"
+      },
+      "tags": [
+        "markdown",
+        "notes"
+      ],
+      "geographicOrLanguageFocus": "Global / English",
+      "priority": 53
+    },
+    {
+      "id": "bubuanabelas-awesome-markdown",
+      "name": "BubuAnabelas/awesome-markdown",
+      "url": "https://github.com/BubuAnabelas/awesome-markdown",
+      "sourceLabel": "GitHub",
+      "type": "awesome list",
+      "phase": "exact-fit-pr-sprint",
+      "primaryAudience": "Markdown users",
+      "intent": "markdown-related tools",
+      "submission": {
+        "kind": "github-pr",
+        "method": "PR",
+        "githubRepo": "BubuAnabelas/awesome-markdown",
+        "draftPullRequest": true
+      },
+      "acceptance": {
+        "likelihood": "Low",
+        "rationale": "indirect fit only"
+      },
+      "tags": [
+        "markdown",
+        "note-taking"
+      ],
+      "geographicOrLanguageFocus": "Global / English",
+      "priority": 54
+    },
+    {
+      "id": "diegoleme-awesome-open-source-alternatives",
+      "name": "diegoleme/awesome-open-source-alternatives",
+      "url": "https://github.com/diegoleme/awesome-open-source-alternatives",
+      "sourceLabel": "GitHub",
+      "type": "awesome list",
+      "phase": "long-tail-sweep",
+      "primaryAudience": "OSS switchers",
+      "intent": "alternatives to proprietary tools",
+      "submission": {
+        "kind": "github-pr",
+        "method": "PR",
+        "githubRepo": "diegoleme/awesome-open-source-alternatives",
+        "draftPullRequest": true
+      },
+      "acceptance": {
+        "likelihood": "High",
+        "rationale": "OATS can be positioned as alternative to Granola / Otter / Plaud-style tools"
+      },
+      "tags": [
+        "open-source-alternative",
+        "notes",
+        "transcription"
+      ],
+      "geographicOrLanguageFocus": "Global / English",
+      "priority": 55
+    },
+    {
+      "id": "runacapital-awesome-oss-alternatives",
+      "name": "RunaCapital/awesome-oss-alternatives",
+      "url": "https://github.com/RunaCapital/awesome-oss-alternatives",
+      "sourceLabel": "GitHub",
+      "type": "awesome list",
+      "phase": "long-tail-sweep",
+      "primaryAudience": "OSS startup watchers",
+      "intent": "open-source SaaS alternatives",
+      "submission": {
+        "kind": "github-pr",
+        "method": "issue / PR",
+        "githubRepo": "RunaCapital/awesome-oss-alternatives",
+        "draftPullRequest": true
+      },
+      "acceptance": {
+        "likelihood": "Medium",
+        "rationale": "startup criteria can be stricter, but category relevance is high"
+      },
+      "tags": [
+        "open-source alternative",
+        "productivity",
+        "notes"
+      ],
+      "geographicOrLanguageFocus": "Global / English",
+      "priority": 56
+    },
+    {
+      "id": "sfermigier-awesome-foss-alternatives",
+      "name": "sfermigier/awesome-foss-alternatives",
+      "url": "https://github.com/sfermigier/awesome-foss-alternatives",
+      "sourceLabel": "GitHub",
+      "type": "awesome list",
+      "phase": "long-tail-sweep",
+      "primaryAudience": "business OSS users",
+      "intent": "FOSS alternatives to SaaS",
+      "submission": {
+        "kind": "github-pr",
+        "method": "PR",
+        "githubRepo": "sfermigier/awesome-foss-alternatives",
+        "draftPullRequest": true
+      },
+      "acceptance": {
+        "likelihood": "Medium",
+        "rationale": "B2B leaning, still relevant"
+      },
+      "tags": [
+        "foss",
+        "alternative",
+        "productivity"
+      ],
+      "geographicOrLanguageFocus": "Global / English",
+      "priority": 57
+    },
+    {
+      "id": "mustbeperfect-definitive-opensource",
+      "name": "mustbeperfect/definitive-opensource",
+      "url": "https://github.com/mustbeperfect/definitive-opensource",
+      "sourceLabel": "GitHub",
+      "type": "awesome list",
+      "phase": "long-tail-sweep",
+      "primaryAudience": "consumers seeking “best of” OSS",
+      "intent": "high-quality consumer OSS",
+      "submission": {
+        "kind": "github-pr",
+        "method": "PR",
+        "githubRepo": "mustbeperfect/definitive-opensource",
+        "draftPullRequest": true
+      },
+      "acceptance": {
+        "likelihood": "Medium",
+        "rationale": "curated/vetted list; fit is strong but bar is high"
+      },
+      "tags": [
+        "macos",
+        "transcription",
+        "note-taking",
+        "privacy"
+      ],
+      "geographicOrLanguageFocus": "Global / English",
+      "priority": 58
+    },
+    {
+      "id": "datadaode-awesome-foss-apps",
+      "name": "DataDaoDe/awesome-foss-apps",
+      "url": "https://github.com/DataDaoDe/awesome-foss-apps",
+      "sourceLabel": "GitHub",
+      "type": "awesome list",
+      "phase": "long-tail-sweep",
+      "primaryAudience": "developers / OSS users",
+      "intent": "quality FOSS apps by category",
+      "submission": {
+        "kind": "github-pr",
+        "method": "PR",
+        "githubRepo": "DataDaoDe/awesome-foss-apps",
+        "draftPullRequest": true
+      },
+      "acceptance": {
+        "likelihood": "Medium",
+        "rationale": "OATS is a desktop OSS app"
+      },
+      "tags": [
+        "foss-apps",
+        "desktop-app",
+        "productivity"
+      ],
+      "geographicOrLanguageFocus": "Global / English",
+      "priority": 59
+    },
+    {
+      "id": "mmachado05-floss-alternatives",
+      "name": "MMachado05/floss-alternatives",
+      "url": "https://github.com/MMachado05/floss-alternatives",
+      "sourceLabel": "GitHub",
+      "type": "awesome list",
+      "phase": "long-tail-sweep",
+      "primaryAudience": "OSS switchers",
+      "intent": "FLOSS alternatives",
+      "submission": {
+        "kind": "github-pr",
+        "method": "PR",
+        "githubRepo": "MMachado05/floss-alternatives",
+        "draftPullRequest": true
+      },
+      "acceptance": {
+        "likelihood": "Medium",
+        "rationale": "good category fit"
+      },
+      "tags": [
+        "floss",
+        "alternative",
+        "note-taking"
+      ],
+      "geographicOrLanguageFocus": "Global / English",
+      "priority": 60
+    },
+    {
+      "id": "an-anonymous-coder-open-source-everything",
+      "name": "An-anonymous-coder/Open-Source-Everything",
+      "url": "https://github.com/An-anonymous-coder/Open-Source-Everything",
+      "sourceLabel": "GitHub",
+      "type": "awesome list",
+      "phase": "long-tail-sweep",
+      "primaryAudience": "broad OSS users",
+      "intent": "best open-source software",
+      "submission": {
+        "kind": "github-pr",
+        "method": "PR / discussion",
+        "githubRepo": "An-anonymous-coder/Open-Source-Everything",
+        "draftPullRequest": true
+      },
+      "acceptance": {
+        "likelihood": "Medium",
+        "rationale": "broad but open-source desktop apps fit"
+      },
+      "tags": [
+        "open-source",
+        "privacy",
+        "notes",
+        "macos"
+      ],
+      "geographicOrLanguageFocus": "Global / English",
+      "priority": 61
+    },
+    {
+      "id": "piotrkulpinski-openalternative",
+      "name": "piotrkulpinski/openalternative",
+      "url": "https://github.com/piotrkulpinski/openalternative",
+      "sourceLabel": "GitHub",
+      "type": "awesome list",
+      "phase": "long-tail-sweep",
+      "primaryAudience": "OSS switchers",
+      "intent": "curated OSS alternatives",
+      "submission": {
+        "kind": "github-pr",
+        "method": "PR",
+        "githubRepo": "piotrkulpinski/openalternative",
+        "draftPullRequest": true
+      },
+      "acceptance": {
+        "likelihood": "High",
+        "rationale": "exact alternative-positioning fit"
+      },
+      "tags": [
+        "open-source-alternative",
+        "productivity"
+      ],
+      "geographicOrLanguageFocus": "Global / English",
+      "priority": 62
+    },
+    {
+      "id": "andrew-ultimate-awesome",
+      "name": "andrew/ultimate-awesome",
+      "url": "https://github.com/andrew/ultimate-awesome",
+      "sourceLabel": "GitHub",
+      "type": "other",
+      "phase": "long-tail-sweep",
+      "primaryAudience": "list curators / discoverers",
+      "intent": "meta discovery of awesome lists",
+      "submission": {
+        "kind": "github-pr",
+        "method": "PR",
+        "githubRepo": "andrew/ultimate-awesome",
+        "draftPullRequest": true
+      },
+      "acceptance": {
+        "likelihood": "Medium",
+        "rationale": "indirect, but can expose OATS-relevant list surfaces"
+      },
+      "tags": [
+        "awesome-lists",
+        "discovery"
+      ],
+      "geographicOrLanguageFocus": "Global / English",
+      "priority": 63
+    },
+    {
+      "id": "best-of-lists-best-of",
+      "name": "best-of-lists/best-of",
+      "url": "https://github.com/best-of-lists/best-of",
+      "sourceLabel": "GitHub",
+      "type": "other",
+      "phase": "long-tail-sweep",
+      "primaryAudience": "OSS discoverers",
+      "intent": "meta-catalog of best-of lists",
+      "submission": {
+        "kind": "github-pr",
+        "method": "issue / PR",
+        "githubRepo": "best-of-lists/best-of",
+        "draftPullRequest": true
+      },
+      "acceptance": {
+        "likelihood": "Medium",
+        "rationale": "indirect, but useful amplifier"
+      },
+      "tags": [
+        "best-of",
+        "open-source",
+        "discovery"
+      ],
+      "geographicOrLanguageFocus": "Global / English",
+      "priority": 64
+    },
+    {
+      "id": "lyz-code-best-of-digital-gardens",
+      "name": "lyz-code/best-of-digital-gardens",
+      "url": "https://github.com/lyz-code/best-of-digital-gardens",
+      "sourceLabel": "GitHub",
+      "type": "other",
+      "phase": "long-tail-sweep",
+      "primaryAudience": "knowledge-sharing users",
+      "intent": "digital garden meta-list",
+      "submission": {
+        "kind": "github-pr",
+        "method": "issue / PR",
+        "githubRepo": "lyz-code/best-of-digital-gardens",
+        "draftPullRequest": true
+      },
+      "acceptance": {
+        "likelihood": "Low",
+        "rationale": "indirect fit unless public-note workflow is emphasized"
+      },
+      "tags": [
+        "notes",
+        "pkm",
+        "knowledge"
+      ],
+      "geographicOrLanguageFocus": "Global / English",
+      "priority": 65
+    },
+    {
+      "id": "richardlitt-meta-knowledge",
+      "name": "RichardLitt/meta-knowledge",
+      "url": "https://github.com/RichardLitt/meta-knowledge",
+      "sourceLabel": "GitHub",
+      "type": "other",
+      "phase": "long-tail-sweep",
+      "primaryAudience": "knowledge-repo users",
+      "intent": "meta list of knowledge repos",
+      "submission": {
+        "kind": "github-pr",
+        "method": "PR",
+        "githubRepo": "RichardLitt/meta-knowledge",
+        "draftPullRequest": true
+      },
+      "acceptance": {
+        "likelihood": "Low",
+        "rationale": "indirect; better for public-knowledge angle than app discovery"
+      },
+      "tags": [
+        "knowledge",
+        "notes",
+        "markdown"
+      ],
+      "geographicOrLanguageFocus": "Global / English",
+      "priority": 66
+    },
+    {
+      "id": "github-topic-meeting-notes",
+      "name": "GitHub Topic: meeting-notes",
+      "url": "https://github.com/topics/meeting-notes",
+      "sourceLabel": "GitHub",
+      "type": "software catalog",
+      "phase": "metadata-sprint",
+      "primaryAudience": "GitHub users",
+      "intent": "browse meeting-note repos",
+      "submission": {
+        "kind": "github-topic",
+        "method": "manual topic edit",
+        "githubRepo": "topics/meeting-notes",
+        "draftPullRequest": false
+      },
+      "acceptance": {
+        "likelihood": "High",
+        "rationale": "direct tag match, self-managed"
+      },
+      "tags": [
+        "meeting-notes",
+        "ai-notes"
+      ],
+      "geographicOrLanguageFocus": "Global / English",
+      "priority": 67
+    },
+    {
+      "id": "github-topic-speech-to-text",
+      "name": "GitHub Topic: speech-to-text",
+      "url": "https://github.com/topics/speech-to-text",
+      "sourceLabel": "GitHub",
+      "type": "software catalog",
+      "phase": "metadata-sprint",
+      "primaryAudience": "STT users",
+      "intent": "browse STT repos",
+      "submission": {
+        "kind": "github-topic",
+        "method": "manual topic edit",
+        "githubRepo": "topics/speech-to-text",
+        "draftPullRequest": false
+      },
+      "acceptance": {
+        "likelihood": "High",
+        "rationale": "exact function"
+      },
+      "tags": [
+        "speech-to-text",
+        "transcription"
+      ],
+      "geographicOrLanguageFocus": "Global / English",
+      "priority": 68
+    },
+    {
+      "id": "github-topic-automatic-speech-recognition",
+      "name": "GitHub Topic: automatic-speech-recognition",
+      "url": "https://github.com/topics/automatic-speech-recognition",
+      "sourceLabel": "GitHub",
+      "type": "software catalog",
+      "phase": "metadata-sprint",
+      "primaryAudience": "ASR users",
+      "intent": "browse ASR repos",
+      "submission": {
+        "kind": "github-topic",
+        "method": "manual topic edit",
+        "githubRepo": "topics/automatic-speech-recognition",
+        "draftPullRequest": false
+      },
+      "acceptance": {
+        "likelihood": "High",
+        "rationale": "direct technical match"
+      },
+      "tags": [
+        "asr",
+        "whisper",
+        "stt"
+      ],
+      "geographicOrLanguageFocus": "Global / English",
+      "priority": 69
+    },
+    {
+      "id": "github-topic-offline-speech-recognition",
+      "name": "GitHub Topic: offline-speech-recognition",
+      "url": "https://github.com/topics/offline-speech-recognition",
+      "sourceLabel": "GitHub",
+      "type": "software catalog",
+      "phase": "metadata-sprint",
+      "primaryAudience": "offline-AI users",
+      "intent": "browse offline STT tools",
+      "submission": {
+        "kind": "github-topic",
+        "method": "manual topic edit",
+        "githubRepo": "topics/offline-speech-recognition",
+        "draftPullRequest": false
+      },
+      "acceptance": {
+        "likelihood": "High",
+        "rationale": "OATS’s on-device mode fits exactly"
+      },
+      "tags": [
+        "offline",
+        "on-device",
+        "stt"
+      ],
+      "geographicOrLanguageFocus": "Global / English",
+      "priority": 70
+    },
+    {
+      "id": "github-topic-speaker-diarization",
+      "name": "GitHub Topic: speaker-diarization",
+      "url": "https://github.com/topics/speaker-diarization",
+      "sourceLabel": "GitHub",
+      "type": "software catalog",
+      "phase": "metadata-sprint",
+      "primaryAudience": "speech-tool users",
+      "intent": "browse diarization tools",
+      "submission": {
+        "kind": "github-topic",
+        "method": "manual topic edit",
+        "githubRepo": "topics/speaker-diarization",
+        "draftPullRequest": false
+      },
+      "acceptance": {
+        "likelihood": "Medium",
+        "rationale": "adjacent capability, still relevant"
+      },
+      "tags": [
+        "diarization",
+        "transcription"
+      ],
+      "geographicOrLanguageFocus": "Global / English",
+      "priority": 71
+    },
+    {
+      "id": "github-topic-transcription",
+      "name": "GitHub Topic: transcription",
+      "url": "https://github.com/topics/transcription",
+      "sourceLabel": "GitHub",
+      "type": "software catalog",
+      "phase": "metadata-sprint",
+      "primaryAudience": "transcription seekers",
+      "intent": "browse transcription repos",
+      "submission": {
+        "kind": "github-topic",
+        "method": "manual topic edit",
+        "githubRepo": "topics/transcription",
+        "draftPullRequest": false
+      },
+      "acceptance": {
+        "likelihood": "High",
+        "rationale": "one of OATS’s core jobs"
+      },
+      "tags": [
+        "transcription",
+        "meeting notes"
+      ],
+      "geographicOrLanguageFocus": "Global / English",
+      "priority": 72
+    },
+    {
+      "id": "github-topic-local-first",
+      "name": "GitHub Topic: local-first",
+      "url": "https://github.com/topics/local-first",
+      "sourceLabel": "GitHub",
+      "type": "software catalog",
+      "phase": "metadata-sprint",
+      "primaryAudience": "privacy / local-first users",
+      "intent": "browse local-first apps",
+      "submission": {
+        "kind": "github-topic",
+        "method": "manual topic edit",
+        "githubRepo": "topics/local-first",
+        "draftPullRequest": false
+      },
+      "acceptance": {
+        "likelihood": "High",
+        "rationale": "exact architecture fit"
+      },
+      "tags": [
+        "local-first",
+        "privacy",
+        "offline"
+      ],
+      "geographicOrLanguageFocus": "Global / English",
+      "priority": 73
+    },
+    {
+      "id": "github-topic-local-first-ai",
+      "name": "GitHub Topic: local-first-ai",
+      "url": "https://github.com/topics/local-first-ai",
+      "sourceLabel": "GitHub",
+      "type": "software catalog",
+      "phase": "metadata-sprint",
+      "primaryAudience": "local-AI users",
+      "intent": "browse local-first AI apps",
+      "submission": {
+        "kind": "github-topic",
+        "method": "manual topic edit",
+        "githubRepo": "topics/local-first-ai",
+        "draftPullRequest": false
+      },
+      "acceptance": {
+        "likelihood": "High",
+        "rationale": "exact positioning fit"
+      },
+      "tags": [
+        "local-first-ai",
+        "privacy",
+        "notes"
+      ],
+      "geographicOrLanguageFocus": "Global / English",
+      "priority": 74
+    },
+    {
+      "id": "github-topic-personal-knowledge-management",
+      "name": "GitHub Topic: personal-knowledge-management",
+      "url": "https://github.com/topics/personal-knowledge-management",
+      "sourceLabel": "GitHub",
+      "type": "software catalog",
+      "phase": "metadata-sprint",
+      "primaryAudience": "PKM users",
+      "intent": "browse PKM software",
+      "submission": {
+        "kind": "github-topic",
+        "method": "manual topic edit",
+        "githubRepo": "topics/personal-knowledge-management",
+        "draftPullRequest": false
+      },
+      "acceptance": {
+        "likelihood": "Medium",
+        "rationale": "good fit if notes/search are emphasized"
+      },
+      "tags": [
+        "pkm",
+        "notes",
+        "second-brain"
+      ],
+      "geographicOrLanguageFocus": "Global / English",
+      "priority": 75
+    },
+    {
+      "id": "github-topic-note-taking",
+      "name": "GitHub Topic: note-taking",
+      "url": "https://github.com/topics/note-taking",
+      "sourceLabel": "GitHub",
+      "type": "software catalog",
+      "phase": "metadata-sprint",
+      "primaryAudience": "note-taking users",
+      "intent": "browse note apps",
+      "submission": {
+        "kind": "github-topic",
+        "method": "manual topic edit",
+        "githubRepo": "topics/note-taking",
+        "draftPullRequest": false
+      },
+      "acceptance": {
+        "likelihood": "High",
+        "rationale": "direct product category"
+      },
+      "tags": [
+        "note-taking",
+        "ai-notes"
+      ],
+      "geographicOrLanguageFocus": "Global / English",
+      "priority": 76
+    },
+    {
+      "id": "github-topic-ai-notes",
+      "name": "GitHub Topic: ai-notes",
+      "url": "https://github.com/topics/ai-notes",
+      "sourceLabel": "GitHub",
+      "type": "software catalog",
+      "phase": "metadata-sprint",
+      "primaryAudience": "AI-note users",
+      "intent": "browse AI note apps",
+      "submission": {
+        "kind": "github-topic",
+        "method": "manual topic edit",
+        "githubRepo": "topics/ai-notes",
+        "draftPullRequest": false
+      },
+      "acceptance": {
+        "likelihood": "High",
+        "rationale": "direct positioning fit"
+      },
+      "tags": [
+        "ai-notes",
+        "meeting-notes"
+      ],
+      "geographicOrLanguageFocus": "Global / English",
+      "priority": 77
+    },
+    {
+      "id": "github-topic-knowledge-management",
+      "name": "GitHub Topic: knowledge-management",
+      "url": "https://github.com/topics/knowledge-management",
+      "sourceLabel": "GitHub",
+      "type": "software catalog",
+      "phase": "metadata-sprint",
+      "primaryAudience": "KM users",
+      "intent": "browse KM repos",
+      "submission": {
+        "kind": "github-topic",
+        "method": "manual topic edit",
+        "githubRepo": "topics/knowledge-management",
+        "draftPullRequest": false
+      },
+      "acceptance": {
+        "likelihood": "Medium",
+        "rationale": "broader but valid"
+      },
+      "tags": [
+        "knowledge-management",
+        "notes"
+      ],
+      "geographicOrLanguageFocus": "Global / English",
+      "priority": 78
+    },
+    {
+      "id": "github-topic-menubar-app",
+      "name": "GitHub Topic: menubar-app",
+      "url": "https://github.com/topics/menubar-app",
+      "sourceLabel": "GitHub",
+      "type": "software catalog",
+      "phase": "metadata-sprint",
+      "primaryAudience": "Mac utility users",
+      "intent": "browse menubar apps",
+      "submission": {
+        "kind": "github-topic",
+        "method": "manual topic edit",
+        "githubRepo": "topics/menubar-app",
+        "draftPullRequest": false
+      },
+      "acceptance": {
+        "likelihood": "High",
+        "rationale": "exact UI pattern"
+      },
+      "tags": [
+        "menubar-app",
+        "macos"
+      ],
+      "geographicOrLanguageFocus": "Global / English",
+      "priority": 79
+    },
+    {
+      "id": "github-topic-macos-apps",
+      "name": "GitHub Topic: macos-apps",
+      "url": "https://github.com/topics/macos-apps",
+      "sourceLabel": "GitHub",
+      "type": "software catalog",
+      "phase": "metadata-sprint",
+      "primaryAudience": "Mac users",
+      "intent": "browse macOS apps",
+      "submission": {
+        "kind": "github-topic",
+        "method": "manual topic edit",
+        "githubRepo": "topics/macos-apps",
+        "draftPullRequest": false
+      },
+      "acceptance": {
+        "likelihood": "High",
+        "rationale": "exact platform fit"
+      },
+      "tags": [
+        "macos",
+        "productivity"
+      ],
+      "geographicOrLanguageFocus": "Global / English",
+      "priority": 80
+    },
+    {
+      "id": "github-topic-macos-application",
+      "name": "GitHub Topic: macos-application",
+      "url": "https://github.com/topics/macos-application",
+      "sourceLabel": "GitHub",
+      "type": "software catalog",
+      "phase": "metadata-sprint",
+      "primaryAudience": "Mac users",
+      "intent": "browse macOS application repos",
+      "submission": {
+        "kind": "github-topic",
+        "method": "manual topic edit",
+        "githubRepo": "topics/macos-application",
+        "draftPullRequest": false
+      },
+      "acceptance": {
+        "likelihood": "High",
+        "rationale": "exact platform fit"
+      },
+      "tags": [
+        "macos-application",
+        "apple-silicon"
+      ],
+      "geographicOrLanguageFocus": "Global / English",
+      "priority": 81
+    },
+    {
+      "id": "github-topic-macos-menubar",
+      "name": "GitHub Topic: macos-menubar",
+      "url": "https://github.com/topics/macos-menubar",
+      "sourceLabel": "GitHub",
+      "type": "software catalog",
+      "phase": "metadata-sprint",
+      "primaryAudience": "Mac utility users",
+      "intent": "browse top-bar apps",
+      "submission": {
+        "kind": "github-topic",
+        "method": "manual topic edit",
+        "githubRepo": "topics/macos-menubar",
+        "draftPullRequest": false
+      },
+      "acceptance": {
+        "likelihood": "High",
+        "rationale": "exact pattern fit"
+      },
+      "tags": [
+        "macos-menubar",
+        "menubar"
+      ],
+      "geographicOrLanguageFocus": "Global / English",
+      "priority": 82
+    },
+    {
+      "id": "github-topic-menu-bar",
+      "name": "GitHub Topic: menu-bar",
+      "url": "https://github.com/topics/menu-bar",
+      "sourceLabel": "GitHub",
+      "type": "software catalog",
+      "phase": "metadata-sprint",
+      "primaryAudience": "utility-app users",
+      "intent": "browse menu-bar software",
+      "submission": {
+        "kind": "github-topic",
+        "method": "manual topic edit",
+        "githubRepo": "topics/menu-bar",
+        "draftPullRequest": false
+      },
+      "acceptance": {
+        "likelihood": "High",
+        "rationale": "direct pattern match"
+      },
+      "tags": [
+        "menu-bar",
+        "macos"
+      ],
+      "geographicOrLanguageFocus": "Global / English",
+      "priority": 83
+    },
+    {
+      "id": "github-topic-mac-setup",
+      "name": "GitHub Topic: mac-setup",
+      "url": "https://github.com/topics/mac-setup",
+      "sourceLabel": "GitHub",
+      "type": "software catalog",
+      "phase": "metadata-sprint",
+      "primaryAudience": "Mac enthusiasts",
+      "intent": "“my setup” discovery",
+      "submission": {
+        "kind": "github-topic",
+        "method": "manual topic edit",
+        "githubRepo": "topics/mac-setup",
+        "draftPullRequest": false
+      },
+      "acceptance": {
+        "likelihood": "Medium",
+        "rationale": "indirect but discoverable"
+      },
+      "tags": [
+        "macos",
+        "productivity"
+      ],
+      "geographicOrLanguageFocus": "Global / English",
+      "priority": 84
+    },
+    {
+      "id": "github-topic-tauri",
+      "name": "GitHub Topic: tauri",
+      "url": "https://github.com/topics/tauri",
+      "sourceLabel": "GitHub",
+      "type": "software catalog",
+      "phase": "metadata-sprint",
+      "primaryAudience": "Tauri builders/users",
+      "intent": "browse Tauri apps",
+      "submission": {
+        "kind": "github-topic",
+        "method": "manual topic edit",
+        "githubRepo": "topics/tauri",
+        "draftPullRequest": false
+      },
+      "acceptance": {
+        "likelihood": "High",
+        "rationale": "core framework fit"
+      },
+      "tags": [
+        "tauri",
+        "rust",
+        "vue"
+      ],
+      "geographicOrLanguageFocus": "Global / English",
+      "priority": 85
+    },
+    {
+      "id": "github-topic-tauri-app",
+      "name": "GitHub Topic: tauri-app",
+      "url": "https://github.com/topics/tauri-app",
+      "sourceLabel": "GitHub",
+      "type": "software catalog",
+      "phase": "metadata-sprint",
+      "primaryAudience": "Tauri users",
+      "intent": "browse shipping Tauri apps",
+      "submission": {
+        "kind": "github-topic",
+        "method": "manual topic edit",
+        "githubRepo": "topics/tauri-app",
+        "draftPullRequest": false
+      },
+      "acceptance": {
+        "likelihood": "High",
+        "rationale": "exact fit"
+      },
+      "tags": [
+        "tauri-app",
+        "macos"
+      ],
+      "geographicOrLanguageFocus": "Global / English",
+      "priority": 86
+    },
+    {
+      "id": "github-topic-rust-lang",
+      "name": "GitHub Topic: rust-lang",
+      "url": "https://github.com/topics/rust-lang",
+      "sourceLabel": "GitHub",
+      "type": "software catalog",
+      "phase": "metadata-sprint",
+      "primaryAudience": "Rust users",
+      "intent": "browse Rust repos",
+      "submission": {
+        "kind": "github-topic",
+        "method": "manual topic edit",
+        "githubRepo": "topics/rust-lang",
+        "draftPullRequest": false
+      },
+      "acceptance": {
+        "likelihood": "Medium",
+        "rationale": "broad language topic"
+      },
+      "tags": [
+        "rust",
+        "desktop-app"
+      ],
+      "geographicOrLanguageFocus": "Global / English",
+      "priority": 87
+    },
+    {
+      "id": "github-topic-privacy",
+      "name": "GitHub Topic: privacy",
+      "url": "https://github.com/topics/privacy",
+      "sourceLabel": "GitHub",
+      "type": "software catalog",
+      "phase": "metadata-sprint",
+      "primaryAudience": "privacy users",
+      "intent": "browse privacy projects",
+      "submission": {
+        "kind": "github-topic",
+        "method": "manual topic edit",
+        "githubRepo": "topics/privacy",
+        "draftPullRequest": false
+      },
+      "acceptance": {
+        "likelihood": "High",
+        "rationale": "OATS’s privacy story is strong"
+      },
+      "tags": [
+        "privacy",
+        "on-device",
+        "local-first"
+      ],
+      "geographicOrLanguageFocus": "Global / English",
+      "priority": 88
+    },
+    {
+      "id": "alternativeto",
+      "name": "AlternativeTo",
+      "url": "https://alternativeto.net/",
+      "sourceLabel": "Site",
+      "type": "alternative-to",
+      "phase": "directory-sprint",
+      "primaryAudience": "end users replacing software",
+      "intent": "app comparison and alternatives",
+      "submission": {
+        "kind": "form",
+        "method": "form / account",
+        "githubRepo": null,
+        "draftPullRequest": false
+      },
+      "acceptance": {
+        "likelihood": "High",
+        "rationale": "direct app discovery; OATS can be framed vs Otter/Granola/Plaid-type tools"
+      },
+      "tags": [
+        "alternative",
+        "note-taking",
+        "transcription",
+        "privacy"
+      ],
+      "geographicOrLanguageFocus": "Global / English-first",
+      "priority": 89
+    },
+    {
+      "id": "saashub",
+      "name": "SaaSHub",
+      "url": "https://www.saashub.com/submit",
+      "sourceLabel": "Site",
+      "type": "alternative-to",
+      "phase": "directory-sprint",
+      "primaryAudience": "startup / software buyers",
+      "intent": "alternatives and startup directory",
+      "submission": {
+        "kind": "form",
+        "method": "form",
+        "githubRepo": null,
+        "draftPullRequest": false
+      },
+      "acceptance": {
+        "likelihood": "Medium",
+        "rationale": "broad SaaS framing, but category coverage is wide"
+      },
+      "tags": [
+        "productivity",
+        "communication",
+        "notes"
+      ],
+      "geographicOrLanguageFocus": "Global / English",
+      "priority": 90
+    },
+    {
+      "id": "openalternative",
+      "name": "OpenAlternative",
+      "url": "https://openalternative.co/",
+      "sourceLabel": "Site",
+      "type": "alternative-to",
+      "phase": "directory-sprint",
+      "primaryAudience": "OSS switchers",
+      "intent": "curated open-source alternatives",
+      "submission": {
+        "kind": "form",
+        "method": "submit / login",
+        "githubRepo": null,
+        "draftPullRequest": false
+      },
+      "acceptance": {
+        "likelihood": "Medium",
+        "rationale": "strong thematic fit, but submission appears gated"
+      },
+      "tags": [
+        "open-source-alternative",
+        "ai",
+        "productivity"
+      ],
+      "geographicOrLanguageFocus": "Global / English",
+      "priority": 91
+    },
+    {
+      "id": "opensourcealternative-to",
+      "name": "OpenSourceAlternative.to",
+      "url": "https://www.opensourcealternative.to/",
+      "sourceLabel": "Site",
+      "type": "alternative-to",
+      "phase": "directory-sprint",
+      "primaryAudience": "OSS switchers",
+      "intent": "proprietary-to-OSS replacement discovery",
+      "submission": {
+        "kind": "form",
+        "method": "submit",
+        "githubRepo": null,
+        "draftPullRequest": false
+      },
+      "acceptance": {
+        "likelihood": "High",
+        "rationale": "exact audience and positioning fit"
+      },
+      "tags": [
+        "open-source alternative",
+        "privacy",
+        "notes"
+      ],
+      "geographicOrLanguageFocus": "Global / English",
+      "priority": 92
+    },
+    {
+      "id": "open-hub",
+      "name": "Open Hub",
+      "url": "https://openhub.net/",
+      "sourceLabel": "Site",
+      "type": "directory",
+      "phase": "directory-sprint",
+      "primaryAudience": "OSS developers/users",
+      "intent": "track and compare OSS projects",
+      "submission": {
+        "kind": "manual",
+        "method": "manual add project",
+        "githubRepo": null,
+        "draftPullRequest": false
+      },
+      "acceptance": {
+        "likelihood": "High",
+        "rationale": "community-driven FOSS project directory"
+      },
+      "tags": [
+        "open-source",
+        "project metrics",
+        "macos"
+      ],
+      "geographicOrLanguageFocus": "Global / English",
+      "priority": 93
+    },
+    {
+      "id": "free-software-directory",
+      "name": "Free Software Directory",
+      "url": "https://directory.fsf.org/wiki/Main_Page",
+      "sourceLabel": "Site",
+      "type": "directory",
+      "phase": "directory-sprint",
+      "primaryAudience": "free-software users",
+      "intent": "FSF-style software discovery",
+      "submission": {
+        "kind": "form",
+        "method": "form",
+        "githubRepo": null,
+        "draftPullRequest": false
+      },
+      "acceptance": {
+        "likelihood": "Medium",
+        "rationale": "strong OSS fit, but licensing review standards are stricter"
+      },
+      "tags": [
+        "free-software",
+        "privacy",
+        "productivity"
+      ],
+      "geographicOrLanguageFocus": "Global / English",
+      "priority": 94
+    },
+    {
+      "id": "awesome-open-source",
+      "name": "Awesome Open Source",
+      "url": "https://awesomeopensource.com/",
+      "sourceLabel": "Site",
+      "type": "directory",
+      "phase": "directory-sprint",
+      "primaryAudience": "developers",
+      "intent": "open-source project discovery / comparisons",
+      "submission": {
+        "kind": "manual",
+        "method": "listing request / indirect",
+        "githubRepo": null,
+        "draftPullRequest": false
+      },
+      "acceptance": {
+        "likelihood": "Medium",
+        "rationale": "strong discoverability, submission path less explicit"
+      },
+      "tags": [
+        "open-source",
+        "rust",
+        "vue",
+        "productivity"
+      ],
+      "geographicOrLanguageFocus": "Global / English",
+      "priority": 95
+    },
+    {
+      "id": "open-apps",
+      "name": "Open Apps",
+      "url": "https://openapps.pro/",
+      "sourceLabel": "Site",
+      "type": "directory",
+      "phase": "directory-sprint",
+      "primaryAudience": "OSS switchers / teams",
+      "intent": "curated OSS apps by category",
+      "submission": {
+        "kind": "manual",
+        "method": "contact / editorial",
+        "githubRepo": null,
+        "draftPullRequest": false
+      },
+      "acceptance": {
+        "likelihood": "Medium",
+        "rationale": "strong fit, but editorial submission path is not explicit"
+      },
+      "tags": [
+        "productivity",
+        "ai-assistants",
+        "notes",
+        "privacy"
+      ],
+      "geographicOrLanguageFocus": "Global / English",
+      "priority": 96
+    },
+    {
+      "id": "macmenubar-com",
+      "name": "MacMenuBar.com",
+      "url": "https://macmenubar.com/",
+      "sourceLabel": "Site",
+      "type": "directory",
+      "phase": "directory-sprint",
+      "primaryAudience": "Mac end users",
+      "intent": "discover menu bar apps",
+      "submission": {
+        "kind": "form",
+        "method": "submit page",
+        "githubRepo": null,
+        "draftPullRequest": false
+      },
+      "acceptance": {
+        "likelihood": "High",
+        "rationale": "exact UI/form-factor fit"
+      },
+      "tags": [
+        "menubar-app",
+        "macos",
+        "productivity"
+      ],
+      "geographicOrLanguageFocus": "Global / English",
+      "priority": 97
+    },
+    {
+      "id": "sourceforge-directory",
+      "name": "SourceForge Directory",
+      "url": "https://sourceforge.net/directory/",
+      "sourceLabel": "Site",
+      "type": "directory",
+      "phase": "directory-sprint",
+      "primaryAudience": "OSS users",
+      "intent": "browse open-source projects",
+      "submission": {
+        "kind": "manual",
+        "method": "project listing",
+        "githubRepo": null,
+        "draftPullRequest": false
+      },
+      "acceptance": {
+        "likelihood": "Medium",
+        "rationale": "broad OSS directory, less targeted than Mac/notes lists"
+      },
+      "tags": [
+        "open-source",
+        "productivity"
+      ],
+      "geographicOrLanguageFocus": "Global / English",
+      "priority": 98
+    },
+    {
+      "id": "libhunt",
+      "name": "LibHunt",
+      "url": "https://www.libhunt.com/repo/submit",
+      "sourceLabel": "Site",
+      "type": "directory",
+      "phase": "packaging-sprint",
+      "primaryAudience": "developers",
+      "intent": "find packages / projects by language & topic",
+      "submission": {
+        "kind": "form",
+        "method": "submit project",
+        "githubRepo": null,
+        "draftPullRequest": false
+      },
+      "acceptance": {
+        "likelihood": "Medium",
+        "rationale": "more dev-facing and library-centric, but still useful"
+      },
+      "tags": [
+        "rust",
+        "vue",
+        "self-hosted",
+        "macos"
+      ],
+      "geographicOrLanguageFocus": "Global / English",
+      "priority": 99
+    },
+    {
+      "id": "switching-software",
+      "name": "switching.software",
+      "url": "https://switching.software/use/",
+      "sourceLabel": "Site",
+      "type": "alternative-to",
+      "phase": "directory-sprint",
+      "primaryAudience": "privacy / anti-lock-in users",
+      "intent": "recommend free/open alternatives",
+      "submission": {
+        "kind": "manual",
+        "method": "editorial / source-linked suggestion",
+        "githubRepo": null,
+        "draftPullRequest": false
+      },
+      "acceptance": {
+        "likelihood": "Medium",
+        "rationale": "strong philosophical fit, but curation is editorial"
+      },
+      "tags": [
+        "privacy",
+        "note-taking",
+        "alternatives"
+      ],
+      "geographicOrLanguageFocus": "Global / English",
+      "priority": 100
+    },
+    {
+      "id": "homebrew-cask",
+      "name": "Homebrew Cask",
+      "url": "https://github.com/Homebrew/homebrew-cask",
+      "sourceLabel": "GitHub",
+      "type": "package index",
+      "phase": "packaging-sprint",
+      "primaryAudience": "Mac developers/users",
+      "intent": "install Mac apps via brew",
+      "submission": {
+        "kind": "package-pr",
+        "method": "PR",
+        "githubRepo": "Homebrew/homebrew-cask",
+        "draftPullRequest": false
+      },
+      "acceptance": {
+        "likelihood": "Medium",
+        "rationale": "valuable channel, but packaging/review work required"
+      },
+      "tags": [
+        "macos",
+        "cask",
+        "apple-silicon"
+      ],
+      "geographicOrLanguageFocus": "Global / English",
+      "priority": 101
+    },
+    {
+      "id": "macports",
+      "name": "MacPorts",
+      "url": "https://github.com/macports/macports-ports",
+      "sourceLabel": "GitHub",
+      "type": "package index",
+      "phase": "packaging-sprint",
+      "primaryAudience": "Mac technical users",
+      "intent": "install packaged software",
+      "submission": {
+        "kind": "package-pr",
+        "method": "PR",
+        "githubRepo": "macports/macports-ports",
+        "draftPullRequest": false
+      },
+      "acceptance": {
+        "likelihood": "Low",
+        "rationale": "packaging-heavy and more technical audience"
+      },
+      "tags": [
+        "macos",
+        "package",
+        "rust"
+      ],
+      "geographicOrLanguageFocus": "Global / English",
+      "priority": 102
+    },
+    {
+      "id": "nixpkgs",
+      "name": "Nixpkgs",
+      "url": "https://github.com/NixOS/nixpkgs",
+      "sourceLabel": "GitHub",
+      "type": "package index",
+      "phase": "packaging-sprint",
+      "primaryAudience": "Nix / reproducibility users",
+      "intent": "packaged software distribution",
+      "submission": {
+        "kind": "package-pr",
+        "method": "PR",
+        "githubRepo": "NixOS/nixpkgs",
+        "draftPullRequest": false
+      },
+      "acceptance": {
+        "likelihood": "Low",
+        "rationale": "packaging overhead, narrower user base"
+      },
+      "tags": [
+        "nix",
+        "macos",
+        "package",
+        "rust"
+      ],
+      "geographicOrLanguageFocus": "Global / English",
+      "priority": 103
+    }
+  ]
+}

--- a/docs/outreach/oats-listing-profile.md
+++ b/docs/outreach/oats-listing-profile.md
@@ -1,0 +1,31 @@
+# oats listing profile
+
+Use this profile when proposing oats for curated software lists and directories.
+
+## Canonical links
+
+- Project: https://github.com/ariso-ai/oats
+- Download: https://github.com/ariso-ai/oats/releases/latest
+- Website: https://ariso.ai
+- License: MIT
+
+## Short descriptions
+
+- Open-source macOS menu bar meeting-notes app with live transcription, speaker labels, AI summaries, and a fully offline on-device mode.
+- macOS meeting recorder that turns conversations into transcripts and Markdown notes, either through a free cloud backend or completely on-device.
+- Privacy-friendly meeting notes for Apple Silicon Macs: record from the menu bar, transcribe, label speakers, and generate summaries.
+
+## Fit signals
+
+- macOS 14+ and Apple Silicon.
+- Tauri v2 desktop app with Vue and Rust.
+- Open source under the MIT license.
+- Menu bar workflow for recording meetings.
+- Live speech-to-text transcription, speaker labels, and generated Markdown notes.
+- Optional fully offline mode for recording, transcription, diarization, and summaries.
+
+## Suggested tags
+
+`macos`, `meeting-notes`, `speech-to-text`, `transcription`, `ai-notes`,
+`local-first`, `privacy`, `menubar-app`, `apple-silicon`, `tauri`, `rust`,
+`vue`.

--- a/docs/outreach/oats-listing-target-research.md
+++ b/docs/outreach/oats-listing-target-research.md
@@ -1,0 +1,269 @@
+# OATS Listing Target Research Report
+
+## Executive summary
+
+OATS is unusually well positioned for catalog and list inclusion because its public positioning spans several high-demand discovery surfaces at once: it is a free and open-source macOS app for meeting notes, transcription, and AI summaries; it emphasizes privacy and on-device use; and its GitHub metadata already aligns with tags such as `speech-to-text`, `transcription`, `meeting-notes`, `menubar-app`, `local-first`, `apple-silicon`, `tauri`, `rust`, and `vue`. The repository README also states that OATS runs on macOS 14+ and Apple Silicon, can work “free in the cloud” or “100% on-device,” and uses Tauri, Vue, and Rust. That combination makes OATS relevant not just to note-taking and productivity lists, but also to privacy, local AI, Whisper/ASR, menubar-app, Apple Silicon, and Tauri ecosystem catalogs. citeturn1view0turn13search1turn35search0turn36search2
+
+The highest-confidence listing surfaces are the ones with explicit self-service or contribution workflows: GitHub Topics pages can be activated directly by managing repo topics; GitHub awesome lists typically accept pull requests; AlternativeTo documents how to suggest a new app; SaaSHub has a dedicated submit flow; MacMenuBar has a dedicated “Submit Menu Bar App” page; Open Hub says it is community-driven and supports “Add New Project”; the Free Software Directory documents a “Submit a new entry” workflow; and Homebrew Cask explicitly says new casks should be submitted by pull request rather than issue. citeturn13search18turn5search0turn16search2turn11search0turn10view1turn18search0turn18search14turn18search2turn19search1turn27search0
+
+The fastest path is not a directory at all, but GitHub metadata hygiene: OATS can immediately improve discoverability across multiple GitHub topic catalogs without waiting for moderation, by tightening and expanding its topics around `meeting-notes`, `speech-to-text`, `ai-notes`, `local-first`, `menubar-app`, `tauri`, `privacy`, `macos-application`, and `apple-silicon`. GitHub topic pages themselves say that repositories are associated by managing topics on the repo page. citeturn13search18turn36search2turn35search0turn35search2
+
+For external outreach, the best first curated target is **serhii-londar/open-source-mac-os-apps** because it is explicitly an awesome list of open-source macOS applications and publishes contribution guidance, while OATS is an open-source Mac app with a clear desktop end-user value proposition. Immediately after that, the strongest sequence is: `awesome-tauri`, `awesome-mac`, `awesome-menubar`, `awesome-note-taking`, `awesome-whisper`, `awesome-voice-typing`, `MacMenuBar.com`, `AlternativeTo`, and `Open Hub`. citeturn5search1turn5search0turn17search1turn16search2turn6search0turn6search2turn18search0turn11search0turn18search2
+
+This report compiles **103 deduplicated targets**. The list is intentionally English-first, but it also includes a small number of multilingual or non-English assets where fit is high enough to justify the effort.
+
+## Methodology and OATS fit profile
+
+I used a fit-first discovery method rather than a generic startup-directory sweep. The inclusion criteria were: the target is public; the target has either a documented listing/submission path or an open GitHub repo where additions are plausibly made by pull request; the target is relevant to at least one core OATS facet; and the target is meaningfully discoverable by developers, Mac users, privacy-conscious users, or people actively looking for note-taking / transcription / local-AI tools. The main discovery anchors were OATS’s own README and GitHub topic metadata, then official contribution and submission pages for GitHub lists and public directories. citeturn1view0turn13search1turn5search0turn16search2turn11search0turn18search2turn19search1turn27search0
+
+The most important OATS matching dimensions were these:
+
+| OATS dimension | Why it matters for inclusion |
+|---|---|
+| macOS app | Opens Mac app directories, Apple Silicon lists, menubar-app lists, macOS awesome lists |
+| open source | Qualifies OATS for FOSS lists, open-source alternative directories, Open Hub, Free Software Directory |
+| meeting notes | Opens note-taking, productivity, PKM, and meeting-notes topic catalogs |
+| speech-to-text / transcription | Opens Whisper, ASR, dictation, diarization, and voice typing lists |
+| privacy / on-device | Opens privacy, local-first, offline / on-device AI, and privacy-first software lists |
+| Tauri / Rust / Vue | Opens ecosystem lists, package catalogs, and GitHub topic catalogs for the underlying stack |
+
+Those dimensions are directly supported by the repo README and visible topic tags. citeturn1view0turn13search1turn35search0
+
+Acceptance likelihood in the master table is an analyst judgment, not a guarantee. I scored it using four concrete signals: category fit, whether the target explicitly welcomes contributions or submissions, whether the target is broad versus niche, and whether OATS would require extra packaging or curation effort beyond a simple listing. That is why GitHub Topics are mostly “high,” PR-driven awesome lists are usually “high” or “medium,” directories with clear forms are “medium” to “high,” and package indexes are often “medium” or “low” because they require packaging review rather than simple editorial inclusion. citeturn13search18turn16search2turn11search0turn27search0turn27search2
+
+## Categorization and target mix
+
+The most useful schema for outreach is not by site type alone, but by **audience** and **intent**.
+
+| Audience category | Intent category | What OATS is “competing” on | Best target families |
+|---|---|---|---|
+| Mac power users | End-user discovery | menubar utility, Apple Silicon app, Mac productivity | MacMenuBar, open-source Mac app lists, awesome-mac lists |
+| Notes / PKM users | Workflow replacement / augmentation | meeting notes, note capture, markdown export, searchable notes | awesome-note-taking, PKM / KM / Markdown lists, AlternativeTo |
+| Privacy-first users | Trust / control | on-device, local-first, no forced cloud | privacy and local-first lists, GitHub topics |
+| Developers / OSS users | Open-source discovery | self-hostable-ish local workflow, OSS desktop tooling | Open Hub, Free Software Directory, Awesome Open Source, open-source alternatives lists |
+| AI / speech users | Technical discovery | Whisper/ASR, speech-to-text, diarization-adjacent workflows | awesome-whisper, awesome-voice-typing, ASR lists, speech topics |
+| Stack-specific builders | Ecosystem discovery | Tauri, Rust, Vue app showcase | awesome-tauri, awesome-rust, awesome-vue, GitHub topics, package indexes |
+
+The practical implication is that the outreach order should follow **precision before breadth**: first the exact-fit categories where OATS is obviously in-scope, then the broader OSS and platform catalogs, then the package indexes and long-tail meta lists.
+
+```mermaid
+pie title Target mix by type
+    "Awesome lists and curated GitHub repos" : 66
+    "GitHub topic catalogs" : 22
+    "Directories and alternative catalogs" : 12
+    "Package indexes" : 3
+```
+
+The highest-value mapping of targets to categories is:
+
+- **Mac end-user discovery**: `open-source-mac-os-apps`, `awesome-mac`, `awesome-macOS`, `awesome-macos`, `awesome-mac-apps`, `awesome-menubar`, `MacMenuBar.com`, `awesome-apple-silicon`.
+- **Notes / PKM / productivity**: `awesome-note-taking`, `awesome-pkm`, `awesome-knowledge-management`, `awesome-productivity`, `awesome-markdown`, GitHub topics for `meeting-notes`, `note-taking`, `personal-knowledge-management`, `knowledge-management`.
+- **Speech / transcription / local AI**: `awesome-whisper`, `Awesome-Whisper-Apps`, `awesome-voice-typing`, `awesome-speech-recognition-speech-synthesis-papers`, `awesome-diarization`, GitHub topics for `speech-to-text`, `automatic-speech-recognition`, `offline-speech-recognition`, `transcription`.
+- **Privacy / local-first**: `awesome-privacy`, `awesome-local-first`, GitHub topics for `privacy`, `local-first`, `local-first-ai`, `ai-notes`.
+- **OSS / alternatives / software directories**: `AlternativeTo`, `Open Hub`, `Free Software Directory`, `Awesome Open Source`, `Open Apps`, `OpenAlternative`, `OpenSourceAlternative.to`, `SourceForge Directory`, `LibHunt`, `RunaCapital/awesome-oss-alternatives`, `definitive-opensource`.
+- **Stack / ecosystem**: `awesome-tauri`, `awesome-rust`, `awesome-vue`, GitHub topics for `tauri`, `tauri-app`, `rust-lang`, `macos-application`, `menubar-app`. citeturn5search1turn5search0turn17search1turn18search0turn16search2turn33search11turn6search0turn6search2turn29search3turn35search0turn35search4turn36search0turn36search4turn11search0turn18search2turn19search10turn20search1turn22search1turn12search0turn11search11
+
+## Deduplicated master table
+
+The `URL` column below is the primary official source for each target, which also serves as the per-entry source link the request asked for. The list is globally deduplicated across all three table blocks.
+
+**Curated GitHub lists and user-curated repos**
+
+| Name | URL | Type | Primary audience | Intent / use-case | Submission method | Acceptance likelihood with rationale | Tags / keywords matched to OATS | Geographic / language focus |
+|---|---|---|---|---|---|---|---|---|
+| tauri-apps/awesome-tauri | [GitHub](https://github.com/tauri-apps/awesome-tauri) | awesome list | Tauri builders | ecosystem showcase | PR | High — exact framework fit | tauri, desktop-app, rust, macos | Global / English |
+| jaywcjlove/awesome-mac | [GitHub](https://github.com/jaywcjlove/awesome-mac) | awesome list | Mac users | Mac app discovery | PR | High — strong Mac/deskop fit, PRs welcome | macos, productivity, menubar, open-source | Global / English |
+| serhii-londar/open-source-mac-os-apps | [GitHub](https://github.com/serhii-londar/open-source-mac-os-apps) | awesome list | Mac OSS users | open-source Mac apps | PR | High — exact scope match | macos, open-source, productivity, notes | Global / English |
+| iCHAIT/awesome-macOS | [GitHub](https://github.com/iCHAIT/awesome-macOS) | awesome list | Mac users | Mac software discovery | PR | High — Mac app list with contribution guide | macos, menubar, productivity, notes | Global / English |
+| phmullins/awesome-macos | [GitHub](https://github.com/phmullins/awesome-macos) | awesome list | Mac users | categorized Mac apps | PR | High — broad Mac coverage | macos, productivity, communication, docs | Global / English |
+| viraat/awesome-mac-apps | [GitHub](https://github.com/viraat/awesome-mac-apps) | awesome list | Mac developers | free/open-source Mac apps | PR / issue | High — open-source Mac apps focus | macos, open-source, productivity | Global / English |
+| jordanbaird/awesome-menubar | [GitHub](https://github.com/jordanbaird/awesome-menubar) | awesome list | menubar-app users | menu bar app discovery | PR | High — exact UI pattern fit | menubar-app, macos, productivity | Global / English |
+| tborychowski/awesome-mac | [GitHub](https://github.com/tborychowski/awesome-mac) | awesome list | Mac power users | personal Mac app curation | issue / PR | Medium — subjective list, but OATS fits | macos, ai, notes, productivity | Global / English |
+| antelle/my-awesome-mac-apps | [GitHub](https://github.com/antelle/my-awesome-mac-apps) | awesome list | Mac power users | curated Mac app picks | PR | Medium — personal list, still accepts contributions | macos, productivity, notes | Global / English |
+| feep/awesome-apple-silicon | [GitHub](https://github.com/feep/awesome-apple-silicon) | awesome list | Apple Silicon users | Apple Silicon software resources | PR | High — OATS requires Apple Silicon | apple-silicon, macos, native | Global / English |
+| smashism/awesome-macadmin-tools | [GitHub](https://github.com/smashism/awesome-macadmin-tools) | awesome list | Mac admins | Mac tooling discovery | PR | Low — audience is admins, not end users | macos, utility, menubar | Global / English |
+| rust-unofficial/awesome-rust | [GitHub](https://github.com/rust-unofficial/awesome-rust) | awesome list | Rust developers | Rust project discovery | PR | Medium — broad, but OATS is a Rust app | rust, desktop-app, productivity | Global / English |
+| awesome-rust-com/awesome-rust | [GitHub](https://github.com/awesome-rust-com/awesome-rust) | awesome list | Rust developers | Rust frameworks and software | PR | Medium — broad but apps section exists | rust, application, macos | Global / English |
+| vuejs/awesome-vue | [GitHub](https://github.com/vuejs/awesome-vue) | awesome list | Vue developers | Vue ecosystem discovery | PR | Medium — broad framework list | vue, tauri-frontend, desktop-ui | Global / English |
+| sonicoder86/awesome-vue-3 | [GitHub](https://github.com/sonicoder86/awesome-vue-3) | awesome list | Vue 3 developers | Vue 3 tooling and examples | PR | Medium — broad, but OATS uses Vue | vue3, desktop-ui, productivity | Global / English |
+| sudhakar3697/awesome-electron-alternatives | [GitHub](https://github.com/sudhakar3697/awesome-electron-alternatives) | awesome list | desktop-app builders | Electron alternatives | PR | High — Tauri app is an exact alt-to-Electron ecosystem fit | tauri, desktop-app, rust, performance | Global / English |
+| pluja/awesome-privacy | [GitHub](https://github.com/pluja/awesome-privacy) | awesome list | privacy-focused users | privacy-respecting services/tools | PR | High — privacy/on-device positioning aligns closely | privacy, local-first, on-device | Global / English |
+| lissy93/awesome-privacy | [GitHub](https://github.com/lissy93/awesome-privacy) | awesome list | privacy-focused users | privacy tools discovery | PR | High — strong privacy-first fit | privacy, macos, notes, local | Global / English |
+| iAnonymous3000/awesome-privacy-tools | [GitHub](https://github.com/iAnonymous3000/awesome-privacy-tools) | awesome list | privacy users | privacy tool catalog | PR | High — OATS’s privacy story is central | privacy, note-taking, local-first | Global / English |
+| janhq/awesome-local-ai | [GitHub](https://github.com/janhq/awesome-local-ai) | awesome list | local-AI users | run AI locally | PR | High — OATS can run fully on-device | local-ai, on-device, privacy, macos | Global / English |
+| msb-msb/awesome-local-ai | [GitHub](https://github.com/msb-msb/awesome-local-ai) | awesome list | local-AI users | consumer local AI resources | PR | High — privacy/local hardware angle matches | local-ai, on-device, apple-silicon | Global / English |
+| rafska/awesome-local-llm | [GitHub](https://github.com/rafska/awesome-local-llm) | awesome list | local-LLM users | local model tools/platforms | PR | Medium — OATS is app-layer, not model infra | local-llm, local-ai, on-device | Global / English |
+| vince-lam/awesome-local-llms | [GitHub](https://github.com/vince-lam/awesome-local-llms) | awesome list | local-LLM users | compare local-LLM projects | PR | Medium — infra-adjacent but still relevant | local-ai, privacy, on-device | Global / English |
+| awesome-selfhosted/awesome-selfhosted | [GitHub](https://github.com/awesome-selfhosted/awesome-selfhosted) | awesome list | self-hosting users | self-hosted software discovery | PR | Low — OATS is desktop-first, not a hosted service | local-first, privacy, self-hosted-ish | Global / English |
+| haiiiiiyun/awesome-selfhosted-cn | [GitHub](https://github.com/haiiiiiyun/awesome-selfhosted-cn) | awesome list | Chinese self-hosting users | localized self-hosted catalog | PR | Low — same mismatch as above | privacy, local, notes | China / Chinese |
+| alexanderop/awesome-local-first | [GitHub](https://github.com/alexanderop/awesome-local-first) | awesome list | local-first builders/users | local-first software catalog | PR | High — exact architectural fit | local-first, privacy, offline, notes | Global / English |
+| schickling/awesome-local-first | [GitHub](https://github.com/schickling/awesome-local-first) | awesome list | local-first builders | local-first projects | PR | High — exact fit | local-first, collaboration, notes | Global / English |
+| alantriesagain/awesome-local-first | [GitHub](https://github.com/alantriesagain/awesome-local-first) | awesome list | local-first builders | local-first apps/resources | PR | High — direct fit | local-first, privacy, offline | Global / English |
+| zhongkechen/awesome-local-first | [GitHub](https://github.com/zhongkechen/awesome-local-first) | awesome list | local-first builders | local-first software list | PR | High — exact fit | local-first, note-taking, privacy | Global / English |
+| sindresorhus/awesome-whisper | [GitHub](https://github.com/sindresorhus/awesome-whisper) | awesome list | Whisper / ASR users | Whisper ecosystem discovery | PR | High — OATS directly uses transcription value prop | whisper, speech-to-text, transcription | Global / English |
+| danielrosehill/Awesome-Whisper-Apps | [GitHub](https://github.com/danielrosehill/Awesome-Whisper-Apps) | awesome list | speech-tool users | Whisper-powered app showcase | PR | High — app-layer match is excellent | whisper, transcription, meeting-notes | Global / English |
+| ancs21/awesome-openai-whisper | [GitHub](https://github.com/ancs21/awesome-openai-whisper) | awesome list | Whisper users | Whisper resources/apps | PR | High — OATS is in-scope technically | whisper, speech-recognition, stt | Global / English |
+| MIBlue119/awesome-whisper-application | [GitHub](https://github.com/MIBlue119/awesome-whisper-application) | awesome list | Whisper hackers | application examples | PR | Medium — smaller list, but direct fit | whisper, asr, meeting notes | Global / English |
+| primaprashant/awesome-voice-typing | [GitHub](https://github.com/primaprashant/awesome-voice-typing) | awesome list | dictation users | voice typing and STT tools | PR | High — exact speech-to-text utility fit | voice-typing, speech-to-text, offline | Global / English |
+| zzw922cn/awesome-speech-recognition-speech-synthesis-papers | [GitHub](https://github.com/zzw922cn/awesome-speech-recognition-speech-synthesis-papers) | awesome list | speech researchers | ASR/TTS paper roadmap | PR | Low — research list, not product-first | speech-recognition, asr | Global / English |
+| goldsmith/awesome-speech-recognition-papers | [GitHub](https://github.com/goldsmith/awesome-speech-recognition-papers) | awesome list | speech researchers | ASR roadmap | PR | Low — paper list, low user acquisition value | asr, speech-recognition | Global / English |
+| wq2012/awesome-diarization | [GitHub](https://github.com/wq2012/awesome-diarization) | awesome list | diarization researchers | speaker diarization resources | PR | Medium — speaker separation is adjacent to meeting notes | speaker-diarization, transcription | Global / English |
+| steven2358/awesome-generative-ai | [GitHub](https://github.com/steven2358/awesome-generative-ai) | awesome list | AI builders | GenAI applications landscape | PR | Medium — broad AI list, but OATS is AI app | generative-ai, ai-notes | Global / English |
+| alvinreal/awesome-opensource-ai | [GitHub](https://github.com/alvinreal/awesome-opensource-ai) | awesome list | open-source AI users | open-source AI projects | PR | Medium — OATS is an AI-enabled app | open-source-ai, local-ai, privacy | Global / English |
+| suncloudsmoon/awesome-open-source-ai | [GitHub](https://github.com/suncloudsmoon/awesome-open-source-ai) | awesome list | open-source AI users | useful AI tools and models | PR | Medium — broad but relevant | open-source-ai, stt, tools | Global / English |
+| swiftsimplify/awesome-open-source-ai-tools | [GitHub](https://github.com/swiftsimplify/awesome-open-source-ai-tools) | awesome list | AI-tool seekers | open-source AI tools | PR | Medium — broader than OATS, still plausible | ai-tools, note-taking, local-ai | Global / English |
+| tehtbl/awesome-note-taking | [GitHub](https://github.com/tehtbl/awesome-note-taking) | awesome list | notes / PKM users | note-taking app discovery | PR / issue | High — exact category fit and active additions | note-taking, meeting-notes, ai-notes | Global / English |
+| nil0x42/awesome-hacker-note-taking | [GitHub](https://github.com/nil0x42/awesome-hacker-note-taking) | awesome list | technical users | note-taking tools for technical work | PR | Medium — niche audience, but note-capture fit exists | note-taking, markdown, knowledge base | Global / English |
+| spsdco/notes | [GitHub](https://github.com/spsdco/notes) | awesome list | note-taking users | note-taking app list | PR | Medium — older repo, but fit is direct | note-taking, markdown, productivity | Global / English |
+| knowfox/awesome-pkm | [GitHub](https://github.com/knowfox/awesome-pkm) | awesome list | PKM users | tools for thought, PKM | PR | Medium — PKM adjacent, not purely meetings | pkm, note-taking, knowledge-management | Global / English |
+| doanhthong/awesome-pkm | [GitHub](https://github.com/doanhthong/awesome-pkm) | awesome list | PKM users | PKM and note-taking tools | PR | Medium — strong conceptual fit | pkm, note-taking, second-brain | Global / English |
+| brettkromkamp/awesome-knowledge-management | [GitHub](https://github.com/brettkromkamp/awesome-knowledge-management) | awesome list | KM / PKM users | knowledge management apps | PR | Medium — broad KM scope | knowledge-management, notes, ai-notes | Global / English |
+| githubkusi/awesome-knowledge-management-tools | [GitHub](https://github.com/githubkusi/awesome-knowledge-management-tools) | awesome list | KM users | compare KM tools | PR | Medium — direct category alignment | knowledge-management, notes, markdown | Global / English |
+| jyguyomarch/awesome-productivity | [GitHub](https://github.com/jyguyomarch/awesome-productivity) | awesome list | productivity users | productivity resources and tools | PR | Medium — broad productivity list | productivity, notes, collaboration | Global / English |
+| ProductivityDirectory/awesome-productivity-tools | [GitHub](https://github.com/productivitydirectory/awesome-productivity-tools) | awesome list | productivity users | productivity software list | PR | Medium — fit is broad but reasonable | productivity, note-taking, ai | Global / English |
+| areknawo/awesome-productivity-software | [GitHub](https://github.com/areknawo/awesome-productivity-software) | awesome list | productivity users | life-management and productivity apps | PR | Medium — category fit is clear | productivity, notes, meeting tools | Global / English |
+| mundimark/awesome-markdown | [GitHub](https://github.com/mundimark/awesome-markdown) | awesome list | Markdown users | markdown tooling discovery | PR | Medium — if OATS exports / works with markdown story is emphasized | markdown, notes, editors | Global / English |
+| mundimark/awesome-markdown-editors | [GitHub](https://github.com/mundimark/awesome-markdown-editors) | awesome list | Markdown users | markdown editors/viewers | PR | Low — only if OATS’s markdown workflow is foregrounded | markdown, notes | Global / English |
+| BubuAnabelas/awesome-markdown | [GitHub](https://github.com/BubuAnabelas/awesome-markdown) | awesome list | Markdown users | markdown-related tools | PR | Low — indirect fit only | markdown, note-taking | Global / English |
+| diegoleme/awesome-open-source-alternatives | [GitHub](https://github.com/diegoleme/awesome-open-source-alternatives) | awesome list | OSS switchers | alternatives to proprietary tools | PR | High — OATS can be positioned as alternative to Granola / Otter / Plaud-style tools | open-source-alternative, notes, transcription | Global / English |
+| RunaCapital/awesome-oss-alternatives | [GitHub](https://github.com/RunaCapital/awesome-oss-alternatives) | awesome list | OSS startup watchers | open-source SaaS alternatives | issue / PR | Medium — startup criteria can be stricter, but category relevance is high | open-source alternative, productivity, notes | Global / English |
+| sfermigier/awesome-foss-alternatives | [GitHub](https://github.com/sfermigier/awesome-foss-alternatives) | awesome list | business OSS users | FOSS alternatives to SaaS | PR | Medium — B2B leaning, still relevant | foss, alternative, productivity | Global / English |
+| mustbeperfect/definitive-opensource | [GitHub](https://github.com/mustbeperfect/definitive-opensource) | awesome list | consumers seeking “best of” OSS | high-quality consumer OSS | PR | Medium — curated/vetted list; fit is strong but bar is high | macos, transcription, note-taking, privacy | Global / English |
+| DataDaoDe/awesome-foss-apps | [GitHub](https://github.com/DataDaoDe/awesome-foss-apps) | awesome list | developers / OSS users | quality FOSS apps by category | PR | Medium — OATS is a desktop OSS app | foss-apps, desktop-app, productivity | Global / English |
+| MMachado05/floss-alternatives | [GitHub](https://github.com/MMachado05/floss-alternatives) | awesome list | OSS switchers | FLOSS alternatives | PR | Medium — good category fit | floss, alternative, note-taking | Global / English |
+| An-anonymous-coder/Open-Source-Everything | [GitHub](https://github.com/An-anonymous-coder/Open-Source-Everything) | awesome list | broad OSS users | best open-source software | PR / discussion | Medium — broad but open-source desktop apps fit | open-source, privacy, notes, macos | Global / English |
+| piotrkulpinski/openalternative | [GitHub](https://github.com/piotrkulpinski/openalternative) | awesome list | OSS switchers | curated OSS alternatives | PR | High — exact alternative-positioning fit | open-source-alternative, productivity | Global / English |
+| andrew/ultimate-awesome | [GitHub](https://github.com/andrew/ultimate-awesome) | other | list curators / discoverers | meta discovery of awesome lists | PR | Medium — indirect, but can expose OATS-relevant list surfaces | awesome-lists, discovery | Global / English |
+| best-of-lists/best-of | [GitHub](https://github.com/best-of-lists/best-of) | other | OSS discoverers | meta-catalog of best-of lists | issue / PR | Medium — indirect, but useful amplifier | best-of, open-source, discovery | Global / English |
+| lyz-code/best-of-digital-gardens | [GitHub](https://github.com/lyz-code/best-of-digital-gardens) | other | knowledge-sharing users | digital garden meta-list | issue / PR | Low — indirect fit unless public-note workflow is emphasized | notes, pkm, knowledge | Global / English |
+| RichardLitt/meta-knowledge | [GitHub](https://github.com/RichardLitt/meta-knowledge) | other | knowledge-repo users | meta list of knowledge repos | PR | Low — indirect; better for public-knowledge angle than app discovery | knowledge, notes, markdown | Global / English |
+
+**GitHub topic catalogs**
+
+| Name | URL | Type | Primary audience | Intent / use-case | Submission method | Acceptance likelihood with rationale | Tags / keywords matched to OATS | Geographic / language focus |
+|---|---|---|---|---|---|---|---|---|
+| GitHub Topic: meeting-notes | [GitHub](https://github.com/topics/meeting-notes) | software catalog | GitHub users | browse meeting-note repos | manual topic edit | High — direct tag match, self-managed | meeting-notes, ai-notes | Global / English |
+| GitHub Topic: speech-to-text | [GitHub](https://github.com/topics/speech-to-text) | software catalog | STT users | browse STT repos | manual topic edit | High — exact function | speech-to-text, transcription | Global / English |
+| GitHub Topic: automatic-speech-recognition | [GitHub](https://github.com/topics/automatic-speech-recognition) | software catalog | ASR users | browse ASR repos | manual topic edit | High — direct technical match | asr, whisper, stt | Global / English |
+| GitHub Topic: offline-speech-recognition | [GitHub](https://github.com/topics/offline-speech-recognition) | software catalog | offline-AI users | browse offline STT tools | manual topic edit | High — OATS’s on-device mode fits exactly | offline, on-device, stt | Global / English |
+| GitHub Topic: speaker-diarization | [GitHub](https://github.com/topics/speaker-diarization) | software catalog | speech-tool users | browse diarization tools | manual topic edit | Medium — adjacent capability, still relevant | diarization, transcription | Global / English |
+| GitHub Topic: transcription | [GitHub](https://github.com/topics/transcription) | software catalog | transcription seekers | browse transcription repos | manual topic edit | High — one of OATS’s core jobs | transcription, meeting notes | Global / English |
+| GitHub Topic: local-first | [GitHub](https://github.com/topics/local-first) | software catalog | privacy / local-first users | browse local-first apps | manual topic edit | High — exact architecture fit | local-first, privacy, offline | Global / English |
+| GitHub Topic: local-first-ai | [GitHub](https://github.com/topics/local-first-ai) | software catalog | local-AI users | browse local-first AI apps | manual topic edit | High — exact positioning fit | local-first-ai, privacy, notes | Global / English |
+| GitHub Topic: personal-knowledge-management | [GitHub](https://github.com/topics/personal-knowledge-management) | software catalog | PKM users | browse PKM software | manual topic edit | Medium — good fit if notes/search are emphasized | pkm, notes, second-brain | Global / English |
+| GitHub Topic: note-taking | [GitHub](https://github.com/topics/note-taking) | software catalog | note-taking users | browse note apps | manual topic edit | High — direct product category | note-taking, ai-notes | Global / English |
+| GitHub Topic: ai-notes | [GitHub](https://github.com/topics/ai-notes) | software catalog | AI-note users | browse AI note apps | manual topic edit | High — direct positioning fit | ai-notes, meeting-notes | Global / English |
+| GitHub Topic: knowledge-management | [GitHub](https://github.com/topics/knowledge-management) | software catalog | KM users | browse KM repos | manual topic edit | Medium — broader but valid | knowledge-management, notes | Global / English |
+| GitHub Topic: menubar-app | [GitHub](https://github.com/topics/menubar-app) | software catalog | Mac utility users | browse menubar apps | manual topic edit | High — exact UI pattern | menubar-app, macos | Global / English |
+| GitHub Topic: macos-apps | [GitHub](https://github.com/topics/macos-apps) | software catalog | Mac users | browse macOS apps | manual topic edit | High — exact platform fit | macos, productivity | Global / English |
+| GitHub Topic: macos-application | [GitHub](https://github.com/topics/macos-application) | software catalog | Mac users | browse macOS application repos | manual topic edit | High — exact platform fit | macos-application, apple-silicon | Global / English |
+| GitHub Topic: macos-menubar | [GitHub](https://github.com/topics/macos-menubar) | software catalog | Mac utility users | browse top-bar apps | manual topic edit | High — exact pattern fit | macos-menubar, menubar | Global / English |
+| GitHub Topic: menu-bar | [GitHub](https://github.com/topics/menu-bar) | software catalog | utility-app users | browse menu-bar software | manual topic edit | High — direct pattern match | menu-bar, macos | Global / English |
+| GitHub Topic: mac-setup | [GitHub](https://github.com/topics/mac-setup) | software catalog | Mac enthusiasts | “my setup” discovery | manual topic edit | Medium — indirect but discoverable | macos, productivity | Global / English |
+| GitHub Topic: tauri | [GitHub](https://github.com/topics/tauri) | software catalog | Tauri builders/users | browse Tauri apps | manual topic edit | High — core framework fit | tauri, rust, vue | Global / English |
+| GitHub Topic: tauri-app | [GitHub](https://github.com/topics/tauri-app) | software catalog | Tauri users | browse shipping Tauri apps | manual topic edit | High — exact fit | tauri-app, macos | Global / English |
+| GitHub Topic: rust-lang | [GitHub](https://github.com/topics/rust-lang) | software catalog | Rust users | browse Rust repos | manual topic edit | Medium — broad language topic | rust, desktop-app | Global / English |
+| GitHub Topic: privacy | [GitHub](https://github.com/topics/privacy) | software catalog | privacy users | browse privacy projects | manual topic edit | High — OATS’s privacy story is strong | privacy, on-device, local-first | Global / English |
+
+**Public directories, alternative catalogs, and package indexes**
+
+| Name | URL | Type | Primary audience | Intent / use-case | Submission method | Acceptance likelihood with rationale | Tags / keywords matched to OATS | Geographic / language focus |
+|---|---|---|---|---|---|---|---|---|
+| AlternativeTo | [Site](https://alternativeto.net/) | alternative-to | end users replacing software | app comparison and alternatives | form / account | High — direct app discovery; OATS can be framed vs Otter/Granola/Plaid-type tools | alternative, note-taking, transcription, privacy | Global / English-first |
+| SaaSHub | [Site](https://www.saashub.com/submit) | alternative-to | startup / software buyers | alternatives and startup directory | form | Medium — broad SaaS framing, but category coverage is wide | productivity, communication, notes | Global / English |
+| OpenAlternative | [Site](https://openalternative.co/) | alternative-to | OSS switchers | curated open-source alternatives | submit / login | Medium — strong thematic fit, but submission appears gated | open-source-alternative, ai, productivity | Global / English |
+| OpenSourceAlternative.to | [Site](https://www.opensourcealternative.to/) | alternative-to | OSS switchers | proprietary-to-OSS replacement discovery | submit | High — exact audience and positioning fit | open-source alternative, privacy, notes | Global / English |
+| Open Hub | [Site](https://openhub.net/) | directory | OSS developers/users | track and compare OSS projects | manual add project | High — community-driven FOSS project directory | open-source, project metrics, macos | Global / English |
+| Free Software Directory | [Site](https://directory.fsf.org/wiki/Main_Page) | directory | free-software users | FSF-style software discovery | form | Medium — strong OSS fit, but licensing review standards are stricter | free-software, privacy, productivity | Global / English |
+| Awesome Open Source | [Site](https://awesomeopensource.com/) | directory | developers | open-source project discovery / comparisons | listing request / indirect | Medium — strong discoverability, submission path less explicit | open-source, rust, vue, productivity | Global / English |
+| Open Apps | [Site](https://openapps.pro/) | directory | OSS switchers / teams | curated OSS apps by category | contact / editorial | Medium — strong fit, but editorial submission path is not explicit | productivity, ai-assistants, notes, privacy | Global / English |
+| MacMenuBar.com | [Site](https://macmenubar.com/) | directory | Mac end users | discover menu bar apps | submit page | High — exact UI/form-factor fit | menubar-app, macos, productivity | Global / English |
+| SourceForge Directory | [Site](https://sourceforge.net/directory/) | directory | OSS users | browse open-source projects | project listing | Medium — broad OSS directory, less targeted than Mac/notes lists | open-source, productivity | Global / English |
+| LibHunt | [Site](https://www.libhunt.com/repo/submit) | directory | developers | find packages / projects by language & topic | submit project | Medium — more dev-facing and library-centric, but still useful | rust, vue, self-hosted, macos | Global / English |
+| switching.software | [Site](https://switching.software/use/) | alternative-to | privacy / anti-lock-in users | recommend free/open alternatives | editorial / source-linked suggestion | Medium — strong philosophical fit, but curation is editorial | privacy, note-taking, alternatives | Global / English |
+| Homebrew Cask | [GitHub](https://github.com/Homebrew/homebrew-cask) | package index | Mac developers/users | install Mac apps via brew | PR | Medium — valuable channel, but packaging/review work required | macos, cask, apple-silicon | Global / English |
+| MacPorts | [GitHub](https://github.com/macports/macports-ports) | package index | Mac technical users | install packaged software | PR | Low — packaging-heavy and more technical audience | macos, package, rust | Global / English |
+| Nixpkgs | [GitHub](https://github.com/NixOS/nixpkgs) | package index | Nix / reproducibility users | packaged software distribution | PR | Low — packaging overhead, narrower user base | nix, macos, package, rust | Global / English |
+
+## Prioritized outreach sequence
+
+The most efficient sequence is to stack **guaranteed discoverability**, then **high-fit curated acceptance**, then **end-user directories**, then **packaging surfaces**.
+
+The single best **first target overall** is **GitHub Topics** on the OATS repository itself. This is the only channel where acceptance is effectively under project control, GitHub explicitly supports listing by repo topics, and the resulting visibility propagates across multiple high-intent topic catalogs immediately. The best first topic bundle is: `meeting-notes`, `speech-to-text`, `transcription`, `ai-notes`, `local-first`, `privacy`, `menubar-app`, `macos-application`, `apple-silicon`, `tauri`, and `tauri-app`. citeturn13search18turn36search2turn35search0turn35search3
+
+The best **first external curated target** is **serhii-londar/open-source-mac-os-apps**. It is exact-fit on platform and license, it has high search and social proof inside the GitHub ecosystem, and OATS is easy to describe in one sentence there: “open-source macOS menubar meeting-notes app with offline transcription and AI notes.” citeturn5search1
+
+A practical campaign order is:
+
+| Phase | Goal | Targets | Why this order |
+|---|---|---|---|
+| Metadata sprint | zero-friction listings | GitHub Topics | no moderation delay, immediate effect |
+| Exact-fit PR sprint | high-likelihood curated wins | open-source-mac-os-apps, awesome-mac, awesome-menubar, awesome-note-taking, awesome-whisper, awesome-voice-typing, awesome-local-first, awesome-privacy | strongest category precision |
+| End-user directory sprint | mainstream discovery | MacMenuBar, AlternativeTo, Open Hub, OpenSourceAlternative.to, Open Apps | better user acquisition potential |
+| Ecosystem sprint | builder/dev discovery | awesome-tauri, awesome-rust, awesome-vue, LibHunt | reaches developers who recommend tools |
+| Packaging sprint | installation convenience | Homebrew Cask, MacPorts, Nixpkgs | high value, more work |
+| Long-tail sweep | compounding backlinks and niche reach | broader OSS alternative/meta lists | lower ROI individually, good cumulative value |
+
+```mermaid
+timeline
+    title OATS outreach timeline
+    Day 1-2 : Update GitHub topics
+             : Refresh repo description, screenshots, badges, one-line pitch
+    Day 2-4 : Submit PRs to exact-fit lists
+             : open-source-mac-os-apps, awesome-mac, awesome-menubar
+             : awesome-note-taking, awesome-whisper, awesome-voice-typing
+    Day 4-6 : Submit to public directories
+             : MacMenuBar, AlternativeTo, Open Hub, OpenSourceAlternative.to
+    Day 6-8 : Submit to ecosystem lists
+             : awesome-tauri, awesome-rust, awesome-vue, awesome-local-first, awesome-privacy
+    Day 8-12 : Package and distribution passes
+              : Homebrew Cask first, then MacPorts and Nixpkgs if bandwidth allows
+    Afterward : Long-tail sweep
+               : broader OSS alternatives and meta lists
+```
+
+The strongest first **ten targets** by return-on-effort are:
+
+1. GitHub Topics
+2. serhii-londar/open-source-mac-os-apps
+3. tauri-apps/awesome-tauri
+4. jaywcjlove/awesome-mac
+5. jordanbaird/awesome-menubar
+6. tehtbl/awesome-note-taking
+7. sindresorhus/awesome-whisper
+8. primaprashant/awesome-voice-typing
+9. MacMenuBar.com
+10. AlternativeTo
+
+One important tactical caution: AlternativeTo documents that new users must wait a week after account creation before submitting a new application, so it is worth creating and warming that account early rather than treating AlternativeTo as a same-day task. Likewise, Homebrew Cask is explicitly PR-first. citeturn11search0turn27search0turn27search16
+
+## Outreach templates
+
+These are written to be copied with minimal editing. I have kept them short because concise, category-specific submissions usually convert better than long generic pitches.
+
+| Target | Recommended message |
+|---|---|
+| GitHub Topics | **Repo metadata update**: “Updating OATS topics for discoverability: `meeting-notes`, `speech-to-text`, `transcription`, `ai-notes`, `local-first`, `privacy`, `menubar-app`, `macos-application`, `apple-silicon`, `tauri`, `tauri-app`. OATS is a free, open-source Mac menubar app for offline transcription and AI meeting notes.” |
+| open-source-mac-os-apps | **PR text**: “Add **OATS** — free, open-source macOS menubar app for meeting recording, transcription, and AI notes. Supports cloud mode or fully on-device mode on Apple Silicon Macs. Suggested category: Productivity / Notes / Audio.” |
+| awesome-tauri | **PR text**: “Add **OATS** under Apps/Productivity: a Tauri + Rust + Vue macOS menubar app for meeting transcription and AI notes, with privacy-first local mode and Apple Silicon support.” |
+| awesome-mac | **PR text**: “Add **OATS** in Productivity / Note Taking: open-source macOS menubar app for meeting notes, offline transcription, and AI summaries. Built with Tauri and optimized for Apple Silicon.” |
+| awesome-menubar | **PR text**: “Add **OATS**: open-source menu bar app for Mac that records/transcribes meetings and generates AI notes, with optional 100% on-device mode for privacy-sensitive workflows.” |
+| awesome-note-taking | **Issue or PR text**: “Suggest adding **OATS** to AI note-taking / meeting notes. It is a free, open-source macOS menubar app focused on meeting capture, offline transcription, and AI-generated notes.” |
+| awesome-whisper | **PR text**: “Add **OATS** to apps built with Whisper/ASR tooling: open-source Mac app for meeting transcription and AI notes, with on-device mode and privacy-first positioning.” |
+| awesome-voice-typing | **PR text**: “Add **OATS** in desktop/macOS section: open-source app for speech-to-text meeting capture and AI notes. Strong fit for offline, local, and privacy-preserving dictation workflows.” |
+| MacMenuBar.com | **Submission copy**: “**OATS** is a free, open-source menu bar app for macOS that records meetings, transcribes speech, and turns conversations into AI notes. Built for Apple Silicon with privacy-first on-device mode.” |
+| AlternativeTo | **App description**: “OATS is a free and open-source macOS app for meeting notes. It records, transcribes, and summarizes meetings with AI, and can run fully on-device on Apple Silicon Macs for privacy-sensitive workflows. Good alternative positioning: Otter.ai, Granola, Plaud, Fathom, Superwhisper-style workflows.” |
+
+A short reusable one-line pitch for most listings is:
+
+> **OATS is a free, open-source macOS menubar app for meeting transcription and AI notes, with privacy-first on-device mode on Apple Silicon.**
+
+A slightly more technical variant for developer lists is:
+
+> **OATS is a Tauri + Rust + Vue desktop app for macOS that records meetings, transcribes audio, and generates AI notes locally or with cloud backends.**
+
+## Open questions and limitations
+
+This report favors **high-confidence official sources and official repo pages**. I did not try to verify the current moderation responsiveness or editorial activity level for every single GitHub list, and some curated repos are broader or more personal than others. For those entries, the “acceptance likelihood” is an informed inference based on scope, contribution posture, and fit rather than a guarantee.
+
+I also intentionally down-ranked some technically plausible surfaces—especially self-hosted lists and deeper package indexes—because OATS’s strongest present story is “open-source local macOS app,” not “server product.” If OATS later ships stronger self-hosted collaboration or remote-backend workflows, several lower-ranked targets could move up substantially.

--- a/progress.md
+++ b/progress.md
@@ -1,0 +1,54 @@
+# Progress
+
+## 2026-07-07
+
+- Approach: revise the outreach work to be OpenProse-native instead of a
+  JavaScript batch runner. The workflow is now a Contract Markdown function that
+  reads the source report and target manifest, fans out selection and publisher
+  workers, opens draft PRs only in explicit live mode, and writes a review report
+  linking the draft PRs.
+- Context gathered: loaded the requested `/Users/michael/.agents/skills/open-prose`
+  skill, Contract Markdown spec, OpenProse tenets, authoring guidance, and
+  ProseScript syntax. Corrected the earlier assumption: `prose run` is embodied
+  by a Prose Complete host such as Codex or Claude Code; this repo should not
+  shell out to a standalone `prose` binary for this campaign.
+- Steps taken: converted the attached OATS listing research report into
+  `docs/outreach/listing-targets.json` with 103 targets, including 66 automated
+  GitHub list PR targets, 22 GitHub topic updates, 7 form submissions, 5 manual
+  editorial targets, and 3 package PR targets; added the source report at
+  `docs/outreach/oats-listing-target-research.md`; added
+  `docs/outreach/listing-pr-batch-report.md` as the PR-linked public campaign
+  report; added `docs/outreach/oats-listing-profile.md` for canonical copy; added
+  `.agents/prose/src/oats-listing-campaign/index.prose.md`; removed the rejected
+  Node runner and legacy `.prose` script; ignored OpenProse generated deps, dist,
+  runs, and env files.
+- Failures/notes: `npm ls --depth=0` initially showed all npm dependencies
+  missing because `node_modules/` was not installed in this worktree.
+  `npm ci --prefer-offline` succeeded, but npm reported two existing
+  high-severity audit findings. The first outreach design was too code-driven
+  and treated OpenProse like an external CLI; the corrected design keeps the
+  orchestration in `.prose.md` and lets the host supply worker sessions.
+- Validation: JSON structure checks passed for `package.json` and
+  `docs/outreach/listing-targets.json`; the manifest count check passed with 103
+  targets and the expected submission-kind split; a lightweight OpenProse
+  contract marker check passed; `gh auth status` confirmed the host is ready for
+  live GitHub work; `npx vitest run src/views/WaveformView.test.ts` passed; full
+  `npm test` passed with 48 files and 507 tests; `npm run vite:build` passed with
+  the existing large-chunk warning. The first full `npm test` run failed on stale
+  `UpdateView` and `LibraryView` expectations, so those tests were updated:
+  update tests now use `__APP_VERSION__`, the LibraryView detail fixture includes
+  `audioClips`, the detail stub exposes `saveNotesNow`, and recording-start
+  assertions now check sidebar collapse rather than disappearance of the titlebar
+  Start button. A later full suite run exposed a `WaveformView` fake-timer leak;
+  the timer tests now unmount the component before restoring real timers.
+- Type/lint notes: there is no `lint` script in `package.json`. There is also no
+  configured typecheck script and TypeScript is not installed as a direct project
+  tool. A diagnostic `npm exec --package typescript -- tsc --noEmit` run was
+  attempted and failed on broad pre-existing app/test typing issues, not on the
+  outreach script; the affected script syntax check above passed.
+- Lessons learned: the target set should stay structured in JSON, with non-PR
+  surfaces kept explicit as manual/form/topic follow-ups rather than forcing
+  every listing surface through GitHub PR automation. OpenProse is the workflow
+  contract and VM behavior, not a subprocess hidden behind a project script.
+  Vue fake-timer tests should clear component intervals before switching timer
+  implementations.

--- a/src/views/LibraryView.test.ts
+++ b/src/views/LibraryView.test.ts
@@ -95,6 +95,12 @@ function item(over: Record<string, unknown>) {
 const detailStub = {
   name: 'MeetingDetailView',
   emits: ['close', 'title-updated'],
+  setup(_props: unknown, { expose }: { expose: (exposed: { saveNotesNow: () => Promise<void> }) => void }) {
+    expose({
+      saveNotesNow: () => writeRecordingNote('stub', ''),
+    });
+    return {};
+  },
   template: '<div class="detail-stub"><button class="btn-close" @click="$emit(\'close\')">x</button></div>',
 };
 function mountWithDetailStub() {
@@ -118,6 +124,7 @@ beforeEach(() => {
       isLocal: true,
       durationSeconds: meeting.durationSeconds,
       hasTranscript: meeting.files?.hasTranscript ?? false,
+      audioClips: [],
     })
   );
   invoke.mockResolvedValue(undefined);
@@ -885,19 +892,19 @@ describe('LibraryView', () => {
     await flushPromises();
     expect(wrapper.find('.up-next').exists()).toBe(false);
     // The recording transition also collapses the sidebar immediately.
-    expect(wrapper.find('.add-btn').exists()).toBe(false);
+    expect(wrapper.find('.sidebar').exists()).toBe(false);
   });
 
   it('leaves the detail panel unchanged when a recording starts without a meeting', async () => {
     listMeetings.mockResolvedValue([item({ id: '42', title: 'Picked Sync' })]);
-    const wrapper = mount(LibraryView);
+    const wrapper = mountWithDetailStub();
     await flushPromises();
     expect(wrapper.find('.up-next').exists()).toBe(false);
 
     emitEvent('recording://started', { meetingId: null });
     await flushPromises();
     expect(wrapper.find('.up-next').exists()).toBe(false);
-    expect(wrapper.find('.add-btn').exists()).toBe(false);
+    expect(wrapper.find('.sidebar').exists()).toBe(false);
   });
 
   it('reloads the meeting list when the picked meeting is not loaded yet', async () => {

--- a/src/views/UpdateView.test.ts
+++ b/src/views/UpdateView.test.ts
@@ -44,6 +44,8 @@ vi.mock('../tauri', () => ({
 
 import UpdateView from './UpdateView.vue';
 
+const currentVersion = __APP_VERSION__;
+
 beforeEach(() => {
   vi.clearAllMocks();
   mocks.listeners.clear();
@@ -56,7 +58,7 @@ describe('UpdateView', () => {
     await flushPromises();
 
     expect(wrapper.text()).toContain('Oats is up to date');
-    expect(wrapper.text()).toContain('Version 0.4.0 is installed.');
+    expect(wrapper.text()).toContain(`Version ${currentVersion} is installed.`);
     expect(wrapper.text()).not.toContain('Install Update');
     expect(wrapper.text()).toContain('Done');
   });
@@ -82,7 +84,7 @@ describe('UpdateView', () => {
     await flushPromises();
 
     expect(wrapper.text()).toContain('What’s new for Oats?');
-    expect(wrapper.text()).toContain('Version 0.4.1 is ready. You have 0.4.0.');
+    expect(wrapper.text()).toContain(`Version 0.4.1 is ready. You have ${currentVersion}.`);
     expect(wrapper.text()).toContain('Features');
     expect(wrapper.text()).toContain('Release-note powered highlights');
     expect(wrapper.text()).toContain('Smaller native update window');
@@ -95,7 +97,7 @@ describe('UpdateView', () => {
     mocks.state = {
       ...mocks.defaultState,
       latest_known: {
-        version: '0.4.0',
+        version: currentVersion,
         mandatory: false,
         notes: '- Should not show as pending',
       },

--- a/src/views/WaveformView.test.ts
+++ b/src/views/WaveformView.test.ts
@@ -265,6 +265,7 @@ describe('WaveformView vertical pill', () => {
     expect(wrapper.find('.status-icon.ok').exists()).toBe(true);
     await vi.advanceTimersByTimeAsync(2000);
     expect(closeWin).toHaveBeenCalled();
+    wrapper.unmount();
     vi.useRealTimers();
   });
 
@@ -309,8 +310,8 @@ describe('WaveformView vertical pill', () => {
     await flushPromises();
     expect(invoke).toHaveBeenCalledWith('show_silence_prompt', {});
     expect(stopRecording).not.toHaveBeenCalled();
-    vi.useRealTimers();
     wrapper.unmount();
+    vi.useRealTimers();
   });
 
   it('never shows the silence prompt when silence detection is disabled', async () => {
@@ -328,8 +329,8 @@ describe('WaveformView vertical pill', () => {
     await flushPromises();
     expect(invoke.mock.calls.some(([cmd]) => cmd === 'show_silence_prompt')).toBe(false);
     expect(stopRecording).not.toHaveBeenCalled();
-    vi.useRealTimers();
     wrapper.unmount();
+    vi.useRealTimers();
   });
 
   it('auto-stops 60s after an unanswered silence prompt', async () => {
@@ -350,8 +351,8 @@ describe('WaveformView vertical pill', () => {
     await flushPromises();
     expect(invoke).toHaveBeenCalledWith('dismiss_silence_prompt');
     expect(stopRecording).toHaveBeenCalled();
-    vi.useRealTimers();
     wrapper.unmount();
+    vi.useRealTimers();
   });
 
   it('silence-prompt://keep reseeds the silence clock so auto-stop is deferred', async () => {
@@ -377,8 +378,8 @@ describe('WaveformView vertical pill', () => {
     await vi.advanceTimersByTimeAsync(SILENCE_GRACE_MS + 1_000);
     await flushPromises();
     expect(stopRecording).not.toHaveBeenCalled();
-    vi.useRealTimers();
     wrapper.unmount();
+    vi.useRealTimers();
   });
 
   it('silence-prompt://stop immediately stops the recording', async () => {
@@ -398,8 +399,8 @@ describe('WaveformView vertical pill', () => {
     await eventHandlers['silence-prompt://stop']?.({});
     await flushPromises();
     expect(stopRecording).toHaveBeenCalled();
-    vi.useRealTimers();
     wrapper.unmount();
+    vi.useRealTimers();
   });
 
   it('does not broadcast a recording phase before capture has started', async () => {
@@ -407,12 +408,13 @@ describe('WaveformView vertical pill', () => {
     vi.setSystemTime(0);
     // getUserMedia still pending: the recorder reports not-recording.
     recorderIsRecording.value = false;
-    mount(WaveformView);
+    const wrapper = mount(WaveformView);
     await vi.runOnlyPendingTimersAsync();
     emitEvent.mockClear();
     await vi.advanceTimersByTimeAsync(2_100); // heartbeats fire
     const states = emitEvent.mock.calls.filter(([name]) => name === 'recorder://state');
     expect(states).toHaveLength(0);
+    wrapper.unmount();
     vi.useRealTimers();
   });
 
@@ -438,13 +440,14 @@ describe('WaveformView vertical pill', () => {
     await vi.advanceTimersByTimeAsync(2000);
     const last = emitEvent.mock.calls.filter(([name]) => name === 'recorder://state').at(-1);
     expect((last?.[1] as { phase: string }).phase).toBe('closed');
+    wrapper.unmount();
     vi.useRealTimers();
   });
 
   it('broadcasts the deterministic local recording id for the local backend', async () => {
     vi.useFakeTimers();
     vi.setSystemTime(0);
-    mount(WaveformView);
+    const wrapper = mount(WaveformView);
     await vi.runOnlyPendingTimersAsync();
     await vi.advanceTimersByTimeAsync(1_100); // heartbeat
 
@@ -454,6 +457,7 @@ describe('WaveformView vertical pill', () => {
       .at(-1);
     // Mirrors Rust sanitize_iso_to_id over the mocked startedAt.
     expect(state?.localRecordingId).toBe('2026-06-09T10-00-00Z');
+    wrapper.unmount();
     vi.useRealTimers();
   });
 
@@ -463,7 +467,7 @@ describe('WaveformView vertical pill', () => {
     // Rust resolves this session to an EXISTING recording (append within window),
     // so the strip must dock to that recording's row, not a new-session id.
     recordingIdForStart.mockResolvedValueOnce('2026-06-02T10-00-00Z');
-    mount(WaveformView);
+    const wrapper = mount(WaveformView);
     await vi.runOnlyPendingTimersAsync();
     await vi.advanceTimersByTimeAsync(1_100); // heartbeat
 
@@ -473,6 +477,7 @@ describe('WaveformView vertical pill', () => {
       .at(-1);
     expect(recordingIdForStart).toHaveBeenCalledWith('2026-06-09T10:00:00Z');
     expect(state?.localRecordingId).toBe('2026-06-02T10-00-00Z');
+    wrapper.unmount();
     vi.useRealTimers();
   });
 
@@ -655,6 +660,7 @@ describe('WaveformView vertical pill', () => {
     expect(wrapper.find('.status-icon.ok').exists()).toBe(true);
     await vi.advanceTimersByTimeAsync(2000);
     expect(closeWin).toHaveBeenCalled();
+    wrapper.unmount();
     vi.useRealTimers();
   });
 
@@ -679,6 +685,7 @@ describe('WaveformView vertical pill', () => {
       .map(([, p]) => (p as { phase: string }).phase);
     expect(phases).toContain('uploading');
     expect(phases).toContain('success');
+    wrapper.unmount();
     vi.useRealTimers();
   });
 


### PR DESCRIPTION
## Summary

Adds an OpenProse-native listing campaign for posting OATS to curated software lists.

## Notes

The campaign sources the attached research report and structured manifest, fans out target selection and publisher workers, keeps external PRs draft by default, and writes a local review report for maintainer follow-up.

Validation already run locally: JSON checks, manifest count check, OpenProse marker check, `npm test`, and `npm run vite:build`.
