### PR TITLE
fix: mark canceled meetings and keep them out of the menu bar

### DIFF
--- a/src-tauri/src/tray_meeting.rs
+++ b/src-tauri/src/tray_meeting.rs
@@ -453,6 +453,7 @@ pub(crate) fn parse_meetings(v: &Value) -> Vec<ScheduledMeeting> {
         .unwrap_or_default();
     items
         .iter()
+        .filter(|it| !is_cancelled_status(it))
         .filter_map(|it| {
             Some(ScheduledMeeting {
                 id: parse_id(it.get("id"))?,
@@ -461,6 +462,20 @@ pub(crate) fn parse_meetings(v: &Value) -> Vec<ScheduledMeeting> {
             })
         })
         .collect()
+}
+
+/// Whether a `/meetings` entry is a canceled meeting. The backend turns a
+/// deleted or canceled calendar event into `status: "cancelled"`; such a
+/// meeting is not happening, so the menu bar must not count down to it or
+/// announce it as current. Accepts the American spelling and stray case for
+/// the same reason the frontend's `isCanceledMeetingStatus` does.
+pub(crate) fn is_cancelled_status(v: &Value) -> bool {
+    v.get("status")
+        .and_then(Value::as_str)
+        .is_some_and(|s| {
+            let s = s.trim().to_ascii_lowercase();
+            s == "cancelled" || s == "canceled"
+        })
 }
 
 /// Read the optional `end_at` from a `GET /meeting-notes/:id` payload.
@@ -791,6 +806,33 @@ mod tests {
         );
         assert_eq!(ms[1].id, 8);
         assert_eq!(ms[1].title, None);
+    }
+
+    #[test]
+    fn parse_meetings_drops_cancelled_meetings() {
+        // A canceled meeting must never reach the tray: no "… in 10min"
+        // countdown and no "… now" once its start time passes.
+        let v = serde_json::json!({ "meetings": [
+            { "id": 7, "title": "Standup", "start_at": "2026-06-11T14:00:00.000Z" },
+            { "id": 8, "title": "Dropped", "start_at": "2026-06-11T15:00:00Z", "status": "cancelled" },
+            { "id": 9, "title": "American", "start_at": "2026-06-11T16:00:00Z", "status": "Canceled" },
+            { "id": 10, "title": "Live", "start_at": "2026-06-11T17:00:00Z", "status": "created" }
+        ]});
+        let ms = parse_meetings(&v);
+        assert_eq!(
+            ms.iter().map(|m| m.id).collect::<Vec<_>>(),
+            vec![7, 10],
+            "cancelled meetings (either spelling) must be filtered out"
+        );
+    }
+
+    #[test]
+    fn cancelled_status_matching_is_narrow() {
+        assert!(is_cancelled_status(&serde_json::json!({ "status": "cancelled" })));
+        assert!(is_cancelled_status(&serde_json::json!({ "status": " CANCELED " })));
+        assert!(!is_cancelled_status(&serde_json::json!({ "status": "recording" })));
+        assert!(!is_cancelled_status(&serde_json::json!({ "status": null })));
+        assert!(!is_cancelled_status(&serde_json::json!({})));
     }
 
     #[test]

--- a/src/composables/meetingStatus.test.ts
+++ b/src/composables/meetingStatus.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { isCanceledMeetingStatus } from './meetingStatus';
+
+describe('isCanceledMeetingStatus', () => {
+  it('matches the backend spelling', () => {
+    expect(isCanceledMeetingStatus('cancelled')).toBe(true);
+  });
+
+  it('tolerates the American spelling, case, and padding', () => {
+    expect(isCanceledMeetingStatus('canceled')).toBe(true);
+    expect(isCanceledMeetingStatus('Cancelled')).toBe(true);
+    expect(isCanceledMeetingStatus(' CANCELED ')).toBe(true);
+  });
+
+  it('leaves every other lifecycle status alone', () => {
+    for (const s of ['created', 'joining', 'joined', 'recording', 'paused', 'processing', 'done', 'expired']) {
+      expect(isCanceledMeetingStatus(s)).toBe(false);
+    }
+  });
+
+  it('is false for missing or non-string values', () => {
+    expect(isCanceledMeetingStatus(null)).toBe(false);
+    expect(isCanceledMeetingStatus(undefined)).toBe(false);
+    expect(isCanceledMeetingStatus(1)).toBe(false);
+    expect(isCanceledMeetingStatus({})).toBe(false);
+  });
+});

--- a/src/composables/meetingStatus.ts
+++ b/src/composables/meetingStatus.ts
@@ -1,0 +1,13 @@
+/**
+ * Whether an ariso meeting `status` means the meeting was canceled — the state
+ * a deleted/canceled calendar event lands in (the backend normalizes calendar
+ * deletions into `status: 'cancelled'`). The web app keys off the exact
+ * `'cancelled'` spelling; we also accept the American spelling and stray
+ * case/whitespace so a payload variation can't silently show a canceled
+ * meeting as a live one.
+ */
+export function isCanceledMeetingStatus(status: unknown): boolean {
+  if (typeof status !== 'string') return false;
+  const s = status.trim().toLowerCase();
+  return s === 'cancelled' || s === 'canceled';
+}

--- a/src/composables/useBackend.test.ts
+++ b/src/composables/useBackend.test.ts
@@ -338,6 +338,48 @@ describe('ArisoBackend', () => {
     expect(d.shareMeetingNotesToPublic).toBe('host_only');
     expect(d.participants[0].id).toBe(11);
   });
+
+  it('marks the detail canceled from the meeting-notes status', async () => {
+    getMeetingNotes.mockResolvedValue({
+      id: 7,
+      title: 'Dropped',
+      start_at: '2026-06-01T10:00:00Z',
+      status: 'cancelled',
+    });
+    const d = await new ArisoBackend().getMeetingDetail({
+      id: '7',
+      title: 'Dropped',
+      timestamp: '2026-06-01T10:00:00Z',
+    });
+    expect(d.canceled).toBe(true);
+  });
+
+  it('keeps the list row canceled flag when the notes payload omits status', async () => {
+    getMeetingNotes.mockResolvedValue({ id: 7, title: 'Dropped', start_at: '2026-06-01T10:00:00Z' });
+    const d = await new ArisoBackend().getMeetingDetail({
+      id: '7',
+      title: 'Dropped',
+      timestamp: '2026-06-01T10:00:00Z',
+      canceled: true,
+    });
+    expect(d.canceled).toBe(true);
+  });
+
+  it('is not canceled for a live meeting', async () => {
+    getMeetingNotes.mockResolvedValue({
+      id: 7,
+      title: 'Live',
+      start_at: '2026-06-01T10:00:00Z',
+      status: 'done',
+    });
+    const d = await new ArisoBackend().getMeetingDetail({
+      id: '7',
+      title: 'Live',
+      timestamp: '2026-06-01T10:00:00Z',
+      canceled: true,
+    });
+    expect(d.canceled).toBe(false);
+  });
 });
 
 describe('ArisoBackend clips', () => {
@@ -506,9 +548,18 @@ describe('ArisoBackend.listMeetings', () => {
       expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/)
     );
     expect(items).toEqual([
-      { id: '7', title: 'Standup', timestamp: '2026-06-08T09:00:00Z', autoJoinScheduled: false },
-      { id: '8', title: 'Untitled meeting', timestamp: '2026-06-09T09:00:00Z', autoJoinScheduled: false },
+      { id: '7', title: 'Standup', timestamp: '2026-06-08T09:00:00Z', autoJoinScheduled: false, canceled: false },
+      { id: '8', title: 'Untitled meeting', timestamp: '2026-06-09T09:00:00Z', autoJoinScheduled: false, canceled: false },
     ]);
+  });
+
+  it('flags meetings whose calendar event was canceled', async () => {
+    listMeetingsInWindow.mockResolvedValue([
+      { id: 7, title: 'Dropped', start_at: '2026-06-08T09:00:00Z', status: 'cancelled' },
+      { id: 8, title: 'Live', start_at: '2026-06-09T09:00:00Z', status: 'done' },
+    ]);
+    const items = await new ArisoBackend().listMeetings();
+    expect(items.map((i) => i.canceled)).toEqual([true, false]);
   });
 });
 
@@ -537,6 +588,7 @@ describe('ArisoBackend.searchMeetings', () => {
         snippet: 'Discussed pipeline notes',
         matchedText: 'pipeline',
         autoJoinScheduled: false,
+        canceled: false,
       },
     ]);
   });

--- a/src/composables/useBackend.ts
+++ b/src/composables/useBackend.ts
@@ -7,6 +7,7 @@ import {
   type MeetingAudioClip,
 } from './useMeetingApi';
 import { arisoTruthy } from './autoJoin';
+import { isCanceledMeetingStatus } from './meetingStatus';
 
 export type BackendId = 'ariso' | 'local';
 
@@ -58,6 +59,9 @@ export interface MeetingListItem {
   matchedText?: string | null;
   /** Ariso scheduled meetings: Ari is set to auto-join and record server-side. */
   autoJoinScheduled?: boolean;
+  /** Ariso: the meeting was canceled (its calendar event was deleted/canceled).
+   *  Rows stay in the list but are struck through. */
+  canceled?: boolean;
 }
 
 export interface MeetingActionItem {
@@ -106,6 +110,9 @@ export interface MeetingDetail {
   meetingType?: string;
   /** Ariso: Ari is scheduled to auto-join and record this meeting server-side. */
   autoJoinScheduled?: boolean;
+  /** Ariso: the meeting was canceled — the detail panel marks it with a chip
+   *  and suppresses the "Ari will join" tag. */
+  canceled?: boolean;
   /** Whether a transcript exists — drives the Live Transcript tab. Content is
    *  loaded lazily via `getMeetingTranscript`. */
   hasTranscript?: boolean;
@@ -212,6 +219,7 @@ function meetingSummaryToListItem(m: ScheduledMeeting | MeetingSearchResult): Me
     timestamp: m.start_at,
     endTimestamp: m.end_at,
     autoJoinScheduled: arisoTruthy(m.auto_join_scheduled),
+    canceled: isCanceledMeetingStatus(m.status),
   };
   if ('snippet' in m && m.snippet) item.snippet = m.snippet;
   if ('matched_text' in m && m.matched_text) item.matchedText = m.matched_text;
@@ -350,6 +358,9 @@ export class ArisoBackend implements Backend {
       hasIndividualNote: !!data.individual_note?.content,
       isLocal: false,
       autoJoinScheduled: item.autoJoinScheduled ?? false,
+      // The notes payload carries the authoritative status; fall back to the
+      // list row when it's absent so a canceled row stays marked once opened.
+      canceled: data.status != null ? isCanceledMeetingStatus(data.status) : !!item.canceled,
       audioClips: data.audio_clips ?? [],
     };
   }

--- a/src/composables/useMeetingApi.ts
+++ b/src/composables/useMeetingApi.ts
@@ -52,6 +52,9 @@ interface ScheduledMeeting {
   title: string | null;
   start_at: string;
   end_at?: string;
+  /** Lifecycle status ('created' | 'recording' | 'done' | 'cancelled' | …).
+   *  A deleted/canceled calendar event surfaces here as 'cancelled'. */
+  status?: string | null;
   /** Ariso: when truthy, Ari (the notetaker bot) is scheduled to auto-join and
    *  record this meeting server-side. May arrive as bool / 0-1 / "true"-"1". */
   auto_join_scheduled?: boolean | number | string;

--- a/src/views/LibraryView.test.ts
+++ b/src/views/LibraryView.test.ts
@@ -544,6 +544,20 @@ describe('LibraryView', () => {
     expect(row.find('.mi-sub').text()).toContain('min');
   });
 
+  it('strikes through the title of a canceled meeting only', async () => {
+    listMeetings.mockResolvedValue([
+      item({ id: 'a', title: 'Dropped Sync', canceled: true }),
+      item({ id: 'b', title: 'Live Sync' }),
+    ]);
+    const wrapper = mount(LibraryView);
+    await flushPromises();
+    const titles = wrapper.findAll('.mi-title');
+    const canceled = titles.find((t) => t.text() === 'Dropped Sync')!;
+    const live = titles.find((t) => t.text() === 'Live Sync')!;
+    expect(canceled.classes()).toContain('mi-title--canceled');
+    expect(live.classes()).not.toContain('mi-title--canceled');
+  });
+
   it('opens the floating recorder window forcing a new recording when the detail pane is empty', async () => {
     listMeetings.mockResolvedValue([]);
     const wrapper = mount(LibraryView);

--- a/src/views/LibraryView.vue
+++ b/src/views/LibraryView.vue
@@ -96,7 +96,7 @@
           >
             <span v-if="recordingActive && recordingMeetingId === m.id" class="mi-rec-dot" aria-hidden="true" />
             <span class="mi-head">
-              <span class="mi-title">{{ m.title }}</span>
+              <span class="mi-title" :class="{ 'mi-title--canceled': m.canceled }">{{ m.title }}</span>
               <span v-if="relLabel(m)" class="mi-rel" :class="{ 'mi-rel--now': isNextNow(m) }">{{ relLabel(m) }}</span>
             </span>
             <span class="mi-sub" :class="{ 'mi-sub--now': isNextNow(m) }">{{ subFor(m) }}</span>
@@ -1080,6 +1080,12 @@ onUnmounted(() => {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+/* Canceled meetings stay in the list (for context) but read as struck out,
+   matching how the web app renders a canceled meeting's title. */
+.mi-title--canceled {
+  text-decoration: line-through;
+  color: #8a8a8a;
 }
 .mi-rel { flex-shrink: 0; font-size: 11px; font-weight: 600; letter-spacing: 0.3px; color: #6f6f6f; }
 .mi-rel--now { color: #2e8b4f; }

--- a/src/views/MeetingCanceledTag.test.ts
+++ b/src/views/MeetingCanceledTag.test.ts
@@ -1,0 +1,11 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import MeetingCanceledTag from './MeetingCanceledTag.vue';
+
+describe('MeetingCanceledTag', () => {
+  it('renders the "Canceled" label', () => {
+    const wrapper = mount(MeetingCanceledTag);
+    expect(wrapper.text()).toContain('Canceled');
+  });
+});

--- a/src/views/MeetingCanceledTag.vue
+++ b/src/views/MeetingCanceledTag.vue
@@ -1,0 +1,30 @@
+<template>
+  <span class="canceled-tag" title="This meeting was canceled">
+    <svg class="canceled-tag__icon" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+      <circle cx="8" cy="8" r="6" stroke="currentColor" stroke-width="1.6" />
+      <path d="M4.6 11.4 11.4 4.6" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" />
+    </svg>
+    <span>Canceled</span>
+  </span>
+</template>
+
+<script setup lang="ts"></script>
+
+<style scoped>
+.canceled-tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: #fef2f2;
+  color: #b91c1c;
+  font-size: 12px;
+  font-weight: 600;
+  white-space: nowrap;
+}
+.canceled-tag__icon {
+  width: 12px;
+  height: 12px;
+}
+</style>

--- a/src/views/MeetingDetailView.test.ts
+++ b/src/views/MeetingDetailView.test.ts
@@ -74,6 +74,9 @@ async function mountWith(d: MeetingDetail) {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  // clearAllMocks keeps queued `mockResolvedValueOnce` implementations, so an
+  // unconsumed one would answer the next test's first detail load.
+  getMeetingDetail.mockReset();
   renameMeeting.mockResolvedValue(undefined);
   getMeetingTranscript.mockResolvedValue(null);
   getMeetingAudio.mockResolvedValue(null);
@@ -1099,5 +1102,30 @@ describe('MeetingDetailView per-clip delete', () => {
     // c2 stays active/showing, rather than snapping back to the (now sole) first clip.
     expect(wrapper.text()).toContain('from clip two');
     expect(wrapper.text()).not.toContain('from clip one');
+  });
+});
+
+describe('MeetingDetailView canceled meetings', () => {
+  it('marks a canceled meeting with a chip', async () => {
+    const wrapper = await mountWith(detail({ canceled: true }));
+    expect(wrapper.find('.canceled-tag').exists()).toBe(true);
+    expect(wrapper.find('.canceled-tag').text()).toContain('Canceled');
+  });
+
+  it('hides the "Ari will join" tag on a canceled meeting', async () => {
+    const wrapper = await mountWith(detail({ canceled: true, autoJoinScheduled: true }));
+    expect(wrapper.find('.ari-tag').exists()).toBe(false);
+    expect(wrapper.find('.canceled-tag').exists()).toBe(true);
+  });
+
+  it('still shows the "Ari will join" tag on a live meeting', async () => {
+    const wrapper = await mountWith(detail({ autoJoinScheduled: true }));
+    expect(wrapper.find('.ari-tag').exists()).toBe(true);
+    expect(wrapper.find('.canceled-tag').exists()).toBe(false);
+  });
+
+  it('shows no canceled chip for a normal meeting', async () => {
+    const wrapper = await mountWith(detail());
+    expect(wrapper.find('.canceled-tag').exists()).toBe(false);
   });
 });

--- a/src/views/MeetingDetailView.vue
+++ b/src/views/MeetingDetailView.vue
@@ -124,7 +124,10 @@
         <span v-if="detail.meetingType" class="chip">
           <span class="chip-hash">#</span>{{ formatType(detail.meetingType) }}
         </span>
-        <AriWillJoinTag v-if="detail?.autoJoinScheduled" class="meta-ari" />
+        <!-- A canceled meeting is marked as such, and never advertises Ari's
+             auto-join: the bot won't join a meeting that isn't happening. -->
+        <MeetingCanceledTag v-if="detail?.canceled" class="meta-canceled" />
+        <AriWillJoinTag v-else-if="detail?.autoJoinScheduled" class="meta-ari" />
       </div>
 
       <div v-else class="divider" />
@@ -357,6 +360,7 @@ import {
   type MeetingCoaching,
 } from '../composables/useBackend';
 import AriWillJoinTag from './AriWillJoinTag.vue';
+import MeetingCanceledTag from './MeetingCanceledTag.vue';
 import MeetingNotesEditor from './MeetingNotesEditor.vue';
 import RecordingAudioPlayer from './RecordingAudioPlayer.vue';
 import RecordingDeleteConfirmDialog from './RecordingDeleteConfirmDialog.vue';
@@ -1101,7 +1105,14 @@ const hasCoaching = computed(() => {
 // The meta band (duration · attendees · category) renders only when at least
 // one of its fields is present; otherwise a plain divider separates header and tabs.
 const hasMeta = computed(
-  () => !!(durationLabel.value || detail.value?.participants.length || detail.value?.meetingType || detail.value?.autoJoinScheduled)
+  () =>
+    !!(
+      durationLabel.value ||
+      detail.value?.participants.length ||
+      detail.value?.meetingType ||
+      detail.value?.autoJoinScheduled ||
+      detail.value?.canceled
+    )
 );
 
 const otesEmpty = computed(() => {
@@ -1271,7 +1282,7 @@ const durationLabel = computed<string | null>(() => {
 
 /* Meta band — full-bleed strip below the header (Figma 2827:34384) */
 .card-meta { display: flex; flex-wrap: wrap; align-items: center; gap: 16px; padding: 11px 24px; background: #f7f6f4; border-bottom: 1px solid #e5e6e3; font-size: 14px; }
-.meta-ari { margin-left: auto; }
+.meta-ari, .meta-canceled { margin-left: auto; }
 .card-audio { display: flex; flex-direction: column; gap: 8px; padding: 0 0 12px; }
 .clip-row { display: flex; align-items: center; gap: 12px; padding: 6px 8px; border-radius: 8px; cursor: pointer; }
 .clip-row--active { background: #f7f6f4; }


### PR DESCRIPTION
## What does this PR do?

Deleted/canceled calendar events currently show up in the desktop app as ordinary meetings with empty notes — indistinguishable from live ones — and they even take over the menu bar. This makes them legible instead.

Closes #264.

The backend normalizes a deleted or canceled calendar event into `status: 'cancelled'` (`meeting-service`'s `handleCancelledEvent`), and both `GET /meetings` and `GET /meeting-notes/:id` already return it — the desktop just never read the field.

- **List view** — a canceled meeting keeps its place in the sidebar (useful for context) but its title renders struck through and greyed, matching how the web app's `MeetingRow.vue` renders one.
- **Detail panel** — shows a red "Canceled" chip in the meta band, and suppresses the "Ari will join" tag: the notetaker won't join a meeting that isn't happening.
- **Menu bar** — canceled meetings are filtered out of the tray orchestrator's meeting list at parse time, so they can no longer be featured as `test oats in 10min` or `test oats now`, and they no longer occupy the tray's meeting row.

Implementation notes: `status` is plumbed through as a dedicated `canceled` boolean on `MeetingListItem` / `MeetingDetail` rather than reusing `MeetingListItem.status`, which already carries local-recording state. The match lives in one helper per side — `isCanceledMeetingStatus` (frontend) and `is_cancelled_status` (Rust) — both accepting the American spelling and stray case so a payload variation can't silently render a canceled meeting as live.

## Type of change

- [x] `fix:` — bug fix
- [ ] `feat:` — new feature
- [ ] `feat!:` / `BREAKING CHANGE:` — breaking change
- [ ] `docs:` / `chore:` / `refactor:` — no user-facing release

## How was this tested?

**Automated** — `npm test`: 52 files / 573 tests green, including 11 new ones (status helper, chip component, list strike-through, detail chip + Ari-tag suppression, and the `useBackend` payload mapping). Rust: 262 passed / 3 ignored, with 2 new tests covering the tray filter. While adding the detail tests I also fixed a latent leak in `MeetingDetailView.test.ts` — `vi.clearAllMocks()` does not drain queued `mockResolvedValueOnce` implementations, so an unconsumed one was bleeding into the next test's first detail load.

**Manually, against the Ariso backend on macOS**, using a real canceled meeting (a calendar event deleted by its organizer, synced back as `status: 'cancelled'`) rather than stubbed data:

- The row rendered struck through — the only struck row among 33 meetings, with the other 32 untouched.
- Opening it produced `{ canceled: true }` from the live `/meeting-notes/:id` payload and rendered the Canceled chip.
- Menu bar before the fix: `test oats now`. After: `morning wo… in 9h51min` — the canceled meeting is skipped and the next real meeting is featured.

Ari-tag suppression could not be produced from a server payload (inviting Ari rewrites `'cancelled'` → `'created'`, so canceled + auto-join is unreachable server-side); it was verified by toggling the flags on the live component in the running app, plus unit tests.

## Screenshots / recordings

Not attached — `gh` can't upload images. Happy to add before/after captures of the struck-through row and the Canceled chip if wanted.

## Known gaps (deliberately out of scope)

Two surfaces still treat a canceled meeting as live, both one-line filters of the same shape if reviewers want them here instead of a follow-up:

- `UpNextCard` features it on the home screen with a *Start Meeting Early* button and no strike-through.
- `current_meeting_title_from` / `current_meeting_auto_join_from` (`src-tauri/src/meeting_notifications.rs`) pick "the meeting happening right now" by start time alone, so a canceled meeting can still name the auto-record prompt.

## Checklist

- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I ran `npm test` and the suite passes
- [x] I tested the change in the app (Ariso backend, macOS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Canceled meetings are now clearly identified throughout the app.
  - Added a “Canceled” label to meeting details.
  - Canceled meeting titles are shown with muted, struck-through styling.
  - Automatic join messaging is hidden for canceled meetings.

- **Bug Fixes**
  - Canceled meetings no longer appear in tray countdowns or titles.
  - Cancellation status is recognized consistently across supported spelling, casing, and whitespace variations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->