### PR TITLE
fix: prompt to stop recording when the next calendar meeting starts

### DIFF
--- a/src-tauri/src/meeting_notifications.rs
+++ b/src-tauri/src/meeting_notifications.rs
@@ -1119,19 +1119,28 @@ pub async fn resize_silence_prompt(app: AppHandle, expanded: bool) -> Result<(),
 const MEETING_END_PROMPT_SECONDS: u64 = 30;
 
 /// Route + params for the meeting-end prompt window. `seconds` drives the
-/// cosmetic countdown bar; `subtitle`, when present, is the meeting title.
-fn meeting_end_prompt_url(seconds: u64, subtitle: Option<&str>) -> String {
+/// cosmetic countdown bar; `subtitle`, when present, is the meeting title;
+/// `title`, when present, overrides the card's "Meeting ended" heading (e.g.
+/// "Next meeting started" when the next calendar meeting is the trigger).
+fn meeting_end_prompt_url(seconds: u64, subtitle: Option<&str>, title: Option<&str>) -> String {
     let mut ser = url::form_urlencoded::Serializer::new(String::new());
     ser.append_pair("seconds", &seconds.to_string());
     if let Some(s) = subtitle.filter(|s| !s.is_empty()) {
         ser.append_pair("subtitle", s);
+    }
+    if let Some(t) = title.filter(|t| !t.is_empty()) {
+        ser.append_pair("title", t);
     }
     format!("/#/meeting-end-prompt?{}", ser.finish())
 }
 
 /// Build (or replace) the borderless top-right meeting-end prompt window. Same
 /// chrome as the silence prompt. Must run on the main thread.
-fn open_meeting_end_prompt_window(app: &AppHandle, subtitle: Option<&str>) -> Result<(), String> {
+fn open_meeting_end_prompt_window(
+    app: &AppHandle,
+    subtitle: Option<&str>,
+    title: Option<&str>,
+) -> Result<(), String> {
     use tauri::{WebviewUrl, WebviewWindowBuilder};
 
     if let Some(existing) = app.get_webview_window("meeting-end-prompt") {
@@ -1140,7 +1149,9 @@ fn open_meeting_end_prompt_window(app: &AppHandle, subtitle: Option<&str>) -> Re
     let win = WebviewWindowBuilder::new(
         app,
         "meeting-end-prompt",
-        WebviewUrl::App(meeting_end_prompt_url(MEETING_END_PROMPT_SECONDS, subtitle).into()),
+        WebviewUrl::App(
+            meeting_end_prompt_url(MEETING_END_PROMPT_SECONDS, subtitle, title).into(),
+        ),
     )
     .title("")
     .inner_size(MEETING_PROMPT_W, MEETING_PROMPT_H)
@@ -1174,13 +1185,16 @@ fn close_meeting_end_prompt_window(app: &AppHandle) {
     }
 }
 
-/// Show the meeting-end prompt. `subtitle`, when present, is the meeting title.
-/// Window creation must happen on the main thread.
+/// Show the meeting-end prompt. `subtitle`, when present, is the meeting title;
+/// `title`, when present, overrides the card heading to say why the prompt
+/// appeared. Window creation must happen on the main thread.
 #[tauri::command]
-pub fn show_meeting_end_prompt(app: AppHandle, subtitle: Option<String>) {
+pub fn show_meeting_end_prompt(app: AppHandle, subtitle: Option<String>, title: Option<String>) {
     let app_main = app.clone();
     let _ = app.run_on_main_thread(move || {
-        if let Err(e) = open_meeting_end_prompt_window(&app_main, subtitle.as_deref()) {
+        if let Err(e) =
+            open_meeting_end_prompt_window(&app_main, subtitle.as_deref(), title.as_deref())
+        {
             eprintln!("meeting-end-prompt: failed to open prompt window: {e}");
         }
     });
@@ -1380,7 +1394,7 @@ mod tests {
     #[test]
     fn meeting_end_prompt_url_carries_the_seconds() {
         assert_eq!(
-            super::meeting_end_prompt_url(30, None),
+            super::meeting_end_prompt_url(30, None, None),
             "/#/meeting-end-prompt?seconds=30"
         );
     }
@@ -1388,13 +1402,28 @@ mod tests {
     #[test]
     fn meeting_end_prompt_url_encodes_the_subtitle_and_omits_when_empty() {
         assert_eq!(
-            super::meeting_end_prompt_url(30, Some("Q3 Plan & Review")),
+            super::meeting_end_prompt_url(30, Some("Q3 Plan & Review"), None),
             "/#/meeting-end-prompt?seconds=30&subtitle=Q3+Plan+%26+Review"
         );
         assert_eq!(
-            super::meeting_end_prompt_url(30, Some("")),
+            super::meeting_end_prompt_url(30, Some(""), None),
             "/#/meeting-end-prompt?seconds=30"
         );
-        assert_eq!(super::meeting_end_prompt_url(30, None), "/#/meeting-end-prompt?seconds=30");
+        assert_eq!(
+            super::meeting_end_prompt_url(30, None, None),
+            "/#/meeting-end-prompt?seconds=30"
+        );
+    }
+
+    #[test]
+    fn meeting_end_prompt_url_encodes_the_title_and_omits_when_empty() {
+        assert_eq!(
+            super::meeting_end_prompt_url(30, Some("Standup"), Some("Next meeting started")),
+            "/#/meeting-end-prompt?seconds=30&subtitle=Standup&title=Next+meeting+started"
+        );
+        assert_eq!(
+            super::meeting_end_prompt_url(30, None, Some("")),
+            "/#/meeting-end-prompt?seconds=30"
+        );
     }
 }

--- a/src-tauri/src/transcribe.rs
+++ b/src-tauri/src/transcribe.rs
@@ -1484,6 +1484,7 @@ mod tests {
             duration_seconds: 60, status: RecordingStatus::Done, language: None,
             participants: vec![], model_version: None, error: None, notes_error: None,
             last_clip_end_at: None, audio_file: None, notes_written: None,
+            title_is_default: false,
         };
         storage::write_meta(&dir, &meta).unwrap();
 

--- a/src/composables/meetingEndWatch.test.ts
+++ b/src/composables/meetingEndWatch.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   shouldPromptMeetingEnd,
   findMeetingEndAt,
+  findNextMeetingStart,
   MEETING_END_GRACE_MS,
   MEETING_END_REPROMPT_MS,
 } from './meetingEndWatch';
@@ -44,6 +45,85 @@ describe('shouldPromptMeetingEnd', () => {
     expect(
       shouldPromptMeetingEnd(END, firstAt + 10 * MEETING_END_REPROMPT_MS, false, 2, firstAt),
     ).toBe(false);
+  });
+});
+
+describe('shouldPromptMeetingEnd with a next meeting start', () => {
+  // Back-to-back: next meeting starts exactly when the current one ends.
+  const NEXT = END;
+
+  it('prompts the moment the next meeting starts, without waiting for grace', () => {
+    expect(shouldPromptMeetingEnd(END, NEXT, false, 0, null, NEXT)).toBe(true);
+  });
+
+  it('prompts at the next start even before the current meeting has ended (overlap)', () => {
+    const overlapStart = END - 60_000; // next meeting begins 1 min before current end
+    expect(shouldPromptMeetingEnd(END, overlapStart, false, 0, null, overlapStart)).toBe(true);
+  });
+
+  it('does not prompt before the next meeting starts (nor before end + grace)', () => {
+    expect(shouldPromptMeetingEnd(END, NEXT - 1, false, 0, null, NEXT)).toBe(false);
+  });
+
+  it('prompts at the next start when the current meeting has no scheduled end', () => {
+    expect(shouldPromptMeetingEnd(null, NEXT, false, 0, null, NEXT)).toBe(true);
+  });
+
+  it('never prompts while paused, even when the next meeting has started', () => {
+    expect(shouldPromptMeetingEnd(END, NEXT, true, 0, null, NEXT)).toBe(false);
+  });
+
+  it('never prompts past the max, even when the next meeting has started', () => {
+    expect(shouldPromptMeetingEnd(END, NEXT + MEETING_END_REPROMPT_MS, false, 2, NEXT, NEXT)).toBe(
+      false,
+    );
+  });
+
+  it('still fires the grace-based prompt when the next start is later', () => {
+    const lateNext = END + 60 * 60_000;
+    expect(
+      shouldPromptMeetingEnd(END, END + MEETING_END_GRACE_MS, false, 0, null, lateNext),
+    ).toBe(true);
+  });
+});
+
+describe('findNextMeetingStart', () => {
+  const meetings = [
+    { id: 1, start_at: '2026-06-28T09:00:00.000Z', end_at: '2026-06-28T10:00:00.000Z', title: 'Standup' },
+    { id: 2, start_at: '2026-06-28T09:00:00.000Z', title: 'Parallel' }, // same start as 1
+    { id: 3, start_at: '2026-06-28T10:00:00.000Z', title: 'Next' },
+    { id: 4, start_at: '2026-06-28T11:00:00.000Z', title: 'Later' },
+    { id: 5, start_at: '2026-06-28T08:00:00.000Z', title: 'Earlier' },
+    { id: 6, start_at: 'not-a-date', title: 'Bad' },
+  ];
+
+  it('returns the earliest meeting starting strictly after the attached one', () => {
+    expect(findNextMeetingStart(meetings, 1)).toEqual({
+      startAt: Date.parse('2026-06-28T10:00:00.000Z'),
+      title: 'Next',
+    });
+  });
+
+  it('ignores meetings starting at the same time (parallel, not back-to-back)', () => {
+    expect(findNextMeetingStart([meetings[0], meetings[1]], 1)).toEqual({
+      startAt: null,
+      title: null,
+    });
+  });
+
+  it('ignores earlier meetings and unparseable starts', () => {
+    expect(findNextMeetingStart([meetings[0], meetings[4], meetings[5]], 1)).toEqual({
+      startAt: null,
+      title: null,
+    });
+  });
+
+  it('returns nulls when the attached meeting is absent from the list', () => {
+    expect(findNextMeetingStart(meetings, 99)).toEqual({ startAt: null, title: null });
+  });
+
+  it('returns nulls when the attached meeting has no parseable start', () => {
+    expect(findNextMeetingStart(meetings, 6)).toEqual({ startAt: null, title: null });
   });
 });
 

--- a/src/composables/meetingEndWatch.ts
+++ b/src/composables/meetingEndWatch.ts
@@ -1,8 +1,8 @@
 /**
  * Meeting-end stop prompt: when a recording attached to a calendar meeting runs
- * past that meeting's scheduled end, prompt the user to keep or stop instead of
- * silently bleeding into the next back-to-back call. Pure for unit testing;
- * mirrors silenceWatch.ts.
+ * past that meeting's scheduled end — or the next calendar meeting has already
+ * started — prompt the user to keep or stop instead of silently bleeding into
+ * the next back-to-back call. Pure for unit testing; mirrors silenceWatch.ts.
  */
 
 /** Grace after the scheduled end before the first prompt. */
@@ -17,9 +17,13 @@ export const MEETING_END_MAX_PROMPTS = 2;
 
 /**
  * Whether the meeting-end prompt should be shown on this tick. Frozen while
- * paused, disabled when there's no scheduled end (`endAt === null`), and capped
- * at MEETING_END_MAX_PROMPTS. The first prompt fires at `endAt + grace`; the
- * second only after `lastPromptAt + reprompt`.
+ * paused, disabled when there's neither a scheduled end (`endAt === null`) nor
+ * a known next-meeting start (`nextStartAt === null`), and capped at
+ * MEETING_END_MAX_PROMPTS. The first prompt fires at `endAt + grace` OR the
+ * moment the next calendar meeting starts, whichever comes first — the next
+ * meeting's start is the transition point, so back-to-back (and slightly
+ * overlapping) meetings prompt without waiting out the grace. The second
+ * prompt only after `lastPromptAt + reprompt`.
  */
 export function shouldPromptMeetingEnd(
   endAt: number | null,
@@ -27,10 +31,16 @@ export function shouldPromptMeetingEnd(
   paused: boolean,
   promptsShown: number,
   lastPromptAt: number | null,
+  nextStartAt: number | null = null,
 ): boolean {
-  if (paused || endAt === null) return false;
+  if (paused || (endAt === null && nextStartAt === null)) return false;
   if (promptsShown >= MEETING_END_MAX_PROMPTS) return false;
-  if (promptsShown === 0) return now >= endAt + MEETING_END_GRACE_MS;
+  if (promptsShown === 0) {
+    return (
+      (endAt !== null && now >= endAt + MEETING_END_GRACE_MS) ||
+      (nextStartAt !== null && now >= nextStartAt)
+    );
+  }
   return lastPromptAt !== null && now >= lastPromptAt + MEETING_END_REPROMPT_MS;
 }
 
@@ -55,4 +65,35 @@ export function findMeetingEndAt(
   if (!m.end_at) return { endAt: null, title: m.title ?? null };
   const ms = new Date(m.end_at).getTime();
   return { endAt: Number.isFinite(ms) ? ms : null, title: m.title ?? null };
+}
+
+export interface NextMeetingInfo {
+  /** Next meeting's scheduled start as epoch ms, or null when there is none. */
+  startAt: number | null;
+  /** Next meeting's title (for the prompt copy), or null. */
+  title: string | null;
+}
+
+/**
+ * The earliest meeting starting strictly AFTER the attached meeting's start —
+ * the transition point for back-to-back and slightly overlapping calls.
+ * Meetings sharing the attached start are parallel, not "next", so they're
+ * skipped. Returns nulls when the attached meeting is missing or has no
+ * parseable start (the watch then degrades to the end-time trigger alone).
+ */
+export function findNextMeetingStart(
+  meetings: ReadonlyArray<{ id: number; start_at?: string | null; title: string | null }>,
+  meetingId: number,
+): NextMeetingInfo {
+  const current = meetings.find((x) => x.id === meetingId);
+  const currentStart = current?.start_at ? new Date(current.start_at).getTime() : NaN;
+  if (!Number.isFinite(currentStart)) return { startAt: null, title: null };
+  let next: NextMeetingInfo = { startAt: null, title: null };
+  for (const m of meetings) {
+    if (m.id === meetingId || !m.start_at) continue;
+    const ms = new Date(m.start_at).getTime();
+    if (!Number.isFinite(ms) || ms <= currentStart) continue;
+    if (next.startAt === null || ms < next.startAt) next = { startAt: ms, title: m.title ?? null };
+  }
+  return next;
 }

--- a/src/views/MeetingEndPromptView.test.ts
+++ b/src/views/MeetingEndPromptView.test.ts
@@ -21,9 +21,18 @@ beforeEach(() => {
 });
 
 describe('MeetingEndPromptView', () => {
-  it('renders the fixed title and the meeting subtitle', () => {
+  it('renders the default title and the meeting subtitle', () => {
     const wrapper = mount(MeetingEndPromptView);
     expect(wrapper.text()).toContain('Meeting ended');
+    expect(wrapper.find('[data-test="subtitle"]').text()).toBe('Weekly sync');
+  });
+
+  it('renders the title param so the card can say the next meeting started', () => {
+    window.location.hash =
+      '#/meeting-end-prompt?seconds=30&title=Next%20meeting%20started&subtitle=Weekly%20sync';
+    const wrapper = mount(MeetingEndPromptView);
+    expect(wrapper.text()).toContain('Next meeting started');
+    expect(wrapper.text()).not.toContain('Meeting ended');
     expect(wrapper.find('[data-test="subtitle"]').text()).toBe('Weekly sync');
   });
 

--- a/src/views/MeetingEndPromptView.vue
+++ b/src/views/MeetingEndPromptView.vue
@@ -7,11 +7,11 @@ import { parseMeetingEndPromptParams } from './meetingPromptParams';
 import oatsLogo from '../assets/oats-light.svg';
 
 // Read params straight from the URL (no router dependency, so the view mounts
-// bare in tests). Opened by Rust with `?seconds=<countdown>&subtitle=`.
+// bare in tests). Opened by Rust with `?seconds=<countdown>&subtitle=&title=`.
 const search = window.location.hash.includes('?')
   ? window.location.hash.slice(window.location.hash.indexOf('?'))
   : '';
-const { seconds, subtitle } = parseMeetingEndPromptParams(search);
+const { seconds, subtitle, title } = parseMeetingEndPromptParams(search);
 
 const menuOpen = ref(false);
 const splitEl = ref<HTMLElement | null>(null);
@@ -58,7 +58,7 @@ async function resolve(stop: boolean) {
       <div class="row">
         <img :src="oatsLogo" alt="oats" class="logo" />
         <div class="copy">
-          <div class="title">Meeting ended</div>
+          <div class="title">{{ title }}</div>
           <div v-if="subtitle" data-test="subtitle" class="subtitle">{{ subtitle }}</div>
         </div>
 

--- a/src/views/WaveformView.vue
+++ b/src/views/WaveformView.vue
@@ -115,6 +115,8 @@ import { shouldPromptSilence, shouldAutoStopAfterPrompt } from '../composables/s
 import {
   shouldPromptMeetingEnd,
   findMeetingEndAt,
+  findNextMeetingStart,
+  MEETING_END_GRACE_MS,
   MEETING_END_PROMPT_TIMEOUT_MS,
 } from '../composables/meetingEndWatch';
 import { localRecordingIdFromStart } from '../composables/localRecordingId';
@@ -325,6 +327,11 @@ let meetingEndTimer: ReturnType<typeof setInterval> | null = null;
 // card subtitle.
 const meetingEndAt = ref<number | null>(null);
 const meetingEndSubtitle = ref<string | undefined>(undefined);
+// Scheduled start of the NEXT calendar meeting (epoch ms), or null when there
+// is none. The next meeting's start is the transition point: it triggers the
+// prompt immediately, so back-to-back (or slightly overlapping) meetings don't
+// bleed through the end+grace wait.
+const meetingNextStartAt = ref<number | null>(null);
 let meetingEndPromptShownAt: number | null = null;
 let meetingEndPromptsShown = 0;
 let meetingEndLastPromptAt: number | null = null;
@@ -514,13 +521,15 @@ async function resolveSilenceSubtitle(): Promise<string | undefined> {
   }
 }
 
-// Resolve the attached meeting's scheduled end (Ariso only). end_at lives on the
-// scheduled-meetings list, NOT /desktop/meetings/{id}, so fetch the ±2h window
-// and match by id. Any failure leaves meetingEndAt null → the watch stays off.
+// Resolve the attached meeting's scheduled end and the next meeting's start
+// (Ariso only). end_at lives on the scheduled-meetings list, NOT
+// /desktop/meetings/{id}, so fetch the ±2h window and match by id. Any failure
+// leaves both null → the watch stays off.
 async function resolveMeetingEnd() {
   if (!meetingEndReminderEnabled || backend.value?.id !== 'ariso' || effectiveMeetingId.value === null) {
     meetingEndAt.value = null;
     meetingEndSubtitle.value = undefined;
+    meetingNextStartAt.value = null;
     return;
   }
   try {
@@ -531,9 +540,11 @@ async function resolveMeetingEnd() {
     const info = findMeetingEndAt(meetings, effectiveMeetingId.value);
     meetingEndAt.value = info.endAt;
     meetingEndSubtitle.value = info.title ?? undefined;
+    meetingNextStartAt.value = findNextMeetingStart(meetings, effectiveMeetingId.value).startAt;
   } catch (e) {
     console.error('Failed to resolve meeting end; meeting-end watch disabled', e);
     meetingEndAt.value = null;
+    meetingNextStartAt.value = null;
   }
 }
 
@@ -750,8 +761,9 @@ onMounted(async () => {
   // watcher covers the async auto path). No-op when the reminder is disabled.
   void resolveMeetingEnd();
 
-  // Meeting-stop reminder: prompts when the attached meeting's scheduled end has
-  // passed; ignoring it keeps recording.
+  // Meeting-stop reminder: prompts when the attached meeting's scheduled end
+  // has passed, or immediately when the next calendar meeting starts (the
+  // transition point for back-to-back calls); ignoring it keeps recording.
   if (meetingEndReminderEnabled) {
     meetingEndTimer = setInterval(() => {
       if (isUploading.value || uploadResult.value || !recorder.isRecording.value) return;
@@ -764,15 +776,23 @@ onMounted(async () => {
             recorder.isPaused.value,
             meetingEndPromptsShown,
             meetingEndLastPromptAt,
+            meetingNextStartAt.value,
           )
         ) {
           meetingEndPromptShownAt = now;
           meetingEndLastPromptAt = now;
           meetingEndPromptsShown += 1;
-          void invoke(
-            'show_meeting_end_prompt',
-            meetingEndSubtitle.value ? { subtitle: meetingEndSubtitle.value } : {},
-          );
+          // Title says why the card appeared; subtitle names the meeting being
+          // ended. "Next meeting started" exactly when the end+grace rule alone
+          // wouldn't have fired yet — i.e. the next meeting is the trigger.
+          const nextStarted =
+            meetingNextStartAt.value !== null &&
+            now >= meetingNextStartAt.value &&
+            (meetingEndAt.value === null || now < meetingEndAt.value + MEETING_END_GRACE_MS);
+          void invoke('show_meeting_end_prompt', {
+            ...(meetingEndSubtitle.value ? { subtitle: meetingEndSubtitle.value } : {}),
+            ...(nextStarted ? { title: 'Next meeting started' } : {}),
+          });
         }
         return;
       }

--- a/src/views/meetingPromptParams.test.ts
+++ b/src/views/meetingPromptParams.test.ts
@@ -53,15 +53,26 @@ describe('parseMeetingEndPromptParams', () => {
     expect(parseMeetingEndPromptParams('?seconds=30&subtitle=Weekly%20sync')).toEqual({
       seconds: 30,
       subtitle: 'Weekly sync',
+      title: 'Meeting ended',
     });
   });
 
-  it('defaults seconds to 30 and subtitle to empty when absent', () => {
-    expect(parseMeetingEndPromptParams('')).toEqual({ seconds: 30, subtitle: '' });
+  it('defaults seconds to 30, subtitle to empty, and title to "Meeting ended"', () => {
+    expect(parseMeetingEndPromptParams('')).toEqual({
+      seconds: 30,
+      subtitle: '',
+      title: 'Meeting ended',
+    });
   });
 
   it('falls back to 30 when seconds is non-positive or NaN', () => {
     expect(parseMeetingEndPromptParams('?seconds=0').seconds).toBe(30);
     expect(parseMeetingEndPromptParams('?seconds=abc').seconds).toBe(30);
+  });
+
+  it('reads the title so the card can say why it appeared (next meeting started)', () => {
+    expect(
+      parseMeetingEndPromptParams('?seconds=30&title=Next%20meeting%20started').title,
+    ).toBe('Next meeting started');
   });
 });

--- a/src/views/meetingPromptParams.ts
+++ b/src/views/meetingPromptParams.ts
@@ -45,16 +45,28 @@ export function parseSilencePromptParams(search: string): SilencePromptParams {
 
 /** Cosmetic countdown for the meeting-end prompt; mirrors the FE timeout. */
 const MEETING_END_DEFAULT_SECONDS = 30;
+/** Default card title; overridden (e.g. "Next meeting started") to say why. */
+const MEETING_END_DEFAULT_TITLE = 'Meeting ended';
+
+export interface MeetingEndPromptParams extends SilencePromptParams {
+  /** Why the card appeared — "Meeting ended" unless the trigger says otherwise. */
+  title: string;
+}
 
 /**
  * Params for the meeting-end stop prompt window. Same shape as the silence
- * prompt (fixed title in the view; subtitle blank when absent), but a 30s
- * default countdown.
+ * prompt (subtitle blank when absent) plus a title that defaults to
+ * "Meeting ended" — the next-meeting-start trigger overrides it so the card
+ * says why it appeared — and a 30s default countdown.
  */
-export function parseMeetingEndPromptParams(search: string): SilencePromptParams {
+export function parseMeetingEndPromptParams(search: string): MeetingEndPromptParams {
   const params = new URLSearchParams(search.startsWith('?') ? search.slice(1) : search);
   const rawSeconds = Number(params.get('seconds'));
   const seconds =
     Number.isFinite(rawSeconds) && rawSeconds > 0 ? rawSeconds : MEETING_END_DEFAULT_SECONDS;
-  return { seconds, subtitle: params.get('subtitle') || '' };
+  return {
+    seconds,
+    subtitle: params.get('subtitle') || '',
+    title: params.get('title') || MEETING_END_DEFAULT_TITLE,
+  };
 }


### PR DESCRIPTION
## Summary

Fixes #230.

The meeting-end stop prompt previously fired only at the attached meeting's scheduled end + 2 min grace. Back-to-back meetings therefore bled ~2 minutes into the next call, and slightly overlapping meetings didn't prompt at all until the current meeting's end had passed.

This PR makes the **next calendar meeting's start** the transition point:

- `findNextMeetingStart()` (new pure helper in `meetingEndWatch.ts`) resolves the earliest meeting starting strictly after the attached one, from the same scheduled-meetings fetch `resolveMeetingEnd()` already does. Meetings sharing the same start are parallel, not "next", and are skipped.
- `shouldPromptMeetingEnd()` now fires the first prompt at `end_at + grace` **or** the moment the next meeting starts, whichever comes first — including when the current meeting has no `end_at`. Reprompt, pause, and max-prompt semantics are unchanged.
- The prompt card gains a `title` param (plumbed through `show_meeting_end_prompt` → `meeting_end_prompt_url` → `MeetingEndPromptView`) so it reads **"Next meeting started"** when the next meeting is the trigger, with the ending meeting's name as the subtitle — signaling which meeting is ending and why the prompt appeared.

Also includes a one-line pre-existing fix: `cargo test` stopped compiling on main because the `RecordingMeta` initializer in `transcribe.rs` tests was missed when `title_is_default` was added in #208.

## Acceptance criteria

- New meeting start = transition point ✅ (`nextStartAt` trigger)
- Prompt when the next meeting begins while still recording ✅ (immediate, no grace)
- Back-to-back with no gap ✅ (fires at the shared boundary)
- Consistent for adjacent and slightly overlapping meetings ✅ (fires at next start even before current `end_at`)
- Signals which meeting is ending and why ✅ (title + subtitle)

## Testing

- `meetingEndWatch`, `meetingPromptParams`, `MeetingEndPromptView`, `WaveformView` Vitest files: 76/76 pass
- Full Rust suite (DYLD workaround, `--test-threads=1`): 239 passed
- `vite:build` succeeds
- Pre-existing LibraryView/UpdateView Vitest failures reproduce identically without this change (verified via stash) and are unrelated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Meeting-end reminders now account for the start of the next calendar meeting, including back-to-back and overlapping meetings.
  * Prompts can display a customized title, such as “Next meeting started,” while retaining meeting details.
  * Meeting-end prompt links support optional custom titles and subtitles.

* **Bug Fixes**
  * Improved reminder behavior when meeting end times are unavailable or the next meeting starts first.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->