### PR TITLE
fix: hide future meetings from the Meetings history list

### DIFF
--- a/src/composables/groupMeetingsByDate.test.ts
+++ b/src/composables/groupMeetingsByDate.test.ts
@@ -83,28 +83,43 @@ describe('nextDaySection', () => {
 });
 
 describe('groupMeetingsByDate', () => {
-  it('buckets meetings by date with upcoming days nearest-first, then past days newest-first', () => {
+  it('buckets meetings by date, today first then past days newest-first', () => {
     const meetings = [
       m('older', '2026-06-08T09:00:00'),
       m('past1', '2026-06-09T09:00:00'),
       m('today1', '2026-06-10T09:00:00'),
       m('today2', '2026-06-10T11:00:00'),
       m('soon', '2026-06-10T18:00:00'),
+    ];
+    const sections = groupMeetingsByDate(meetings, NOW);
+    expect(sections.map((s) => s.label)).toEqual(['TODAY', 'YESTERDAY', 'MON, JUN 8']);
+    // Within a date, earliest-first (ascending) — including later-today meetings.
+    expect(sections[0].items.map((x) => x.id)).toEqual(['today1', 'today2', 'soon']);
+  });
+
+  it('drops meetings dated beyond today', () => {
+    const meetings = [
+      m('past1', '2026-06-09T09:00:00'),
+      m('today1', '2026-06-10T09:00:00'),
       m('tomorrow', '2026-06-11T09:00:00'),
       m('future', '2026-06-12T10:00:00'),
     ];
     const sections = groupMeetingsByDate(meetings, NOW);
-    // No UPCOMING section: future meetings live under their own date header.
-    expect(sections.map((s) => s.label)).toEqual([
-      'TODAY',
-      'TOMORROW',
-      'FRI, JUN 12',
-      'YESTERDAY',
-      'MON, JUN 8',
-    ]);
-    // Within a date, earliest-first (ascending).
-    expect(sections[0].items.map((x) => x.id)).toEqual(['today1', 'today2', 'soon']);
-    expect(sections[2].items.map((x) => x.id)).toEqual(['future']);
+    expect(sections.map((s) => s.label)).toEqual(['TODAY', 'YESTERDAY']);
+    expect(sections.flatMap((s) => s.items.map((x) => x.id))).toEqual(['today1', 'past1']);
+  });
+
+  it('hides a past meeting that was rescheduled into the future', () => {
+    // The rescheduled meeting carries its new (future) start, so it must not
+    // land between TODAY and YESTERDAY (issue #263).
+    const meetings = [
+      m('yesterday', '2026-06-09T09:00:00'),
+      m('rescheduled', '2026-06-17T10:00:00'),
+      m('today', '2026-06-10T09:00:00'),
+    ];
+    const sections = groupMeetingsByDate(meetings, NOW);
+    expect(sections.map((s) => s.label)).toEqual(['TODAY', 'YESTERDAY']);
+    expect(sections.flatMap((s) => s.items.map((x) => x.id))).not.toContain('rescheduled');
   });
 
   it('returns an empty array for no meetings', () => {

--- a/src/composables/groupMeetingsByDate.ts
+++ b/src/composables/groupMeetingsByDate.ts
@@ -104,27 +104,28 @@ export function nextDaySection(meetings: MeetingListItem[], now: Date): MeetingS
   return { key: nextKey, label: dayLabelWithDate(nextKey, now), items };
 }
 
-/** Bucket every meeting under per-calendar-date headers in a meeting-list order:
- *  today and future dates read nearest-first, while past dates read newest-first. */
+/** Bucket meetings up to and including today under per-calendar-date headers,
+ *  newest day first. Days beyond today are dropped: this is the history list, and
+ *  a meeting rescheduled into the future would otherwise wedge itself between
+ *  TODAY and YESTERDAY. Upcoming meetings live in the Today view / UpNextCard. */
 export function groupMeetingsByDate(meetings: MeetingListItem[], now: Date): MeetingSection[] {
+  const today = localDateKey(now);
   const buckets = new Map<string, MeetingListItem[]>();
   for (const meeting of meetings) {
     const d = new Date(meeting.timestamp);
+    // Zero-padded YYYY-MM-DD keys compare lexically, so this drops future days.
     const key = Number.isNaN(d.getTime()) ? 'unknown' : localDateKey(d);
+    if (key !== 'unknown' && key > today) continue;
     const bucket = buckets.get(key);
     if (bucket) bucket.push(meeting);
     else buckets.set(key, [meeting]);
   }
 
   const sections: MeetingSection[] = [];
-  const today = localDateKey(now);
-  // Lexical sort == chronological because keys are zero-padded YYYY-MM-DD. The
-  // split keeps upcoming days from being pushed below farther-future meetings.
-  const datedKeys = [...buckets.keys()].filter((k) => k !== 'unknown');
-  const futureAndTodayKeys = datedKeys.filter((key) => key >= today).sort();
-  const pastKeys = datedKeys.filter((key) => key < today).sort().reverse();
+  // Lexical sort == chronological because the keys are zero-padded.
+  const pastKeys = [...buckets.keys()].filter((k) => k !== 'unknown').sort().reverse();
 
-  for (const key of [...futureAndTodayKeys, ...pastKeys]) {
+  for (const key of pastKeys) {
     const items = [...buckets.get(key)!].sort(
       (a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime()
     );

--- a/src/views/LibraryView.test.ts
+++ b/src/views/LibraryView.test.ts
@@ -751,6 +751,32 @@ describe('LibraryView', () => {
     expect(wrapper.get('button[title="Meetings"]').classes()).not.toContain('nav-tab--active');
   });
 
+  it('Meetings tab hides meetings scheduled beyond today', async () => {
+    const inAWeek = new Date();
+    inAWeek.setDate(inAWeek.getDate() + 7);
+    listMeetings.mockResolvedValue([
+      item({ id: 'today', title: 'Today Standup', timestamp: todayAt(9) }),
+      item({ id: 'old', title: 'Old Sync', timestamp: '2020-01-02T10:00:00Z' }),
+      item({ id: 'moved', title: 'Rescheduled Sync', timestamp: inAWeek.toISOString() }),
+    ]);
+    const wrapper = mount(LibraryView);
+    await flushPromises();
+    expect(wrapper.findAll('.meeting-item')).toHaveLength(2);
+    expect(wrapper.text()).not.toContain('Rescheduled Sync');
+  });
+
+  it('Meetings tab shows a past-specific hint when only future meetings exist', async () => {
+    const inAWeek = new Date();
+    inAWeek.setDate(inAWeek.getDate() + 7);
+    listMeetings.mockResolvedValue([
+      item({ id: 'moved', title: 'Rescheduled Sync', timestamp: inAWeek.toISOString() }),
+    ]);
+    const wrapper = mount(LibraryView);
+    await flushPromises();
+    expect(wrapper.findAll('.meeting-item')).toHaveLength(0);
+    expect(wrapper.text()).toContain('No past meetings.');
+  });
+
   it('Today tab shows the empty hint when there are no meetings today', async () => {
     listMeetings.mockResolvedValue([item({ id: 'old', title: 'Old Sync', timestamp: '2020-01-02T10:00:00Z' })]);
     const wrapper = mount(LibraryView);

--- a/src/views/LibraryView.vue
+++ b/src/views/LibraryView.vue
@@ -493,10 +493,9 @@ async function loadMeetings(autoSelectFirst = false): Promise<void> {
     void emitNotificationsSync().catch((err) => {
       console.warn('Failed to sync tray after meeting list refresh', err);
     });
-    if (autoSelectFirst && !selectedItem.value && meetings.value.length > 0) {
-      await selectMeeting(displayedSections.value[0]?.items[0] ?? meetings.value[0], {
-        userSelected: false,
-      });
+    const firstVisible = displayedSections.value[0]?.items[0];
+    if (autoSelectFirst && !selectedItem.value && firstVisible) {
+      await selectMeeting(firstVisible, { userSelected: false });
     } else if (selectedItem.value) {
       selectedItem.value =
         meetings.value.find((m) => m.id === selectedItem.value?.id) ?? selectedItem.value;

--- a/src/views/LibraryView.vue
+++ b/src/views/LibraryView.vue
@@ -102,7 +102,7 @@
             <span class="mi-sub" :class="{ 'mi-sub--now': isNextNow(m) }">{{ subFor(m) }}</span>
           </button>
         </template>
-        <p v-if="displayedSections.length === 0" class="hint">No meetings today.</p>
+        <p v-if="displayedSections.length === 0" class="hint">{{ emptyListHint }}</p>
       </div>
 
       <!-- Floating bottom navigation -->
@@ -303,12 +303,18 @@ const displayMeetings = computed<MeetingListItem[]>(() => {
   ];
 });
 
+// The Meetings view is a history list — it stops at today, so it can come up
+// empty even when the backend returned only future (scheduled) meetings.
 const displayedSections = computed<MeetingSection[]>(() => {
   if (activeView.value === 'today') {
     return groupTodaysMeetings(displayMeetings.value, now.value);
   }
   return groupMeetingsByDate(displayMeetings.value, now.value);
 });
+
+const emptyListHint = computed(() =>
+  activeView.value === 'today' ? 'No meetings today.' : 'No past meetings.'
+);
 
 // Only the next upcoming meeting (soonest, or the one in progress) carries a
 // relative-time chip; it's the first item of the Today view's UPCOMING section.


### PR DESCRIPTION
Fixes #263

## Problem

The Meetings view grouped date keys into two halves — `>= today` sorted ascending, `< today` sorted descending — then concatenated them. Today sorts first in the ascending half, so any future day landed immediately after TODAY and before YESTERDAY.

A meeting rescheduled from the past into the future carries its new start, so it hit that branch and produced the reported ordering: **today, Wednesday Jul 29, yesterday, Thu**.

## Fix

`groupMeetingsByDate` now stops at today: days beyond today are dropped and past days read newest-first. Upcoming meetings were already surfaced elsewhere (`groupTodaysMeetings` for the Today view, `nextDaySection` for `UpNextCard`) — both untouched.

Later-today meetings still show, and undated (NaN-timestamp) meetings keep their UNDATED bucket at the end.

One consequence handled: the Meetings view can now come up empty while the backend returned only future meetings, and the empty hint was shared with the Today view. It's now view-aware — "No past meetings." in Meetings, unchanged in Today.

## Verification

- Failing tests written first; they reproduced the bug as `['TODAY', 'WED, JUN 17', 'YESTERDAY']`.
- `npm test` — 563 tests across 50 files, all passing.
- `npm run vite:build` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Future-dated meetings are now excluded from the Meetings tab and grouped views.
  * Meeting sections are ordered with **Today first**, then **Yesterday**, then earlier dates.
  * Rescheduled meetings that move into the future no longer appear in past-meeting views.
  * Empty states now correctly distinguish between **“No meetings today.”** and **“No past meetings.”**
  * After loading, the highlighted selection now targets the first visible grouped item.
* **Tests**
  * Updated and expanded coverage for the meeting filtering and grouping behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->