### PR TITLE
fix: clear the 'Upload failed' pill after a pending upload succeeds

### DIFF
--- a/src/views/LibraryView.test.ts
+++ b/src/views/LibraryView.test.ts
@@ -26,6 +26,7 @@ vi.mock('@tauri-apps/api/webviewWindow', () => ({
 // handlers, `emitEvent` drives them the way the Rust side would.
 type EventHandler = (e: { payload: unknown }) => void;
 const eventHandlers = new Map<string, EventHandler[]>();
+const emitAppEvent = vi.fn(() => Promise.resolve());
 vi.mock('@tauri-apps/api/event', () => ({
   listen: (name: string, cb: EventHandler) => {
     const arr = eventHandlers.get(name) ?? [];
@@ -37,6 +38,7 @@ vi.mock('@tauri-apps/api/event', () => ({
       if (i >= 0) list.splice(i, 1);
     });
   },
+  emit: (...a: unknown[]) => emitAppEvent(...a),
 }));
 
 function emitEvent(name: string, payload: unknown): void {
@@ -1236,6 +1238,30 @@ describe('LibraryView', () => {
     });
     await flushPromises();
     expect(wrapper.find('.pending-stub').exists()).toBe(true);
+  });
+
+  it('notifies the recorder window when a sidebar pending upload succeeds', async () => {
+    listMeetings.mockResolvedValue([]);
+    const wrapper = mount(LibraryView, {
+      global: {
+        stubs: {
+          PendingUploads: {
+            name: 'PendingUploads',
+            emits: ['uploaded'],
+            template: '<div class="pending-stub" />',
+          },
+        },
+      },
+    });
+    await flushPromises();
+    emitAppEvent.mockClear();
+
+    wrapper.findComponent({ name: 'PendingUploads' }).vm.$emit('uploaded');
+    await flushPromises();
+
+    // Broadcasts the stand-down so a still-open failed pill (mirrored into the
+    // recorder strip) clears instead of lingering after a successful retry.
+    expect(emitAppEvent).toHaveBeenCalledWith('pending-upload://succeeded');
   });
 
   it('confirms before recording an ariso auto-join meeting, and records only on confirm', async () => {

--- a/src/views/LibraryView.vue
+++ b/src/views/LibraryView.vue
@@ -180,7 +180,7 @@
 <script setup lang="ts">
 import { ref, computed, watch, nextTick, onMounted, onUnmounted } from 'vue';
 import { invoke } from '@tauri-apps/api/core';
-import { listen, type UnlistenFn } from '@tauri-apps/api/event';
+import { emit, listen, type UnlistenFn } from '@tauri-apps/api/event';
 import { getAllWebviewWindows } from '@tauri-apps/api/webviewWindow';
 import { getActiveBackend, timestampTitle, BACKEND_CHANGED_EVENT, type Backend, type MeetingListItem } from '../composables/useBackend';
 import { timestampFromLocalRecordingId } from '../composables/localRecordingId';
@@ -505,6 +505,13 @@ async function loadMeetings(autoSelectFirst = false): Promise<void> {
 }
 
 async function onPendingUploaded(): Promise<void> {
+  // A still-open waveform window may be sitting on a stale "Upload failed" pill
+  // for the recording we just uploaded from the sidebar. Tell it to stand down
+  // so its failed pill (mirrored into the recorder strip) clears and no Retry
+  // can double-upload the buffer we already discarded.
+  await emit('pending-upload://succeeded').catch((e) =>
+    console.error('Failed to notify recorder of pending upload success', e),
+  );
   await loadMeetings();
 }
 

--- a/src/views/WaveformView.test.ts
+++ b/src/views/WaveformView.test.ts
@@ -753,4 +753,37 @@ describe('WaveformView vertical pill', () => {
     const last = emitEvent.mock.calls.filter(([n]) => n === 'recorder://state').at(-1);
     expect((last?.[1] as { phase: string }).phase).toBe('closed');
   });
+
+  it('closes the failed pill when the sidebar pending-upload retry succeeds', async () => {
+    stopRecording.mockResolvedValue(new Blob(['x'], { type: 'audio/mpeg' }));
+    finalizeRecording.mockRejectedValue(new Error('boom'));
+    const wrapper = mount(WaveformView);
+    await flushPromises();
+    await wrapper.find('.stop-btn').trigger('click');
+    await flushPromises();
+    expect(wrapper.find('.status-icon.err').exists()).toBe(true);
+
+    // The Pending-uploads retry uploaded and discarded this same buffer: the
+    // stale failed pill must go away (window closes → broadcasts 'closed'), and
+    // the window must not re-discard or re-upload the already-gone buffer.
+    emitEvent.mockClear();
+    eventHandlers['pending-upload://succeeded']?.({ payload: undefined });
+    await flushPromises();
+
+    expect(closeWin).toHaveBeenCalled();
+    const last = emitEvent.mock.calls.filter(([n]) => n === 'recorder://state').at(-1);
+    expect((last?.[1] as { phase: string }).phase).toBe('closed');
+    expect(discardPendingAudio).not.toHaveBeenCalled();
+  });
+
+  it('ignores a pending-upload success while still actively recording', async () => {
+    const wrapper = mount(WaveformView);
+    await flushPromises();
+
+    eventHandlers['pending-upload://succeeded']?.({ payload: undefined });
+    await flushPromises();
+
+    expect(closeWin).not.toHaveBeenCalled();
+    wrapper.unmount();
+  });
 });

--- a/src/views/WaveformView.vue
+++ b/src/views/WaveformView.vue
@@ -313,6 +313,7 @@ async function applyPillVisibility(hidden: boolean) {
 }
 
 let unlistenPillVisible: UnlistenFn | null = null;
+let unlistenPendingUploaded: UnlistenFn | null = null;
 let unlistenPause: UnlistenFn | null = null;
 let unlistenResume: UnlistenFn | null = null;
 let unlistenStop: UnlistenFn | null = null;
@@ -663,6 +664,20 @@ async function dismissFailed() {
   await closeWindow();
 }
 
+// The sidebar "Pending uploads" retry uploaded (and discarded) this recording's
+// on-disk buffer out from under us. Our failed pill — and the library strip it
+// heartbeats — is now stale, and our held blob would double-upload on Retry.
+// Drop the in-memory copy without re-discarding the (already-gone) buffer, then
+// close so both pills clear. Ignored unless we're actually showing the failed
+// pill: a live recording or an in-flight resume must not be torn down.
+async function handlePendingUploadSucceeded() {
+  if (uploadResult.value !== 'failed') return;
+  inFlightFinalize = null;
+  stoppedBlob.value = null;
+  stoppedMeta.value = null;
+  await closeWindow();
+}
+
 // Keep the failed recording's audio and resume capturing into a fresh buffer.
 // The next stop concatenates the held blob with the new segment (see handleStop).
 async function resumeFailed() {
@@ -710,6 +725,8 @@ onMounted(async () => {
   unlistenPillVisible = await listen<boolean>('recorder://pill-visible', (e) => {
     void applyPillVisibility(!e.payload);
   });
+
+  unlistenPendingUploaded = await listen('pending-upload://succeeded', handlePendingUploadSucceeded);
 
   unlistenPause = await listen('tray://pause-recording', handlePause);
   unlistenResume = await listen('tray://resume-recording', handleResume);
@@ -834,6 +851,7 @@ onUnmounted(() => {
   if (silenceTimer) clearInterval(silenceTimer);
   if (closeTimer) clearTimeout(closeTimer);
   unlistenPillVisible?.();
+  unlistenPendingUploaded?.();
   unlistenPause?.();
   unlistenResume?.();
   unlistenStop?.();


### PR DESCRIPTION
## Problem

The library's "Upload failed" pill (`RecorderStrip`) mirrors the waveform window's `recorder://state` heartbeat, which keeps broadcasting `phase: 'failed'` while that window stays open. The sidebar "Pending uploads" retry (`combineAndUpload`) is a separate path — it uploads and discards the on-disk buffer but never tells the still-open waveform window. So after a successful pending upload the pill lingered, and the window's stale in-memory blob could double-upload on Retry.

## Fix

- `LibraryView.onPendingUploaded` emits `pending-upload://succeeded` on a successful sidebar upload.
- `WaveformView` listens for it and — only when it's showing the failed pill — drops its held blob/meta and closes, which broadcasts `closed` and clears both the floating pill and the mirrored recorder strip. The guard leaves a live recording or in-flight resume untouched.

## Tests

- Unit: WaveformView closes on the event (and ignores it while recording); LibraryView emits the event on `uploaded`. Full suite green (551 tests).
- Manual E2E via the `oats-desktop` MCP: drove a real waveform window into the failed state, confirmed the library pill, ran the real handler, and verified the window closed and the pill cleared.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved synchronization between pending uploads and the recorder window.
  - Successful sidebar uploads now clear stale “upload failed” states and close the related recorder window.
  - Active recordings are unaffected by upload completion events.
- **Tests**
  - Added coverage for successful upload notifications, failed-upload cleanup, and active recording behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->