### PR TITLE
feat: add Locate button to pending upload rows

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1184,6 +1184,29 @@ pub fn combine_pending_audio(
     Ok(tauri::ipc::Response::new(bytes))
 }
 
+/// Reveal a buffered pending upload in the OS file manager (Finder on macOS,
+/// Explorer on Windows). If the mp3 is gone, still open `pending-uploads/`
+/// itself so the button always lands the user in the right folder.
+#[tauri::command]
+pub fn reveal_pending_upload(app: tauri::AppHandle, created_at: String) -> Result<(), String> {
+    use tauri_plugin_opener::OpenerExt;
+
+    let root = crate::storage::ariso_root()?;
+    let audio = crate::storage::pending_audio_path(&root, &created_at)?;
+    if audio.is_file() {
+        return app
+            .opener()
+            .reveal_item_in_dir(&audio)
+            .map_err(|e| e.to_string());
+    }
+
+    let dir = crate::storage::pending_uploads_dir(&root);
+    std::fs::create_dir_all(&dir).map_err(|e| format!("create pending-uploads dir: {e}"))?;
+    app.opener()
+        .open_path(dir.to_string_lossy().into_owned(), None::<&str>)
+        .map_err(|e| e.to_string())
+}
+
 /// Resolve a recording's directory under `<vault>/.oats/recordings/<id>`,
 /// guarding against path traversal. Ids are normally sanitized timestamps
 /// (e.g. `2026-06-02T14-30-05Z`), so the guard never rejects legitimate ids.

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -219,6 +219,7 @@ fn main() {
             commands::discard_pending_audio,
             commands::list_pending_uploads,
             commands::combine_pending_audio,
+            commands::reveal_pending_upload,
             commands::fetch_meeting_audio,
             commands::share_text_native,
             transcribe::local_recording_id_for_start,

--- a/src-tauri/src/storage.rs
+++ b/src-tauri/src/storage.rs
@@ -213,7 +213,7 @@ fn validate_pending_id(id: &str) -> Result<(), String> {
     Ok(())
 }
 
-fn pending_audio_path(root: &Path, created_at: &str) -> Result<PathBuf, String> {
+pub fn pending_audio_path(root: &Path, created_at: &str) -> Result<PathBuf, String> {
     let id = sanitize_iso_to_pending_id(created_at);
     validate_pending_id(&id)?;
     Ok(pending_uploads_dir(root).join(format!("{id}.mp3")))

--- a/src/tauri.ts
+++ b/src/tauri.ts
@@ -365,6 +365,10 @@ export const pending = {
   combine(createdAtKeys: string[]): Promise<ArrayBuffer> {
     return invoke<ArrayBuffer>('combine_pending_audio', { createdAtKeys });
   },
+  /** Open `~/.ariso/pending-uploads` in Finder/Explorer, selecting this buffer. */
+  reveal(createdAt: string): Promise<void> {
+    return invoke('reveal_pending_upload', { createdAt });
+  },
 };
 
 export async function getBackendSetting(): Promise<'ariso' | 'local'> {

--- a/src/views/PendingUploads.test.ts
+++ b/src/views/PendingUploads.test.ts
@@ -4,6 +4,7 @@ import { mount, flushPromises } from '@vue/test-utils';
 
 const list = vi.fn();
 const combine = vi.fn();
+const reveal = vi.fn();
 const checkSession = vi.fn();
 const combineAndUpload = vi.fn();
 const discardAll = vi.fn();
@@ -13,6 +14,7 @@ vi.mock('../tauri', () => ({
   pending: {
     list: (...a: unknown[]) => list(...a),
     combine: (...a: unknown[]) => combine(...a),
+    reveal: (...a: unknown[]) => reveal(...a),
   },
 }));
 vi.mock('../composables/usePendingUploads', () => ({
@@ -73,6 +75,33 @@ describe('PendingUploads', () => {
 
     expect(combine).toHaveBeenCalledWith(['2026-06-12T11:00:00Z']);
     expect(loaded).toBe(buf);
+  });
+
+  it('Locate opens the buffer folder for that recording', async () => {
+    list.mockResolvedValue(items);
+    reveal.mockResolvedValue(undefined);
+    const wrapper = mount(PendingUploads);
+    await flushPromises();
+
+    const buttons = wrapper.findAll('.pi-locate');
+    expect(buttons).toHaveLength(2);
+    await buttons[1].trigger('click');
+    await flushPromises();
+
+    expect(reveal).toHaveBeenCalledWith('2026-06-12T11:00:00Z');
+    expect(wrapper.find('.pending-error').exists()).toBe(false);
+  });
+
+  it('shows an error when the buffer folder cannot be opened', async () => {
+    list.mockResolvedValue(items);
+    reveal.mockRejectedValue(new Error('no such directory'));
+    const wrapper = mount(PendingUploads);
+    await flushPromises();
+
+    await wrapper.find('.pi-locate').trigger('click');
+    await flushPromises();
+
+    expect(wrapper.find('.pending-error').text()).toBe('Could not open the pending uploads folder.');
   });
 
   it('Upload combines+uploads, refreshes, and emits uploaded on success', async () => {

--- a/src/views/PendingUploads.vue
+++ b/src/views/PendingUploads.vue
@@ -2,17 +2,30 @@
   <div v-if="items.length > 0" class="pending">
     <div class="group-label">Pending uploads</div>
     <div class="pending-card">
+      <!-- Two lines per item: the sidebar is ~250px wide, so Play + Locate on
+           the title's line would squeeze the title itself down to nothing. -->
       <div v-for="it in items" :key="it.createdAt" class="pending-item">
-        <span class="pi-dot" aria-hidden="true" />
-        <span class="pi-wave" aria-hidden="true" />
-        <span class="pi-title">{{ titleFor(it) }}</span>
-        <span class="pi-dur">{{ durationFor(it) }}</span>
-        <span class="pi-play">
-          <RecordingAudioPlayer
-            :load="() => loadAudio(it)"
-            title="Plays the recording buffered on this Mac, not an uploaded copy"
-          />
-        </span>
+        <div class="pi-head">
+          <span class="pi-dot" aria-hidden="true" />
+          <span class="pi-wave" aria-hidden="true" />
+          <span class="pi-title">{{ titleFor(it) }}</span>
+          <span class="pi-dur">{{ durationFor(it) }}</span>
+        </div>
+        <div class="pi-controls">
+          <span class="pi-play">
+            <RecordingAudioPlayer
+              :load="() => loadAudio(it)"
+              title="Plays the recording buffered on this Mac, not an uploaded copy"
+            />
+          </span>
+          <button
+            class="pi-locate"
+            title="Show this buffered recording in Finder (~/.ariso/pending-uploads)"
+            @click="onLocate(it)"
+          >
+            Locate
+          </button>
+        </div>
       </div>
       <!-- Leaving the actions row cancels a pending discard confirmation so the
            destructive second click can't linger armed after the user moves away. -->
@@ -79,6 +92,18 @@ function durationFor(it: PendingUploadMeta): string {
 // so playback exercises the exact bytes an upload retry would send.
 function loadAudio(it: PendingUploadMeta): Promise<ArrayBuffer> {
   return pending.combine([it.createdAt]);
+}
+
+// Opens the buffer folder in the OS file manager so the mp3 can be recovered
+// by hand — the backend selects this recording's file when it still exists.
+async function onLocate(it: PendingUploadMeta): Promise<void> {
+  error.value = null;
+  try {
+    await pending.reveal(it.createdAt);
+  } catch (e) {
+    console.error('Failed to reveal pending upload', e);
+    error.value = 'Could not open the pending uploads folder.';
+  }
 }
 
 // Retry is only useful when desktop has an Ari session to attach to the upload
@@ -150,11 +175,22 @@ onMounted(refresh);
 }
 .pending-item {
   display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 10px;
+  box-sizing: border-box;
+}
+.pi-head {
+  display: flex;
   align-items: center;
   gap: 7px;
-  min-height: 52px;
-  padding: 0 10px;
-  box-sizing: border-box;
+  min-width: 0;
+}
+.pi-controls {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  min-width: 0;
 }
 .pending-item + .pending-item {
   border-top: 1px solid #e5e2dd;
@@ -196,23 +232,40 @@ onMounted(refresh);
   font-weight: 600;
   font-variant-numeric: tabular-nums;
 }
+/* Collapsed, the Play button sits directly beside Locate; expanded, the
+   <audio> element claims the rest of the line and pushes Locate to the edge. */
 .pi-play {
   display: flex;
   align-items: center;
+  flex: 0 1 auto;
   min-width: 0;
 }
-/* Once playing, cap the native controls so they share the row with the title
+.pi-play:has(.audio-el) {
+  flex: 1 1 auto;
+}
+/* Once playing, let the native controls fill the controls line beside Locate
    instead of the <audio> element's intrinsic ~300px width overflowing it. */
 .pi-play :deep(.audio-el) {
-  width: 150px;
+  width: 100%;
   min-width: 0;
-  flex: 0 1 auto;
+  flex: 1 1 auto;
 }
-/* The expanded player has its own timeline; drop the redundant wave glyph and
-   duration so the title isn't squeezed to nothing in the narrow sidebar row. */
-.pending-item:has(.audio-el) .pi-wave,
-.pending-item:has(.audio-el) .pi-dur {
-  display: none;
+/* Matches the player's Play button so the pair reads as one control group. */
+.pi-locate {
+  flex-shrink: 0;
+  font-family: inherit;
+  font-size: 13px;
+  padding: 5px 10px;
+  border-radius: 6px;
+  border: 1px solid #d1d5db;
+  background: #ffffff;
+  color: #1d1d1f;
+  cursor: pointer;
+  white-space: nowrap;
+}
+.pi-locate:hover {
+  background: #f7f6f4;
+  border-color: #bdbbb6;
 }
 .pending-error {
   margin: 0 10px;


### PR DESCRIPTION

<img width="285" height="176" alt="Screenshot 2026-07-24 at 21 11 08" src="https://github.com/user-attachments/assets/5f3b3c17-09f3-496e-bf5f-ef7dd0da447f" />

Adds a **Locate** button next to each pending upload's Play control. It reveals that recording's mp3 in Finder (Explorer on Windows) under `~/.ariso/pending-uploads`, so a buffered recording can be recovered by hand when an upload keeps failing. If the mp3 is missing it still opens the folder.

New `reveal_pending_upload` command uses `tauri-plugin-opener` from the Rust side (same pattern as `open_recording_file`), so no capability change is needed. The path comes from the existing validated `pending_audio_path`.

The extra button squeezed the row title to zero width in the ~250px sidebar, so each item is now two lines: title + duration above, Play + Locate below.

## Testing

- `PendingUploads.test.ts`: 13 passing, incl. new coverage for the reveal call and its error path.
- Verified in the running app with two seeded buffers: each Locate opened `~/.ariso/pending-uploads` with the correct mp3 selected; with the mp3 deleted the folder still opened with no error; playback and layout unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a **Locate** control for each pending recording.
  - Opens the recording in the system file manager when available.
  - If the recording cannot be found, opens the pending uploads folder instead.

- **Bug Fixes**
  - Added clear feedback when the pending uploads folder cannot be opened.
  - Improved the layout and responsiveness of pending recording controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->