### PR TITLE
fix: make ari will join chip conditional

### DIFF
--- a/src/composables/meetingStatus.test.ts
+++ b/src/composables/meetingStatus.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { isCanceledMeetingStatus } from './meetingStatus';
+import { ariJoinChip, isCanceledMeetingStatus } from './meetingStatus';
 
 describe('isCanceledMeetingStatus', () => {
   it('matches the backend spelling', () => {
@@ -23,5 +23,83 @@ describe('isCanceledMeetingStatus', () => {
     expect(isCanceledMeetingStatus(undefined)).toBe(false);
     expect(isCanceledMeetingStatus(1)).toBe(false);
     expect(isCanceledMeetingStatus({})).toBe(false);
+  });
+});
+
+describe('ariJoinChip', () => {
+  const NOW = new Date('2026-06-16T12:00:00Z');
+  // A meeting running right now: started at 11:45, ends at 12:30.
+  const running = {
+    autoJoinScheduled: true,
+    startAt: '2026-06-16T11:45:00Z',
+    endAt: '2026-06-16T12:30:00Z',
+  };
+
+  it('promises the join for a meeting that has not started', () => {
+    expect(
+      ariJoinChip(
+        { autoJoinScheduled: true, startAt: '2026-06-16T13:00:00Z', endAt: '2026-06-16T13:30:00Z' },
+        NOW
+      )
+    ).toBe('will-join');
+  });
+
+  it('switches to joined once Ari is in a running meeting', () => {
+    expect(ariJoinChip({ ...running, status: 'joined' }, NOW)).toBe('joined');
+  });
+
+  it('tolerates case and padding on the joined status', () => {
+    expect(ariJoinChip({ ...running, status: ' Joined ' }, NOW)).toBe('joined');
+  });
+
+  it('keeps the promise for a running meeting Ari has not joined yet', () => {
+    expect(ariJoinChip({ ...running, status: 'joining' }, NOW)).toBe('will-join');
+  });
+
+  it('does not claim Ari joined before the meeting starts', () => {
+    expect(
+      ariJoinChip(
+        {
+          autoJoinScheduled: true,
+          status: 'joined',
+          startAt: '2026-06-16T13:00:00Z',
+          endAt: '2026-06-16T13:30:00Z',
+        },
+        NOW
+      )
+    ).toBe('will-join');
+  });
+
+  it('shows no chip once the meeting has ended', () => {
+    expect(
+      ariJoinChip(
+        {
+          autoJoinScheduled: true,
+          status: 'joined',
+          startAt: '2026-06-16T10:00:00Z',
+          endAt: '2026-06-16T11:00:00Z',
+        },
+        NOW
+      )
+    ).toBeNull();
+  });
+
+  it('shows no chip for a meeting the backend marked done', () => {
+    expect(ariJoinChip({ ...running, status: 'done' }, NOW)).toBeNull();
+  });
+
+  it('shows no chip for a canceled or non-auto-join meeting', () => {
+    expect(ariJoinChip({ ...running, status: 'cancelled' }, NOW)).toBeNull();
+    expect(ariJoinChip({ ...running, autoJoinScheduled: false }, NOW)).toBeNull();
+    expect(ariJoinChip({}, NOW)).toBeNull();
+  });
+
+  it('keeps the chip when the end time is missing or unparseable', () => {
+    expect(ariJoinChip({ autoJoinScheduled: true, startAt: '2026-06-16T11:45:00Z' }, NOW)).toBe(
+      'will-join'
+    );
+    expect(
+      ariJoinChip({ ...running, status: 'joined', endAt: 'not-a-date' }, NOW)
+    ).toBe('joined');
   });
 });

--- a/src/composables/meetingStatus.ts
+++ b/src/composables/meetingStatus.ts
@@ -11,3 +11,64 @@ export function isCanceledMeetingStatus(status: unknown): boolean {
   const s = status.trim().toLowerCase();
   return s === 'cancelled' || s === 'canceled';
 }
+
+function statusIs(status: unknown, want: string): boolean {
+  return typeof status === 'string' && status.trim().toLowerCase() === want;
+}
+
+/** Ari (the notetaker bot) is in the meeting right now. */
+export function isJoinedMeetingStatus(status: unknown): boolean {
+  return statusIs(status, 'joined');
+}
+
+/** The meeting is over as far as the backend is concerned. */
+export function isDoneMeetingStatus(status: unknown): boolean {
+  return statusIs(status, 'done');
+}
+
+/** Which Ari chip a meeting should show: none, the scheduled promise, or the
+ *  present-tense "Ari has joined". */
+export type AriJoinChip = 'will-join' | 'joined' | null;
+
+export interface AriJoinChipInput {
+  /** Ari is scheduled to auto-join and record this meeting server-side. */
+  autoJoinScheduled?: boolean;
+  /** Ariso lifecycle status ('created' | 'joined' | 'done' | 'cancelled' | …). */
+  status?: string | null;
+  startAt?: string | null;
+  endAt?: string | null;
+}
+
+function toMs(iso: string | null | undefined): number | null {
+  if (!iso) return null;
+  const t = new Date(iso).getTime();
+  return Number.isNaN(t) ? null : t;
+}
+
+/**
+ * Decide the Ari chip for a meeting.
+ *
+ * Once the meeting is over — its end time has passed, or the backend moved it
+ * to `done` — the chip disappears entirely: a promise about the future reads as
+ * wrong on a finished meeting. While the meeting is running and Ari has
+ * actually joined, the chip switches to the present tense. Everything else
+ * (canceled meetings, meetings with no auto-join) is handled by the callers'
+ * own chips or shows the plain "Ari will join".
+ *
+ * A meeting with no parsable end time is never treated as ended — calendar
+ * meetings always carry one, and guessing would hide the chip mid-meeting.
+ */
+export function ariJoinChip(meeting: AriJoinChipInput, now: Date): AriJoinChip {
+  if (!meeting.autoJoinScheduled) return null;
+  if (isCanceledMeetingStatus(meeting.status)) return null;
+  if (isDoneMeetingStatus(meeting.status)) return null;
+
+  const t = now.getTime();
+  const end = toMs(meeting.endAt);
+  if (end !== null && end <= t) return null;
+
+  const start = toMs(meeting.startAt);
+  const started = start !== null && start <= t;
+  if (started && isJoinedMeetingStatus(meeting.status)) return 'joined';
+  return 'will-join';
+}

--- a/src/composables/useBackend.ts
+++ b/src/composables/useBackend.ts
@@ -65,6 +65,9 @@ export interface MeetingListItem {
   /** Ariso: the meeting was canceled (its calendar event was deleted/canceled).
    *  Rows stay in the list but are struck through. */
   canceled?: boolean;
+  /** Ariso: raw lifecycle status ('created' | 'joined' | 'done' | 'cancelled' |
+   *  …). Kept alongside `canceled` because the Ari chip keys off more of it. */
+  arisoStatus?: string;
 }
 
 export interface MeetingActionItem {
@@ -119,6 +122,9 @@ export interface MeetingDetail {
   /** Ariso: the meeting was canceled — the detail panel marks it with a chip
    *  and suppresses the "Ari will join" tag. */
   canceled?: boolean;
+  /** Ariso: raw lifecycle status — drives the Ari chip ("will join" vs
+   *  "has joined" vs nothing once the meeting is done). */
+  arisoStatus?: string;
   /** Whether a transcript exists — drives the Live Transcript tab. Content is
    *  loaded lazily via `getMeetingTranscript`. */
   hasTranscript?: boolean;
@@ -230,6 +236,7 @@ function meetingSummaryToListItem(m: ScheduledMeeting | MeetingSearchResult): Me
     endTimestamp: m.end_at,
     autoJoinScheduled: arisoTruthy(m.auto_join_scheduled),
     canceled: isCanceledMeetingStatus(m.status),
+    arisoStatus: typeof m.status === 'string' ? m.status : undefined,
   };
   if ('snippet' in m && m.snippet) item.snippet = m.snippet;
   if ('matched_text' in m && m.matched_text) item.matchedText = m.matched_text;
@@ -375,6 +382,7 @@ export class ArisoBackend implements Backend {
       // The notes payload carries the authoritative status; fall back to the
       // list row when it's absent so a canceled row stays marked once opened.
       canceled: data.status != null ? isCanceledMeetingStatus(data.status) : !!item.canceled,
+      arisoStatus: typeof data.status === 'string' ? data.status : item.arisoStatus,
       audioClips: data.audio_clips ?? [],
     };
   }

--- a/src/views/AriWillJoinTag.test.ts
+++ b/src/views/AriWillJoinTag.test.ts
@@ -7,5 +7,14 @@ describe('AriWillJoinTag', () => {
   it('renders the "Ari will join" label', () => {
     const wrapper = mount(AriWillJoinTag);
     expect(wrapper.text()).toContain('Ari will join');
+    expect(wrapper.find('.ari-tag--joined').exists()).toBe(false);
+  });
+
+  it('renders the present tense once Ari has joined', () => {
+    const wrapper = mount(AriWillJoinTag, { props: { joined: true } });
+    expect(wrapper.text()).toContain('Ari has joined');
+    expect(wrapper.text()).not.toContain('will join');
+    expect(wrapper.find('.ari-tag--joined').exists()).toBe(true);
+    expect(wrapper.find('.ari-tag').attributes('title')).toContain('has joined');
   });
 });

--- a/src/views/AriWillJoinTag.vue
+++ b/src/views/AriWillJoinTag.vue
@@ -1,13 +1,26 @@
 <template>
-  <span class="ari-tag" title="Ari (the notetaker) is scheduled to join this meeting">
+  <span class="ari-tag" :class="{ 'ari-tag--joined': joined }" :title="title">
     <svg class="ari-tag__icon" viewBox="0 0 16 16" fill="none" aria-hidden="true">
       <path d="M8 1.5 9.6 6 14 8 9.6 10 8 14.5 6.4 10 2 8l4.4-2L8 1.5Z" fill="currentColor" />
     </svg>
-    <span>Ari will join</span>
+    <span>{{ label }}</span>
   </span>
 </template>
 
-<script setup lang="ts"></script>
+<script setup lang="ts">
+import { computed } from 'vue';
+
+// `joined` flips the chip to the present tense once Ari is actually in the
+// meeting; callers decide that from the meeting's status via `ariJoinChip`.
+const props = defineProps<{ joined?: boolean }>();
+
+const label = computed(() => (props.joined ? 'Ari has joined' : 'Ari will join'));
+const title = computed(() =>
+  props.joined
+    ? 'Ari (the notetaker) has joined this meeting'
+    : 'Ari (the notetaker) is scheduled to join this meeting'
+);
+</script>
 
 <style scoped>
 .ari-tag {
@@ -21,6 +34,12 @@
   font-size: 12px;
   font-weight: 600;
   white-space: nowrap;
+}
+/* Ari is in the meeting: green reads as "live/active" next to the indigo
+   "scheduled" state, matching the canceled chip's colour-per-state pattern. */
+.ari-tag--joined {
+  background: #ecfdf5;
+  color: #047857;
 }
 .ari-tag__icon {
   width: 12px;

--- a/src/views/LibraryView.vue
+++ b/src/views/LibraryView.vue
@@ -132,6 +132,7 @@
           v-if="selectedItem"
           ref="detailView"
           :item="selectedItem"
+          :now="now"
           @close="clearSelection"
           @title-updated="onTitleUpdated"
         />

--- a/src/views/MeetingDetailView.test.ts
+++ b/src/views/MeetingDetailView.test.ts
@@ -1346,3 +1346,47 @@ describe('MeetingDetailView canceled meetings', () => {
     expect(wrapper.find('.canceled-tag').exists()).toBe(false);
   });
 });
+
+describe('MeetingDetailView Ari chip', () => {
+  const NOW = new Date('2026-06-16T12:00:00Z');
+  // Started at 11:45, ends at 12:30 — running as of NOW.
+  const running = {
+    autoJoinScheduled: true,
+    startAt: '2026-06-16T11:45:00Z',
+    endAt: '2026-06-16T12:30:00Z',
+  };
+
+  async function mountAt(d: MeetingDetail, now = NOW) {
+    getMeetingDetail.mockResolvedValue(d);
+    const wrapper = mount(MeetingDetailView, { props: { item, now } });
+    await flushPromises();
+    return wrapper;
+  }
+
+  it('says Ari has joined for a running meeting whose status is joined', async () => {
+    const wrapper = await mountAt(detail({ ...running, arisoStatus: 'joined' }));
+    expect(wrapper.find('.ari-tag').text()).toContain('Ari has joined');
+  });
+
+  it('keeps the promise while the meeting is running but Ari has not joined', async () => {
+    const wrapper = await mountAt(detail({ ...running, arisoStatus: 'joining' }));
+    expect(wrapper.find('.ari-tag').text()).toContain('Ari will join');
+  });
+
+  it('drops the chip once the meeting has ended', async () => {
+    const wrapper = await mountAt(
+      detail({
+        autoJoinScheduled: true,
+        arisoStatus: 'joined',
+        startAt: '2026-06-16T10:00:00Z',
+        endAt: '2026-06-16T11:00:00Z',
+      })
+    );
+    expect(wrapper.find('.ari-tag').exists()).toBe(false);
+  });
+
+  it('drops the chip once the meeting is done', async () => {
+    const wrapper = await mountAt(detail({ ...running, arisoStatus: 'done' }));
+    expect(wrapper.find('.ari-tag').exists()).toBe(false);
+  });
+});

--- a/src/views/MeetingDetailView.vue
+++ b/src/views/MeetingDetailView.vue
@@ -127,7 +127,7 @@
         <!-- A canceled meeting is marked as such, and never advertises Ari's
              auto-join: the bot won't join a meeting that isn't happening. -->
         <MeetingCanceledTag v-if="detail?.canceled" class="meta-canceled" />
-        <AriWillJoinTag v-else-if="detail?.autoJoinScheduled" class="meta-ari" />
+        <AriWillJoinTag v-else-if="ariChip" :joined="ariChip === 'joined'" class="meta-ari" />
       </div>
 
       <div v-else class="divider" />
@@ -376,10 +376,13 @@ import RecordingDeleteConfirmDialog from './RecordingDeleteConfirmDialog.vue';
 import ShareMeetingPopover from './ShareMeetingPopover.vue';
 import { composeLocalShareText } from './meetingShareText';
 import { shareTextNative, local } from '../tauri';
+import { ariJoinChip } from '../composables/meetingStatus';
 import { useLocalRecordingProgress } from '../composables/useLocalRecordingProgress';
 import { loadPlatformCapabilities } from '../composables/usePlatformCapabilities';
 
-const props = defineProps<{ item: MeetingListItem | null }>();
+// `now` is the parent's ticking clock — it lets the Ari chip retire itself when
+// the meeting's end time passes. Absent, the chip is evaluated once at render.
+const props = defineProps<{ item: MeetingListItem | null; now?: Date }>();
 const emit = defineEmits<{
   close: [];
   titleUpdated: [payload: { id: string; title: string }];
@@ -389,6 +392,20 @@ const loading = ref(false);
 const error = ref<string | null>(null);
 const detail = ref<MeetingDetail | null>(null);
 const showFullNotes = ref(false);
+
+// "Ari will join" while the meeting is still ahead, "Ari has joined" once the
+// bot is in a running meeting, and no chip at all once the meeting is over.
+const ariChip = computed(() =>
+  ariJoinChip(
+    {
+      autoJoinScheduled: detail.value?.autoJoinScheduled,
+      status: detail.value?.arisoStatus,
+      startAt: detail.value?.startAt,
+      endAt: detail.value?.endAt,
+    },
+    props.now ?? new Date()
+  )
+);
 type TabKey = 'note' | 'transcript' | 'mynote' | 'prep' | 'assessment';
 const activeTab = ref<TabKey>('note');
 

--- a/src/views/UpNextCard.test.ts
+++ b/src/views/UpNextCard.test.ts
@@ -211,3 +211,31 @@ describe('UpNextCard', () => {
     expect(rows.map((r) => r.find('.row-title').text())).toEqual(['Standup', 'Sync']);
   });
 });
+
+describe('UpNextCard Ari chip', () => {
+  // In progress at NOW (12:00Z), so the "started but not ended" branch applies.
+  const running = {
+    id: 'live',
+    timestamp: '2026-06-16T11:45:00Z',
+    endTimestamp: '2026-06-16T12:30:00Z',
+    autoJoinScheduled: true,
+  };
+
+  it('promises the join for an upcoming meeting', async () => {
+    const wrapper = mountCard([meeting({ autoJoinScheduled: true })]);
+    await flushPromises();
+    expect(wrapper.find('.ari-tag').text()).toContain('Ari will join');
+  });
+
+  it('says Ari has joined once the running meeting reports it', async () => {
+    const wrapper = mountCard([meeting({ ...running, arisoStatus: 'joined' })]);
+    await flushPromises();
+    expect(wrapper.find('.ari-tag').text()).toContain('Ari has joined');
+  });
+
+  it('drops the chip for a meeting the backend marked done', async () => {
+    const wrapper = mountCard([meeting({ ...running, arisoStatus: 'done' })]);
+    await flushPromises();
+    expect(wrapper.find('.ari-tag').exists()).toBe(false);
+  });
+});

--- a/src/views/UpNextCard.vue
+++ b/src/views/UpNextCard.vue
@@ -70,7 +70,7 @@
               >{{ featured.title }}</button>
             </div>
             <div
-              v-if="attendees.length || featured.autoJoinScheduled"
+              v-if="attendees.length || ariChip"
               class="head-right"
             >
               <div v-if="attendees.length" class="avatars">
@@ -91,7 +91,7 @@
                 </template>
                 <span v-if="attendees.length > 3" class="avatar avatar--more">+{{ attendees.length - 3 }}</span>
               </div>
-              <AriWillJoinTag v-if="featured.autoJoinScheduled" />
+              <AriWillJoinTag v-if="ariChip" :joined="ariChip === 'joined'" />
             </div>
           </div>
           <div class="head-actions">
@@ -152,6 +152,7 @@ import {
   type MeetingListItem,
   type MeetingParticipantInfo,
 } from '../composables/useBackend';
+import { ariJoinChip } from '../composables/meetingStatus';
 import {
   groupTodaysMeetings,
   nextDaySection,
@@ -237,6 +238,22 @@ const safeIndex = computed(() =>
 const featured = computed<MeetingListItem | null>(() => upcoming.value[safeIndex.value] ?? null);
 const featuredRel = computed(() =>
   featured.value ? upcomingRelLabel(featured.value, props.now).replace(/^in /, '') : ''
+);
+
+// Ari's chip for the featured meeting: the scheduled promise until Ari is in
+// the meeting, then "Ari has joined", then nothing once the meeting is over.
+const ariChip = computed(() =>
+  featured.value
+    ? ariJoinChip(
+        {
+          autoJoinScheduled: featured.value.autoJoinScheduled,
+          status: featured.value.arisoStatus,
+          startAt: featured.value.timestamp,
+          endAt: featured.value.endTimestamp,
+        },
+        props.now
+      )
+    : null
 );
 
 // Everything after the featured meeting fills the list, capped with a "N more…"


### PR DESCRIPTION

<img width="604" height="374" alt="Screenshot 2026-07-29 at 22 00 19" src="https://github.com/user-attachments/assets/d49e489d-260f-449f-9909-a2073255cdfa" />

<!--
Thanks for contributing to oats! A few quick things before you open this PR.
See CONTRIBUTING.md for the full guide.
-->

## What does this PR do?

<!-- A short summary of the change and the problem it solves. Link any related issue, e.g. "Closes #123". -->

- for meeting already ended - no "Ari will join" chip
- for meeting already started - if Ari has join, show "Ari has joined"

## Type of change

<!-- Releases are automated by release-please from your commit messages. -->
<!-- Make sure your PR title / commits follow Conventional Commits: -->
<!--   feat: ...        → minor bump        fix: ...   → patch bump -->
<!--   feat!: / BREAKING CHANGE: → major bump   chore/docs/refactor: → no release -->

- [ ] `fix:` — bug fix
- [x] `feat:` — new feature
- [ ] `feat!:` / `BREAKING CHANGE:` — breaking change
- [ ] `docs:` / `chore:` / `refactor:` — no user-facing release

## How was this tested?

<!-- Did you run the frontend tests (`npm test`)? Test manually with which backend (Ariso / Local)? On which OS/platform? -->

manually tested with meetings that ended/under-going.

## Screenshots / recordings

<!-- For any UI change, drop a before/after screenshot or short clip here. -->

## Checklist

- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I ran `npm test` and the suite passes
- [x] I tested the change in the app (note which backend above)
