### PR TITLE
fix: match settings titlebar background

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -483,8 +483,6 @@ pub async fn set_tray_recording(app: tauri::AppHandle, is_recording: bool, is_pa
 
 #[tauri::command]
 pub async fn create_settings_window(app: tauri::AppHandle) -> Result<(), String> {
-    use tauri::{WebviewWindowBuilder, WebviewUrl};
-
     // Focus if already exists
     if let Some(win) = app.get_webview_window("settings") {
         win.show().map_err(|e: tauri::Error| e.to_string())?;
@@ -492,11 +490,7 @@ pub async fn create_settings_window(app: tauri::AppHandle) -> Result<(), String>
         return Ok(());
     }
 
-    WebviewWindowBuilder::new(&app, "settings", WebviewUrl::App("/#/settings".into()))
-        .title("Oats Settings")
-        .inner_size(450.0, 800.0)
-        .resizable(false)
-        .center()
+    crate::window_style::settings_window_builder(&app)
         .build()
         .map_err(|e| e.to_string())?;
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -17,6 +17,7 @@ mod tray;
 mod tray_meeting;
 mod update_manager;
 mod vault;
+mod window_style;
 
 /// Build the macOS application menu. Mirrors Tauri's default menu (so the
 /// standard Edit/Window/View items and their shortcuts still work) but injects
@@ -288,13 +289,8 @@ fn main() {
             // Pre-create settings window (hidden) — shown on demand from tray.
             // Intercept close requests so the window hides instead of being
             // destroyed; otherwise re-opening from the tray would do nothing.
-            let settings = WebviewWindowBuilder::new(app, "settings", WebviewUrl::App("/#/settings".into()))
-                .title("Oats Settings")
-                .inner_size(450.0, 800.0)
-                .resizable(false)
-                .center()
+            let settings = crate::window_style::settings_window_builder(app)
                 .visible(false)
-                .skip_taskbar(true)
                 .build()?;
 
             let settings_clone = settings.clone();

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -2,7 +2,7 @@ use tauri::{
     image::Image,
     menu::{MenuBuilder, MenuItemBuilder},
     tray::TrayIconBuilder,
-    AppHandle, Emitter, Manager, WebviewWindowBuilder,
+    AppHandle, Emitter, Manager,
 };
 
 // The menu-bar icon is a macOS template image: AppKit uses the PNG alpha mask
@@ -186,17 +186,8 @@ pub fn create_tray(app: &AppHandle) -> tauri::Result<()> {
                     if let Some(win) = app.get_webview_window("settings") {
                         let _ = win.show();
                         let _ = win.set_focus();
-                    } else if let Ok(win) = WebviewWindowBuilder::new(
-                        app,
-                        "settings",
-                        tauri::WebviewUrl::App("/#/settings".into()),
-                    )
-                    .title("oats Settings")
-                    .inner_size(450.0, 800.0)
-                    .resizable(false)
-                    .center()
-                    .skip_taskbar(true)
-                    .build()
+                    } else if let Ok(win) = crate::window_style::settings_window_builder(app)
+                        .build()
                     {
                         let win_clone = win.clone();
                         win.on_window_event(move |event| {

--- a/src-tauri/src/window_style.rs
+++ b/src-tauri/src/window_style.rs
@@ -1,0 +1,19 @@
+use tauri::webview::{Color, WebviewWindowBuilder};
+use tauri::{Manager, Runtime, TitleBarStyle, WebviewUrl};
+
+const SETTINGS_BACKGROUND: Color = Color(247, 246, 244, 255);
+
+pub(crate) fn settings_window_builder<'a, R, M>(manager: &'a M) -> WebviewWindowBuilder<'a, R, M>
+where
+    R: Runtime,
+    M: Manager<R>,
+{
+    WebviewWindowBuilder::new(manager, "settings", WebviewUrl::App("/#/settings".into()))
+        .title("Oats Settings")
+        .title_bar_style(TitleBarStyle::Transparent)
+        .background_color(SETTINGS_BACKGROUND)
+        .inner_size(450.0, 800.0)
+        .resizable(false)
+        .center()
+        .skip_taskbar(true)
+}


### PR DESCRIPTION
Makes settings title bar blend in with the window background
<img width="509" height="136" alt="Screenshot 2026-07-07 at 11 03 20 AM" src="https://github.com/user-attachments/assets/249d8ad5-c321-4a64-be4c-36e1ab592302" />


## Summary
- add a shared Tauri Settings window builder
- make the Settings titlebar transparent with the same background color as the Settings page
- use the shared builder across startup, command, and tray creation paths

## Validation
- git diff --check -- src-tauri/src/commands.rs src-tauri/src/main.rs src-tauri/src/tray.rs src-tauri/src/window_style.rs
- npm run vite:build
- focused Settings Vitest and Rust checks passed in the validation worktree before draft PR prep
- current d9a9 dev screenshot attempt was blocked by disk pressure before producing a saved image

## Notes
- progress.md remains local and untracked


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized the Settings window’s appearance and behavior across all entry points.
  * Settings now consistently opens with its configured size, centered placement, transparent title bar, background styling, and hidden taskbar presence.
  * Existing behavior for showing, focusing, hiding, and preventing accidental closure remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->