### PR TITLE
feat: play button for buffered recordings in Pending Uploads

### DIFF
--- a/src/views/PendingUploads.test.ts
+++ b/src/views/PendingUploads.test.ts
@@ -3,13 +3,17 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { mount, flushPromises } from '@vue/test-utils';
 
 const list = vi.fn();
+const combine = vi.fn();
 const checkSession = vi.fn();
 const combineAndUpload = vi.fn();
 const discardAll = vi.fn();
 
 vi.mock('../tauri', () => ({
   auth: { checkSession: (...a: unknown[]) => checkSession(...a) },
-  pending: { list: (...a: unknown[]) => list(...a) },
+  pending: {
+    list: (...a: unknown[]) => list(...a),
+    combine: (...a: unknown[]) => combine(...a),
+  },
 }));
 vi.mock('../composables/usePendingUploads', () => ({
   combineAndUpload: (...a: unknown[]) => combineAndUpload(...a),
@@ -17,6 +21,7 @@ vi.mock('../composables/usePendingUploads', () => ({
 }));
 
 import PendingUploads from './PendingUploads.vue';
+import RecordingAudioPlayer from './RecordingAudioPlayer.vue';
 
 const items = [
   { createdAt: '2026-06-12T09:00:00Z', startAt: '2026-06-12T09:00:00Z', endAt: '2026-06-12T09:05:00Z', durationSeconds: 300 },
@@ -44,6 +49,29 @@ describe('PendingUploads', () => {
     expect(wrapper.findAll('.pending-item')).toHaveLength(2);
     expect(wrapper.findAll('.pi-wave')).toHaveLength(2);
     expect(wrapper.find('.upload').text()).toContain('Upload (2)');
+  });
+
+  it('renders a play control for each buffered recording', async () => {
+    list.mockResolvedValue(items);
+    const wrapper = mount(PendingUploads);
+    await flushPromises();
+    expect(wrapper.findAllComponents(RecordingAudioPlayer)).toHaveLength(2);
+    // Each control says it plays the local buffered copy, not the cloud version.
+    expect(wrapper.find('.pi-play').attributes('title')).toContain('on this Mac');
+  });
+
+  it('play loads only that recording\'s buffered audio', async () => {
+    list.mockResolvedValue(items);
+    const buf = new ArrayBuffer(4);
+    combine.mockResolvedValue(buf);
+    const wrapper = mount(PendingUploads);
+    await flushPromises();
+
+    const players = wrapper.findAllComponents(RecordingAudioPlayer);
+    const loaded = await players[1].props('load')();
+
+    expect(combine).toHaveBeenCalledWith(['2026-06-12T11:00:00Z']);
+    expect(loaded).toBe(buf);
   });
 
   it('Upload combines+uploads, refreshes, and emits uploaded on success', async () => {

--- a/src/views/PendingUploads.test.ts
+++ b/src/views/PendingUploads.test.ts
@@ -56,8 +56,9 @@ describe('PendingUploads', () => {
     const wrapper = mount(PendingUploads);
     await flushPromises();
     expect(wrapper.findAllComponents(RecordingAudioPlayer)).toHaveLength(2);
-    // Each control says it plays the local buffered copy, not the cloud version.
-    expect(wrapper.find('.pi-play').attributes('title')).toContain('on this Mac');
+    // Each control says it plays the local buffered copy, not the cloud
+    // version — on the focusable button itself so keyboard/AT users get it.
+    expect(wrapper.find('.pi-play .play-btn').attributes('title')).toContain('on this Mac');
   });
 
   it('play loads only that recording\'s buffered audio', async () => {

--- a/src/views/PendingUploads.vue
+++ b/src/views/PendingUploads.vue
@@ -7,6 +7,9 @@
         <span class="pi-wave" aria-hidden="true" />
         <span class="pi-title">{{ titleFor(it) }}</span>
         <span class="pi-dur">{{ durationFor(it) }}</span>
+        <span class="pi-play" title="Plays the recording buffered on this Mac, not an uploaded copy">
+          <RecordingAudioPlayer :load="() => loadAudio(it)" />
+        </span>
       </div>
       <!-- Leaving the actions row cancels a pending discard confirmation so the
            destructive second click can't linger armed after the user moves away. -->
@@ -28,6 +31,7 @@
 import { ref, onMounted } from 'vue';
 import { auth, pending, type PendingUploadMeta } from '../tauri';
 import { combineAndUpload, discardAll } from '../composables/usePendingUploads';
+import RecordingAudioPlayer from './RecordingAudioPlayer.vue';
 
 const emit = defineEmits<{ uploaded: [] }>();
 
@@ -66,6 +70,12 @@ function durationFor(it: PendingUploadMeta): string {
   const mins = Math.floor(it.durationSeconds / 60).toString().padStart(2, '0');
   const secs = (it.durationSeconds % 60).toString().padStart(2, '0');
   return `${mins}:${secs}`;
+}
+
+// Reuses the combine command with a single key to read one buffer's mp3 bytes,
+// so playback exercises the exact bytes an upload retry would send.
+function loadAudio(it: PendingUploadMeta): Promise<ArrayBuffer> {
+  return pending.combine([it.createdAt]);
 }
 
 // Retry is only useful when desktop has an Ari session to attach to the upload
@@ -182,6 +192,24 @@ onMounted(refresh);
   font-size: 13px;
   font-weight: 600;
   font-variant-numeric: tabular-nums;
+}
+.pi-play {
+  display: flex;
+  align-items: center;
+  min-width: 0;
+}
+/* Once playing, cap the native controls so they share the row with the title
+   instead of the <audio> element's intrinsic ~300px width overflowing it. */
+.pi-play :deep(.audio-el) {
+  width: 150px;
+  min-width: 0;
+  flex: 0 1 auto;
+}
+/* The expanded player has its own timeline; drop the redundant wave glyph and
+   duration so the title isn't squeezed to nothing in the narrow sidebar row. */
+.pending-item:has(.audio-el) .pi-wave,
+.pending-item:has(.audio-el) .pi-dur {
+  display: none;
 }
 .pending-error {
   margin: 0 10px;

--- a/src/views/PendingUploads.vue
+++ b/src/views/PendingUploads.vue
@@ -7,8 +7,11 @@
         <span class="pi-wave" aria-hidden="true" />
         <span class="pi-title">{{ titleFor(it) }}</span>
         <span class="pi-dur">{{ durationFor(it) }}</span>
-        <span class="pi-play" title="Plays the recording buffered on this Mac, not an uploaded copy">
-          <RecordingAudioPlayer :load="() => loadAudio(it)" />
+        <span class="pi-play">
+          <RecordingAudioPlayer
+            :load="() => loadAudio(it)"
+            title="Plays the recording buffered on this Mac, not an uploaded copy"
+          />
         </span>
       </div>
       <!-- Leaving the actions row cancels a pending discard confirmation so the

--- a/src/views/RecordingAudioPlayer.test.ts
+++ b/src/views/RecordingAudioPlayer.test.ts
@@ -25,6 +25,22 @@ describe('RecordingAudioPlayer', () => {
     expect(wrapper.find('audio').attributes('src')).toBe('blob:test');
   });
 
+  it('describes via title without overriding the accessible state name', async () => {
+    const load = vi.fn().mockResolvedValue(new ArrayBuffer(4));
+    const wrapper = mount(RecordingAudioPlayer, { props: { load, title: 'Plays the local copy' } });
+
+    // The title supplements the visible label ("▶ Play" / "Failed" / …) as the
+    // accessible description; aria-label would replace that state name entirely.
+    const btn = wrapper.find('button.play-btn');
+    expect(btn.attributes('title')).toBe('Plays the local copy');
+    expect(btn.attributes('aria-label')).toBeUndefined();
+    expect(btn.text()).toContain('Play');
+
+    await btn.trigger('click');
+    await flushPromises();
+    expect(wrapper.find('audio').attributes('title')).toBe('Plays the local copy');
+  });
+
   it('shows a disabled "No audio" state when load resolves null', async () => {
     const load = vi.fn().mockResolvedValue(null);
     const wrapper = mount(RecordingAudioPlayer, { props: { load } });

--- a/src/views/RecordingAudioPlayer.vue
+++ b/src/views/RecordingAudioPlayer.vue
@@ -13,7 +13,6 @@
     :class="{ 'play-btn--error': errored }"
     :disabled="noAudio || loading"
     :title="title"
-    :aria-label="title"
     @click="onPlay"
   >
     <span v-if="noAudio">▶ No audio</span>

--- a/src/views/RecordingAudioPlayer.vue
+++ b/src/views/RecordingAudioPlayer.vue
@@ -4,6 +4,7 @@
     ref="audioEl"
     class="audio-el"
     :src="blobUrl"
+    :title="title"
     controls
   ></audio>
   <button
@@ -11,6 +12,8 @@
     class="play-btn"
     :class="{ 'play-btn--error': errored }"
     :disabled="noAudio || loading"
+    :title="title"
+    :aria-label="title"
     @click="onPlay"
   >
     <span v-if="noAudio">▶ No audio</span>
@@ -27,7 +30,10 @@ import { ref, onBeforeUnmount, nextTick } from 'vue';
 // or null when no audio exists (e.g. the server 404s). Local recordings pass
 // read_recording_audio; Ariso meetings pass the authenticated
 // /meeting-notes/{id}/audio fetch.
-const props = defineProps<{ load: () => Promise<ArrayBuffer | null> }>();
+const props = defineProps<{
+  load: () => Promise<ArrayBuffer | null>;
+  title?: string;
+}>();
 
 const blobUrl = ref<string | null>(null);
 const loading = ref(false);


### PR DESCRIPTION

<img width="900" height="599" alt="Screenshot 2026-07-18 at 00 17 00" src="https://github.com/user-attachments/assets/2a388897-cd69-424b-a5a3-ee89c685337e" />

Closes #229.

Each buffered recording in the Pending Uploads section now has a Play button so users can listen to the local copy before upload or after a failed one.

- Reuses `RecordingAudioPlayer` per pending row; audio loads via the existing `combine_pending_audio` command with that item's single key, so playback exercises the exact bytes an upload retry would send (no Rust changes).
- Tooltip clarifies playback is the recording buffered on this Mac, not an uploaded copy.
- While playing, the row hides the redundant wave glyph/duration so the title stays visible in the narrow sidebar.

Verified in the running app: seeded buffers play end-to-end; a missing buffer file shows a retryable "Failed" state without breaking other rows. Unit tests added (Vitest, 540/540 green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added inline playback controls for each pending recording.
  * Users can play the locally buffered audio copy before retrying an upload.
  * Playback loads the same buffered audio bytes used for the retry flow.
* **Tests**
  * Added coverage to verify playback controls render for buffered items and that loading triggers the correct buffered-combine behavior.
* **Accessibility**
  * Improved playback UI labeling by wiring dynamic titles into the audio/button and adding an accessible aria-label.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->