### PR TITLE
ci: show autofix:working label on PR during apply-fixes run

### DIFF
--- a/.github/workflows/apply-fixes.yml
+++ b/.github/workflows/apply-fixes.yml
@@ -16,9 +16,8 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: apply-review-fixes-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
-
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
 env:
   CODERABBIT_BOT_LOGIN: "coderabbitai[bot]"
   HUMAN_REVIEWERS: "shawnzhu"

--- a/.github/workflows/apply-fixes.yml
+++ b/.github/workflows/apply-fixes.yml
@@ -56,6 +56,20 @@ jobs:
       HEAD_REF: ${{ github.event.pull_request.head.ref }}
       BASE_REF: ${{ github.event.pull_request.base.ref }}
     steps:
+      # Show an at-a-glance status on the PR while the run is in flight.
+      # Added before checkout so it's visible even if a later step fails;
+      # the final always() step below removes it. Best-effort — a labeling
+      # hiccup must not abort the actual autofix.
+      - name: Mark PR autofix:working
+        run: |
+          gh label create "autofix:working" \
+            --repo "$REPO" \
+            --color FBCA04 \
+            --description "Autofix workflow is applying review fixes" \
+            2>/dev/null || true
+          gh pr edit "$PR" --repo "$REPO" --add-label "autofix:working" \
+            || echo "::warning::could not add autofix:working label"
+
       - name: Checkout PR head
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
@@ -233,3 +247,12 @@ jobs:
       - name: Cleanup
         if: always()
         run: rm -f /tmp/commit-message.txt /tmp/thread-replies.json /tmp/claude-output.json
+
+      # Clear the in-flight status label whatever the outcome (success,
+      # no-op, failure, or cancellation). Best-effort so cleanup never
+      # fails the run.
+      - name: Remove autofix:working label
+        if: always()
+        run: |
+          gh pr edit "$PR" --repo "$REPO" --remove-label "autofix:working" \
+            2>/dev/null || true

--- a/.github/workflows/apply-fixes.yml
+++ b/.github/workflows/apply-fixes.yml
@@ -12,6 +12,7 @@ on:
     types: [submitted]
 
 permissions:
+  issues: write
   contents: write
   pull-requests: write
 


### PR DESCRIPTION
Add an `autofix:working` label to the PR at the start of the apply-fixes workflow so its status is visible while running, and remove it in a final always() step regardless of outcome (success, no-op, failure, or cancel).

Both label operations are best-effort so a labeling hiccup never aborts or fails the actual autofix run. The add step runs before checkout so the label appears immediately and stays visible even if a later step fails.

<!--
Thanks for contributing to oats! A few quick things before you open this PR.
See CONTRIBUTING.md for the full guide.
-->

## What does this PR do?

auto labeling a PR under autofix

## Type of change

<!-- Releases are automated by release-please from your commit messages. -->
<!-- Make sure your PR title / commits follow Conventional Commits: -->
<!--   feat: ...        → minor bump        fix: ...   → patch bump -->
<!--   feat!: / BREAKING CHANGE: → major bump   chore/docs/refactor: → no release -->

- [ ] `fix:` — bug fix
- [x] `feat:` — new feature
- [ ] `feat!:` / `BREAKING CHANGE:` — breaking change
- [ ] `docs:` / `chore:` / `refactor:` — no user-facing release

## How was this tested?

<!-- Did you run the frontend tests (`npm test`)? Test manually with which backend (Ariso / Local)? On which OS/platform? -->

## Screenshots / recordings

<!-- For any UI change, drop a before/after screenshot or short clip here. -->

## Checklist

- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I ran `npm test` and the suite passes
- [ ] I tested the change in the app (note which backend above)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a temporary status label indicating automated fixes are actively running.
  * The label is now best-effort applied at job start and reliably cleaned up at the end (including on failure or cancellation).

* **Bug Fixes**
  * Improved automation stability by adjusting concurrency behavior to prevent cancelling in-progress runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->