### PR TITLE
fix: preserve meeting id when resuming pending uploads

### DIFF
--- a/docs/superpowers/specs/2026-06-14-resumable-uploads-from-library-design.md
+++ b/docs/superpowers/specs/2026-06-14-resumable-uploads-from-library-design.md
@@ -3,6 +3,17 @@
 **Date:** 2026-06-14
 **Status:** Approved
 
+> **Amendment (2026-07-20) — preserve `meetingId` on resume.** The original
+> design concatenated *all* pending items into one new meeting and dropped every
+> `meetingId` (see the struck decisions below). That orphaned the pre-created
+> server meeting whenever a buffered item carried an id. Resume now **groups
+> pending items by `meetingId`**: items sharing an id combine and re-attach to
+> that meeting via `POST /desktop/meetings/:id/audio/presign`; items with no id
+> combine into one fresh meeting. Each group uploads independently — a group that
+> fails is left buffered for a later retry while the others upload and discard.
+> This changes the "one merged meeting / all-or-nothing" decisions in §Goals,
+> §Decisions, §Design step 4, and the error table; those are annotated inline.
+
 ## Problem
 
 When recording with the Ariso (cloud) backend and the network is down, stopping
@@ -26,8 +37,10 @@ appears done ("Recording saved") and there is no option to resume uploading.
    resumed after an app restart.
 2. Surface pending/failed uploads in the Library with a resume control that
    survives restart.
-3. When more than one upload is pending, **combine** them into a single
-   concatenated MP3 and upload once, producing one merged meeting.
+3. When more than one upload is pending, **combine** them per meeting (grouped
+   by `meetingId`) and upload each group — re-attaching to its existing meeting
+   when it has an id, else producing one fresh merged meeting.
+   *(2026-07-20 amendment; was "combine all into one merged meeting".)*
 
 ## Non-goals
 
@@ -42,9 +55,11 @@ appears done ("Recording saved") and there is no option to resume uploading.
 - **Durability:** survive app restart (persist a metadata sidecar; scan on demand).
 - **Backend in scope:** Ariso (cloud) only.
 - **Placement:** a pinned "Pending uploads" group at the top of the Library sidebar.
-- **Multiple pending → one merged meeting:** concatenate all pending audio
-  chronologically into a single MP3; the separate recordings do not survive as
-  individual meetings.
+- **Multiple pending → one merged meeting per meetingId** *(2026-07-20 amendment;
+  was "concatenate all pending audio into a single MP3 / one meeting").*
+  Group pending items by `meetingId`; each group concatenates chronologically
+  into one MP3 and uploads to its own meeting (existing id → re-attached; no id →
+  one fresh meeting). Recordings within a group do not survive individually.
 - **Trigger:** a single primary **`Upload (N)`** button (auto-combine, all-or-
   nothing). No per-item upload/retry.
 - **Discard:** a secondary **`Discard all`** button. No per-item discard in the
@@ -148,17 +163,28 @@ disk.
 Lives in a small composable (e.g. `usePendingUploads.ts`) so the Library view
 and tests share one implementation:
 
+*(2026-07-20 amendment: steps now run per `meetingId` group instead of over the
+whole list at once — see `groupByMeetingId` in `usePendingUploads.ts`.)*
+
 1. `items = await pending.list()` (already chronological).
-2. `keys = items.map(i => i.createdAt)`.
-3. `merged = { startAt: items[0].startAt ?? items[0].createdAt,
-   endAt: items.at(-1).endAt,
-   durationSeconds: sum(items.durationSeconds) }`. `meetingId` is omitted →
-   the upload creates one new meeting.
-4. `buf = await pending.combine(keys)` → `new Blob([buf], { type: 'audio/mpeg' })`.
-5. `await useMeetingApi().uploadAudio(blob, merged)` — reuses the existing
-   presign → PUT → confirm path unchanged.
-6. On success: `await Promise.all(keys.map(k => pending.discardAudio(k)))`,
-   then refresh the list. On failure: leave everything in place, surface an error.
+2. `groups = groupByMeetingId(items)` — partition by `meetingId ?? null`,
+   preserving order (items with no id form one group).
+3. For each `group`:
+   1. `keys = group.map(i => i.createdAt)`.
+   2. `merged = { startAt: group[0].startAt ?? group[0].createdAt,
+      endAt: group.at(-1).endAt,
+      durationSeconds: sum(group.durationSeconds),
+      ...(group[0].meetingId != null ? { meetingId: group[0].meetingId } : {}) }`.
+      A present `meetingId` re-attaches to that meeting; an absent one creates a
+      fresh meeting.
+   3. `buf = await pending.combine(keys)` → `new Blob([buf], { type: 'audio/mpeg' })`.
+   4. `await useMeetingApi().uploadAudio(blob, merged)` — reuses the existing
+      presign → PUT → confirm path unchanged.
+   5. On success: discard that group's keys. On failure: leave that group's
+      buffers in place.
+4. Groups upload independently; if any group failed, re-throw the first failure
+   so the caller surfaces an error. Refresh the list — succeeded groups drop off,
+   failed ones remain for a later retry.
 
 `Discard all`: snapshot `keys` from `list()`, then discard each.
 
@@ -197,11 +223,11 @@ state.
 | Upload fails (offline) | Pill shows ✗ + Retry/Dismiss; buffer + sidecar persist; item appears in Library's Pending uploads |
 | Combine: a key missing | Error surfaced as upload failure; nothing discarded |
 | Combine: total > `MAX_AUDIO_BYTES` | Error surfaced as upload failure; nothing discarded |
-| Resume upload fails | Items left in place; section shows error; user can try again |
-| Resume upload succeeds | Combined keys discarded; one new meeting created; list refreshed |
+| A meetingId group's upload fails | That group's buffers left in place; other groups still upload; section shows error; user can retry |
+| Resume upload succeeds (a group) | That group's keys discarded; its meeting created (no id) or re-attached (had id); list refreshed |
 | `Discard all` | All listed buffers + sidecars deleted (explicit discard) |
 | Orphan `.mp3` with no `.json` | Skipped by `list_pending_uploads`; left for manual recovery |
-| Pending item had a `meetingId` (rare) | Combined upload still creates a new meeting; the pre-created server meeting is left empty |
+| Pending item had a `meetingId` | *(2026-07-20 amendment)* Its group re-attaches to that meeting via `/desktop/meetings/:id/audio/presign` instead of orphaning it |
 
 ## Testing
 
@@ -216,8 +242,11 @@ state.
   upload, discards on success, leaves both on failure, and does not fail
   finalize when buffering itself fails.
 - **`usePendingUploads` / `PendingUploads.vue`:** section hidden when empty;
-  shows count and rows; `Upload (N)` combines (chronological keys), uploads with
-  merged meta (earliest start / latest end / summed duration), discards the
-  combined keys on success and leaves them on failure; `Discard all` clears.
+  shows count and rows; `Upload (N)` groups by `meetingId` and, per group,
+  combines (chronological keys) and uploads with merged meta (earliest start /
+  latest end / summed duration / the group's `meetingId` when present), discards
+  a group's keys on success and leaves them on failure; a failed group doesn't
+  block the others; `Discard all` clears. *(2026-07-20 amendment: `mergedMeta`
+  now carries `meetingId`; `groupByMeetingId` partitions items.)*
 - **Honest-status regression:** a finalize failure broadcasts `failed`, never
   `success` / "Recording saved".

--- a/src/composables/usePendingUploads.test.ts
+++ b/src/composables/usePendingUploads.test.ts
@@ -16,7 +16,7 @@ vi.mock('./useMeetingApi', () => ({
   useMeetingApi: () => ({ uploadAudio: (...a: unknown[]) => uploadAudio(...a) }),
 }));
 
-import { mergedMeta, combineAndUpload, discardAll } from './usePendingUploads';
+import { mergedMeta, groupByMeetingId, combineAndUpload, discardAll } from './usePendingUploads';
 
 const items = [
   { createdAt: '2026-06-12T09:00:00Z', startAt: '2026-06-12T09:00:00Z', endAt: '2026-06-12T09:05:00Z', durationSeconds: 300 },
@@ -35,6 +35,32 @@ describe('mergedMeta', () => {
   });
   it('falls back to createdAt when the first item has no startAt', () => {
     expect(mergedMeta([items[1]]).startAt).toBe('2026-06-12T11:00:00Z');
+  });
+  it('preserves the meetingId when the group carries one', () => {
+    expect(mergedMeta([{ ...items[0], meetingId: 7 }])).toEqual({
+      startAt: '2026-06-12T09:00:00Z',
+      endAt: '2026-06-12T09:05:00Z',
+      durationSeconds: 300,
+      meetingId: 7,
+    });
+  });
+  it('omits meetingId when no item in the group has one', () => {
+    expect(mergedMeta(items)).not.toHaveProperty('meetingId');
+  });
+});
+
+describe('groupByMeetingId', () => {
+  it('keeps items with no meetingId together as one group', () => {
+    expect(groupByMeetingId(items)).toEqual([items]);
+  });
+
+  it('splits items into one group per distinct meetingId, preserving order', () => {
+    const a = { ...items[0], createdAt: 'a', meetingId: 5 };
+    const b = { ...items[0], createdAt: 'b', meetingId: 5 };
+    const c = { ...items[0], createdAt: 'c' };
+    const d = { ...items[0], createdAt: 'd', meetingId: 9 };
+
+    expect(groupByMeetingId([a, b, c, d])).toEqual([[a, b], [c], [d]]);
   });
 });
 
@@ -56,6 +82,53 @@ describe('combineAndUpload', () => {
     });
     expect(discardAudio).toHaveBeenCalledWith('2026-06-12T09:00:00Z');
     expect(discardAudio).toHaveBeenCalledWith('2026-06-12T11:00:00Z');
+  });
+
+  it('uploads each meetingId group to its own meeting, preserving the id', async () => {
+    const a = { ...items[0], createdAt: 'a', endAt: 'a-end', durationSeconds: 300, meetingId: 5 };
+    const b = { ...items[0], createdAt: 'b', endAt: 'b-end', durationSeconds: 120, meetingId: 5 };
+    const c = { ...items[0], createdAt: 'c', endAt: 'c-end', durationSeconds: 60, meetingId: undefined };
+    const d = { ...items[0], createdAt: 'd', endAt: 'd-end', durationSeconds: 90, meetingId: 9 };
+
+    combine.mockResolvedValue(new ArrayBuffer(4));
+    uploadAudio.mockResolvedValue({ meetingId: 1 });
+    discardAudio.mockResolvedValue(undefined);
+
+    await combineAndUpload([a, b, c, d]);
+
+    // One combine + upload per group.
+    expect(combine.mock.calls).toEqual([[['a', 'b']], [['c']], [['d']]]);
+
+    const metas = uploadAudio.mock.calls.map((call) => call[1]);
+    expect(metas).toContainEqual(expect.objectContaining({ meetingId: 5, durationSeconds: 420 }));
+    expect(metas).toContainEqual(expect.objectContaining({ meetingId: 9, durationSeconds: 90 }));
+    // The id-less group creates a fresh meeting.
+    const fresh = metas.find((m) => m.meetingId === undefined);
+    expect(fresh).toBeDefined();
+    expect(fresh).not.toHaveProperty('meetingId');
+
+    // Every buffered key is discarded after its group uploads.
+    for (const key of ['a', 'b', 'c', 'd']) {
+      expect(discardAudio).toHaveBeenCalledWith(key);
+    }
+  });
+
+  it('leaves a failed group buffered while still uploading and discarding the others', async () => {
+    const a = { ...items[0], createdAt: 'a', durationSeconds: 300, meetingId: 5 };
+    const d = { ...items[0], createdAt: 'd', durationSeconds: 90, meetingId: 9 };
+
+    combine.mockResolvedValue(new ArrayBuffer(4));
+    // Group with meetingId 9 fails to upload; meetingId 5 succeeds.
+    uploadAudio.mockImplementation((_blob: unknown, meta: { meetingId?: number }) =>
+      meta.meetingId === 9 ? Promise.reject(new Error('offline')) : Promise.resolve({ meetingId: 5 })
+    );
+    discardAudio.mockResolvedValue(undefined);
+
+    await expect(combineAndUpload([a, d])).rejects.toThrow('offline');
+
+    // The succeeded group is discarded; the failed group is left in place.
+    expect(discardAudio).toHaveBeenCalledWith('a');
+    expect(discardAudio).not.toHaveBeenCalledWith('d');
   });
 
   it('does not discard when the upload fails', async () => {

--- a/src/composables/usePendingUploads.ts
+++ b/src/composables/usePendingUploads.ts
@@ -1,32 +1,49 @@
 import { pending, type PendingUploadMeta } from '../tauri';
 import { useMeetingApi } from './useMeetingApi';
 
-/** Merge a chronological list of pending uploads into one recording's meta:
- *  earliest start, latest end, summed duration. `meetingId` is intentionally
- *  dropped so the combined upload always creates one fresh meeting. */
+/** Merge a chronological list of pending uploads (all sharing one `meetingId`,
+ *  as produced by {@link groupByMeetingId}) into one recording's meta: earliest
+ *  start, latest end, summed duration. The group's `meetingId` is carried
+ *  through so the retry re-attaches to the same meeting instead of orphaning it;
+ *  it is omitted when the group has none (an ad-hoc recording → fresh meeting). */
 export function mergedMeta(items: PendingUploadMeta[]): {
   startAt: string;
   endAt: string;
   durationSeconds: number;
+  meetingId?: number;
 } {
   const first = items[0];
   const last = items[items.length - 1];
-  return {
+  const meta = {
     startAt: first.startAt ?? first.createdAt,
     endAt: last.endAt,
     durationSeconds: items.reduce((sum, i) => sum + i.durationSeconds, 0),
   };
+  return first.meetingId != null ? { ...meta, meetingId: first.meetingId } : meta;
 }
 
-/** Concatenate all pending uploads server-side, upload as one meeting, then
- *  discard the combined buffers. Leaves everything in place if the upload
- *  fails. `items` must be chronological (as `pending.list()` returns). */
-export async function combineAndUpload(items: PendingUploadMeta[]): Promise<void> {
-  if (items.length === 0) return;
-  const keys = items.map((i) => i.createdAt);
+/** Partition pending items by `meetingId` so each server meeting keeps its own
+ *  audio. Items that were tied to the same meeting combine into one upload for
+ *  that meeting; items with no `meetingId` form a single group uploaded as one
+ *  fresh meeting. Chronological order is preserved within and across groups. */
+export function groupByMeetingId(items: PendingUploadMeta[]): PendingUploadMeta[][] {
+  const groups = new Map<number | null, PendingUploadMeta[]>();
+  for (const item of items) {
+    const key = item.meetingId ?? null;
+    const group = groups.get(key);
+    if (group) group.push(item);
+    else groups.set(key, [item]);
+  }
+  return [...groups.values()];
+}
+
+/** Concatenate one meetingId group server-side, upload it (to its existing
+ *  meeting when it has an id, else a fresh one), then discard its buffers. */
+async function uploadGroup(group: PendingUploadMeta[]): Promise<void> {
+  const keys = group.map((i) => i.createdAt);
   const buf = await pending.combine(keys);
   const blob = new Blob([buf], { type: 'audio/mpeg' });
-  await useMeetingApi().uploadAudio(blob, mergedMeta(items));
+  await useMeetingApi().uploadAudio(blob, mergedMeta(group));
   // Upload succeeded; a buffer discard failure must not bubble up — otherwise
   // the caller would retry and double-upload. Match the per-recording path in
   // useBackend.ts/finalizeRecording.
@@ -35,6 +52,18 @@ export async function combineAndUpload(items: PendingUploadMeta[]): Promise<void
   if (failed > 0) {
     console.error(`Uploaded combined audio, but failed to discard ${failed} buffered item(s)`);
   }
+}
+
+/** Resume pending uploads: group by meeting so each meeting's audio re-attaches
+ *  to that meeting (preserving its id), then upload each group. A group that
+ *  fails is left buffered for a later retry while the others still upload and
+ *  discard; the first failure is re-thrown so the caller surfaces an error.
+ *  `items` must be chronological (as `pending.list()` returns). */
+export async function combineAndUpload(items: PendingUploadMeta[]): Promise<void> {
+  if (items.length === 0) return;
+  const results = await Promise.allSettled(groupByMeetingId(items).map(uploadGroup));
+  const firstFailure = results.find((r) => r.status === 'rejected');
+  if (firstFailure) throw (firstFailure as PromiseRejectedResult).reason;
 }
 
 /** Discard every pending upload (the "Discard all" action). */


### PR DESCRIPTION
## Problem

When an Ariso upload fails, the audio is buffered to disk and can be retried from the Library's **Pending uploads** section. But the retry (`combineAndUpload`) merged *all* buffered items into a single upload and **deliberately dropped `meetingId`**, always hitting the create-new endpoint `POST /desktop/meetings/audio/presign`. Any recording that was tied to a pre-existing server meeting got **orphaned** — the original meeting was left empty and a brand-new one created in its place.

## Fix

Group buffered items by `meetingId` before uploading (`groupByMeetingId`):

- Items sharing a `meetingId` combine and **re-attach to that meeting** via `POST /desktop/meetings/:id/audio/presign`.
- Items with no id combine into **one fresh meeting** (unchanged behavior for ad-hoc recordings).
- Each group uploads **independently** — a group whose upload fails stays buffered for a later retry while the others upload and discard; the first failure is re-thrown so the UI still shows "Upload failed."

Example: `[A(id=5), B(id=5), C(no id), D(id=9)]` → `{A,B}`→meeting 5, `{C}`→new meeting, `{D}`→meeting 9.

`mergedMeta` now carries the group's `meetingId` through. `PendingUploads.vue` is unchanged — it delegates to `combineAndUpload`, so grouping is fully encapsulated in the composable.

## Testing

TDD: wrote the failing tests first (grouping, id preservation, per-group upload/discard, partial-failure isolation), watched them fail, then implemented to green.

- `usePendingUploads.test.ts`: 12/12
- Full frontend suite: **548/548 passing**

## Notes

- `meetingId` is a typed `number` (Rust `Option<u64>`), so interpolating it into the presign path carries no injection risk.
- The approved design spec (`2026-06-14-resumable-uploads-from-library-design.md`) documented the old "drop meetingId / one merged meeting" behavior; updated with a dated amendment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Resumable uploads now preserve existing meeting associations.
  * Pending recordings are combined and uploaded separately for each meeting, while unassociated recordings create a new meeting.
  * Uploads continue independently when one group fails, allowing successful recordings to finish and failed ones to retry later.

* **Tests**
  * Added coverage for meeting grouping, metadata preservation, successful cleanup, and partial upload failures.

* **Documentation**
  * Updated the resumable upload design documentation to reflect the revised behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->