### PR TITLE
fix(windows): bundle Visual C++ runtime app-local

### DIFF
--- a/.github/workflows/desktop.yaml
+++ b/.github/workflows/desktop.yaml
@@ -136,7 +136,8 @@ jobs:
           path: |
             src-tauri/binaries/ariso-stt-x86_64-pc-windows-msvc.exe
             src-tauri/binaries/llama
-          key: ariso-stt-windows-x64-${{ steps.windows-toolchain.outputs.version }}-${{ hashFiles('src-tauri/ariso-stt/windows/Cargo.lock', 'src-tauri/ariso-stt/windows/Cargo.toml', 'src-tauri/ariso-stt/windows/src/**', 'src-tauri/ariso-stt/shared/**', 'scripts/build-windows-sidecar.ps1', 'scripts/prepare-windows-llama-runtime.ps1', 'scripts/import-windows-build-env.ps1') }}
+            src-tauri/binaries/windows-runtime
+          key: ariso-stt-windows-x64-${{ steps.windows-toolchain.outputs.version }}-${{ hashFiles('src-tauri/ariso-stt/windows/Cargo.lock', 'src-tauri/ariso-stt/windows/Cargo.toml', 'src-tauri/ariso-stt/windows/src/**', 'src-tauri/ariso-stt/shared/**', 'scripts/build-windows-sidecar.ps1', 'scripts/prepare-windows-llama-runtime.ps1', 'scripts/prepare-windows-vc-runtime.ps1', 'scripts/import-windows-build-env.ps1') }}
 
       # Exercise the sidecar's shared CLI/JSON contract before its release
       # binary is copied into Tauri's externalBin location.
@@ -154,6 +155,16 @@ jobs:
         if: runner.os == 'Windows' && steps.windows-sidecar-cache.outputs.cache-hit != 'true'
         shell: pwsh
         run: ./scripts/build-windows-sidecar.ps1
+
+      - name: Verify Windows app-local Visual C++ runtime
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          ./scripts/verify-windows-vc-runtime.ps1 `
+            -RootRuntimeDirectory src-tauri/binaries/windows-runtime `
+            -LlamaRuntimeDirectory src-tauri/binaries/llama `
+            -SidecarPath src-tauri/binaries/ariso-stt-x86_64-pc-windows-msvc.exe `
+            -LlamaServerPath src-tauri/binaries/llama/llama-server.exe
 
       # Host tests mutate process-scoped test overrides, so keep them serial on
       # Windows while exercising the same target that Tauri packages.

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -281,12 +281,22 @@ jobs:
           path: |
             src-tauri/binaries/ariso-stt-x86_64-pc-windows-msvc.exe
             src-tauri/binaries/llama
-          key: ariso-stt-windows-x64-${{ steps.windows-toolchain.outputs.version }}-${{ hashFiles('src-tauri/ariso-stt/windows/Cargo.lock', 'src-tauri/ariso-stt/windows/Cargo.toml', 'src-tauri/ariso-stt/windows/src/**', 'src-tauri/ariso-stt/shared/**', 'scripts/build-windows-sidecar.ps1', 'scripts/prepare-windows-llama-runtime.ps1', 'scripts/import-windows-build-env.ps1') }}
+            src-tauri/binaries/windows-runtime
+          key: ariso-stt-windows-x64-${{ steps.windows-toolchain.outputs.version }}-${{ hashFiles('src-tauri/ariso-stt/windows/Cargo.lock', 'src-tauri/ariso-stt/windows/Cargo.toml', 'src-tauri/ariso-stt/windows/src/**', 'src-tauri/ariso-stt/shared/**', 'scripts/build-windows-sidecar.ps1', 'scripts/prepare-windows-llama-runtime.ps1', 'scripts/prepare-windows-vc-runtime.ps1', 'scripts/import-windows-build-env.ps1') }}
 
       - name: Build Windows sidecar and executable resources
         if: steps.windows-sidecar-cache.outputs.cache-hit != 'true'
         shell: pwsh
         run: ./scripts/build-windows-sidecar.ps1
+
+      - name: Verify app-local Visual C++ runtime
+        shell: pwsh
+        run: |
+          ./scripts/verify-windows-vc-runtime.ps1 `
+            -RootRuntimeDirectory src-tauri/binaries/windows-runtime `
+            -LlamaRuntimeDirectory src-tauri/binaries/llama `
+            -SidecarPath src-tauri/binaries/ariso-stt-x86_64-pc-windows-msvc.exe `
+            -LlamaServerPath src-tauri/binaries/llama/llama-server.exe
 
       # Pin the reviewed SSL.com action. This invocation only installs and
       # configures CodeSignTool; Tauri calls our secret-safe wrapper once for
@@ -432,12 +442,22 @@ jobs:
           path: |
             src-tauri/binaries/ariso-stt-x86_64-pc-windows-msvc.exe
             src-tauri/binaries/llama
-          key: ariso-stt-windows-x64-${{ steps.windows-toolchain.outputs.version }}-${{ hashFiles('src-tauri/ariso-stt/windows/Cargo.lock', 'src-tauri/ariso-stt/windows/Cargo.toml', 'src-tauri/ariso-stt/windows/src/**', 'src-tauri/ariso-stt/shared/**', 'scripts/build-windows-sidecar.ps1', 'scripts/prepare-windows-llama-runtime.ps1', 'scripts/import-windows-build-env.ps1') }}
+            src-tauri/binaries/windows-runtime
+          key: ariso-stt-windows-x64-${{ steps.windows-toolchain.outputs.version }}-${{ hashFiles('src-tauri/ariso-stt/windows/Cargo.lock', 'src-tauri/ariso-stt/windows/Cargo.toml', 'src-tauri/ariso-stt/windows/src/**', 'src-tauri/ariso-stt/shared/**', 'scripts/build-windows-sidecar.ps1', 'scripts/prepare-windows-llama-runtime.ps1', 'scripts/prepare-windows-vc-runtime.ps1', 'scripts/import-windows-build-env.ps1') }}
 
       - name: Build Windows sidecar and executable resources
         if: steps.windows-sidecar-cache.outputs.cache-hit != 'true'
         shell: pwsh
         run: ./scripts/build-windows-sidecar.ps1
+
+      - name: Verify app-local Visual C++ runtime
+        shell: pwsh
+        run: |
+          ./scripts/verify-windows-vc-runtime.ps1 `
+            -RootRuntimeDirectory src-tauri/binaries/windows-runtime `
+            -LlamaRuntimeDirectory src-tauri/binaries/llama `
+            -SidecarPath src-tauri/binaries/ariso-stt-x86_64-pc-windows-msvc.exe `
+            -LlamaServerPath src-tauri/binaries/llama/llama-server.exe
 
       - name: Cache Windows Rust release dependencies
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
@@ -484,6 +504,10 @@ jobs:
               throw "Expected unsigned installer '$($installer.Name)', found $($signature.SignatureType)."
             }
           }
+
+          ./scripts/verify-windows-installer-runtime.ps1 `
+            -NsisInstallerPath $nsis[0].FullName `
+            -MsiInstallerPath $msi[0].FullName
 
       - name: Upload unsigned Windows installers
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1

--- a/scripts/build-windows-installers.ps1
+++ b/scripts/build-windows-installers.ps1
@@ -51,6 +51,12 @@ try {
   Import-WindowsBuildEnvironment
   $env:RUSTUP_TOOLCHAIN = $Toolchain
 
+  & (Join-Path $PSScriptRoot "verify-windows-vc-runtime.ps1") `
+    -RootRuntimeDirectory (Join-Path $Root "src-tauri\binaries\windows-runtime") `
+    -LlamaRuntimeDirectory (Join-Path $Root "src-tauri\binaries\llama") `
+    -SidecarPath (Join-Path $Root "src-tauri\binaries\ariso-stt-$Target.exe") `
+    -LlamaServerPath (Join-Path $Root "src-tauri\binaries\llama\llama-server.exe")
+
   $effectiveConfig = if ($TauriConfig) {
     (Resolve-Path -LiteralPath $TauriConfig).Path
   } else {

--- a/scripts/build-windows-sidecar.ps1
+++ b/scripts/build-windows-sidecar.ps1
@@ -39,6 +39,7 @@ try {
     -Force
 
   & (Join-Path $PSScriptRoot "prepare-windows-llama-runtime.ps1")
+  & (Join-Path $PSScriptRoot "prepare-windows-vc-runtime.ps1")
 } finally {
   Pop-Location
 }

--- a/scripts/prepare-windows-vc-runtime.ps1
+++ b/scripts/prepare-windows-vc-runtime.ps1
@@ -1,0 +1,181 @@
+<#
+Stages the Microsoft Visual C++ x64 runtime for app-local deployment.
+
+Release builds source the DLLs from Visual Studio's redistributable directory,
+validate Microsoft's Authenticode signatures, and place identical copies beside
+both Windows native entry points:
+
+  - binaries/windows-runtime -> installed beside oats.exe and ariso-stt.exe
+  - binaries/llama           -> installed beside llama-server.exe and its DLLs
+
+The generated provenance files make the exact runtime version and hashes in an
+installer auditable without committing Microsoft binaries to Git.
+#>
+param(
+  [string]$SourceDirectory,
+  [string]$RootDestination,
+  [string]$LlamaDestination
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$Root = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+$BinariesRoot = [System.IO.Path]::GetFullPath((Join-Path $Root "src-tauri\binaries"))
+$RequiredFiles = @(
+  "vcruntime140.dll",
+  "vcruntime140_1.dll",
+  "msvcp140.dll"
+)
+
+if (-not $RootDestination) {
+  $RootDestination = Join-Path $BinariesRoot "windows-runtime"
+}
+if (-not $LlamaDestination) {
+  $LlamaDestination = Join-Path $BinariesRoot "llama"
+}
+
+function Assert-ChildPath {
+  param(
+    [Parameter(Mandatory = $true)][string]$Path,
+    [Parameter(Mandatory = $true)][string]$Parent
+  )
+
+  $fullPath = [System.IO.Path]::GetFullPath($Path)
+  $fullParent = [System.IO.Path]::GetFullPath($Parent).TrimEnd("\") + "\"
+  if (-not $fullPath.StartsWith($fullParent, [System.StringComparison]::OrdinalIgnoreCase)) {
+    throw "VC runtime destination must stay inside $Parent."
+  }
+  return $fullPath
+}
+
+function Test-RuntimeDirectory {
+  param([Parameter(Mandatory = $true)][string]$Path)
+
+  if (-not (Test-Path -LiteralPath $Path -PathType Container)) {
+    return $false
+  }
+  foreach ($name in $RequiredFiles) {
+    if (-not (Test-Path -LiteralPath (Join-Path $Path $name) -PathType Leaf)) {
+      return $false
+    }
+  }
+  return $true
+}
+
+function Get-RuntimeVersion {
+  param([Parameter(Mandatory = $true)][string]$Path)
+
+  $version = (Get-Item -LiteralPath (Join-Path $Path "vcruntime140.dll")).VersionInfo.FileVersion
+  try {
+    return [version]$version
+  } catch {
+    throw "Invalid Visual C++ runtime version '$version' under $Path."
+  }
+}
+
+function Find-VisualStudioRuntime {
+  $candidates = @()
+
+  if ($env:VCToolsRedistDir) {
+    $candidates += Get-ChildItem -LiteralPath $env:VCToolsRedistDir `
+      -Directory -Filter "Microsoft.VC*.CRT" -Recurse -ErrorAction SilentlyContinue
+  }
+
+  $visualStudioRoots = @(
+    (Join-Path ${env:ProgramFiles(x86)} "Microsoft Visual Studio"),
+    (Join-Path $env:ProgramFiles "Microsoft Visual Studio")
+  ) | Where-Object { Test-Path -LiteralPath $_ }
+  foreach ($visualStudioRoot in $visualStudioRoots) {
+    $candidates += Get-ChildItem -LiteralPath $visualStudioRoot `
+      -Directory -Filter "Microsoft.VC*.CRT" -Recurse -ErrorAction SilentlyContinue
+  }
+
+  $matching = @(
+    $candidates |
+      Where-Object {
+        $_.FullName -match "[\\/]x64[\\/]" -and
+        (Test-RuntimeDirectory -Path $_.FullName)
+      } |
+      Sort-Object -Property @{ Expression = { Get-RuntimeVersion -Path $_.FullName } } -Descending
+  )
+  if ($matching.Count -eq 0) {
+    throw "The Visual Studio x64 redistributable directory was not found. Install the C++ build workload or pass -SourceDirectory explicitly."
+  }
+  return $matching[0].FullName
+}
+
+function Get-ValidatedRuntimeFile {
+  param([Parameter(Mandatory = $true)][string]$Path)
+
+  $file = Get-Item -LiteralPath $Path
+  $signature = Get-AuthenticodeSignature -LiteralPath $file.FullName
+  $subject = if ($signature.SignerCertificate) {
+    $signature.SignerCertificate.Subject
+  } else {
+    ""
+  }
+  if ($signature.Status -ne "Valid" -or $subject -notmatch "(^|,\s*)O=Microsoft Corporation(,|$)") {
+    throw "Refusing to package untrusted VC runtime file '$Path' (signature=$($signature.Status), signer='$subject')."
+  }
+
+  $version = $file.VersionInfo.FileVersion
+  if ($version -notmatch "^14\.") {
+    throw "Unexpected Visual C++ runtime version '$version' for '$Path'."
+  }
+
+  return [ordered]@{
+    name = $file.Name.ToLowerInvariant()
+    version = $version
+    size = $file.Length
+    sha256 = (Get-FileHash -LiteralPath $file.FullName -Algorithm SHA256).Hash.ToLowerInvariant()
+    signer = $subject
+  }
+}
+
+$rootDestinationPath = Assert-ChildPath -Path $RootDestination -Parent $BinariesRoot
+$llamaDestinationPath = Assert-ChildPath -Path $LlamaDestination -Parent $BinariesRoot
+if (-not (Test-Path -LiteralPath $llamaDestinationPath -PathType Container)) {
+  throw "The llama runtime must be staged before the VC runtime: $llamaDestinationPath"
+}
+
+$sourcePath = if ($SourceDirectory) {
+  (Resolve-Path -LiteralPath $SourceDirectory).Path
+} else {
+  Find-VisualStudioRuntime
+}
+if (-not (Test-RuntimeDirectory -Path $sourcePath)) {
+  throw "VC runtime source is missing one or more required x64 DLLs: $sourcePath"
+}
+
+$metadata = @()
+foreach ($name in $RequiredFiles) {
+  $metadata += Get-ValidatedRuntimeFile -Path (Join-Path $sourcePath $name)
+}
+$versions = @($metadata | ForEach-Object { $_.version } | Select-Object -Unique)
+if ($versions.Count -ne 1) {
+  throw "VC runtime files must have one consistent version; found $($versions -join ', ')."
+}
+
+if (Test-Path -LiteralPath $rootDestinationPath) {
+  Remove-Item -LiteralPath $rootDestinationPath -Recurse -Force
+}
+New-Item -ItemType Directory -Force -Path $rootDestinationPath | Out-Null
+
+foreach ($name in $RequiredFiles) {
+  $source = Join-Path $sourcePath $name
+  Copy-Item -LiteralPath $source -Destination (Join-Path $rootDestinationPath $name) -Force
+  Copy-Item -LiteralPath $source -Destination (Join-Path $llamaDestinationPath $name) -Force
+}
+
+$provenance = [ordered]@{
+  schemaVersion = 1
+  architecture = "x64"
+  version = $versions[0]
+  files = $metadata
+}
+$json = $provenance | ConvertTo-Json -Depth 5
+$json | Set-Content -LiteralPath (Join-Path $rootDestinationPath "vc-runtime.json") -Encoding utf8
+$json | Set-Content -LiteralPath (Join-Path $llamaDestinationPath "vc-runtime.json") -Encoding utf8
+
+Write-Output "Staged Microsoft Visual C++ runtime $($versions[0]) for app-local deployment."

--- a/scripts/prepare-windows-vc-runtime.ps1
+++ b/scripts/prepare-windows-vc-runtime.ps1
@@ -66,12 +66,11 @@ function Test-RuntimeDirectory {
 function Get-RuntimeVersion {
   param([Parameter(Mandatory = $true)][string]$Path)
 
-  $version = (Get-Item -LiteralPath (Join-Path $Path "vcruntime140.dll")).VersionInfo.FileVersion
-  try {
-    return [version]$version
-  } catch {
-    throw "Invalid Visual C++ runtime version '$version' under $Path."
+  $rawVersion = (Get-Item -LiteralPath (Join-Path $Path "vcruntime140.dll")).VersionInfo.FileVersion
+  if ($rawVersion -notmatch "^(\d+\.\d+\.\d+\.\d+)") {
+    throw "Invalid Visual C++ runtime version '$rawVersion' under $Path."
   }
+  return [version]$matches[1]
 }
 
 function Find-VisualStudioRuntime {
@@ -119,10 +118,11 @@ function Get-ValidatedRuntimeFile {
     throw "Refusing to package untrusted VC runtime file '$Path' (signature=$($signature.Status), signer='$subject')."
   }
 
-  $version = $file.VersionInfo.FileVersion
-  if ($version -notmatch "^14\.") {
-    throw "Unexpected Visual C++ runtime version '$version' for '$Path'."
+  $rawVersion = $file.VersionInfo.FileVersion
+  if ($rawVersion -notmatch "^(14\.\d+\.\d+\.\d+)") {
+    throw "Unexpected Visual C++ runtime version '$rawVersion' for '$Path'."
   }
+  $version = $matches[1]
 
   return [ordered]@{
     name = $file.Name.ToLowerInvariant()

--- a/scripts/verify-windows-installer-runtime.ps1
+++ b/scripts/verify-windows-installer-runtime.ps1
@@ -1,0 +1,130 @@
+<#
+Installs the NSIS package and administratively extracts the MSI into disposable
+directories, then verifies that both carry the app-local Visual C++ runtime and
+that the installed ariso-stt and llama-server binaries can start.
+#>
+param(
+  [string]$NsisInstallerPath,
+  [string]$MsiInstallerPath
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$Root = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+$Verifier = Join-Path $PSScriptRoot "verify-windows-vc-runtime.ps1"
+if (-not $NsisInstallerPath -and -not $MsiInstallerPath) {
+  throw "Provide at least one Windows installer to verify."
+}
+$NsisInstaller = if ($NsisInstallerPath) {
+  (Resolve-Path -LiteralPath $NsisInstallerPath).Path
+} else {
+  $null
+}
+$MsiInstaller = if ($MsiInstallerPath) {
+  (Resolve-Path -LiteralPath $MsiInstallerPath).Path
+} else {
+  $null
+}
+$TempParent = [System.IO.Path]::GetFullPath([System.IO.Path]::GetTempPath()).TrimEnd("\") + "\"
+$ScratchRoot = Join-Path $TempParent "oats-vc-runtime-installer-$PID"
+$ScratchRoot = [System.IO.Path]::GetFullPath($ScratchRoot)
+if (-not $ScratchRoot.StartsWith($TempParent, [System.StringComparison]::OrdinalIgnoreCase)) {
+  throw "Refusing to use a verification directory outside the system temporary directory."
+}
+
+function Invoke-Process {
+  param(
+    [Parameter(Mandatory = $true)][string]$Path,
+    [Parameter(Mandatory = $true)][string]$Arguments,
+    [Parameter(Mandatory = $true)][string]$Description
+  )
+
+  $process = Start-Process -FilePath $Path -ArgumentList $Arguments -Wait -PassThru
+  if ($process.ExitCode -ne 0) {
+    throw "$Description failed with exit code $($process.ExitCode)."
+  }
+}
+
+function Assert-InstalledPayload {
+  param([Parameter(Mandatory = $true)][string]$SearchRoot)
+
+  $sidecars = @(
+    Get-ChildItem -LiteralPath $SearchRoot -Recurse -File -Filter "ariso-stt.exe" -ErrorAction SilentlyContinue
+  )
+  if ($sidecars.Count -ne 1) {
+    throw "Expected exactly one installed ariso-stt.exe under '$SearchRoot'; found $($sidecars.Count)."
+  }
+  $appRoot = $sidecars[0].Directory.FullName
+  $llamaServer = Join-Path $appRoot "llama\llama-server.exe"
+  if (-not (Test-Path -LiteralPath $llamaServer -PathType Leaf)) {
+    throw "Installed payload is missing '$llamaServer'."
+  }
+
+  & $Verifier `
+    -RootRuntimeDirectory $appRoot `
+    -LlamaRuntimeDirectory (Join-Path $appRoot "llama") `
+    -SidecarPath $sidecars[0].FullName `
+    -LlamaServerPath $llamaServer
+}
+
+New-Item -ItemType Directory -Force -Path $ScratchRoot | Out-Null
+$NsisRoot = Join-Path $ScratchRoot "nsis"
+$MsiRoot = Join-Path $ScratchRoot "msi"
+$NsisUninstalled = -not [bool]$NsisInstaller
+
+try {
+  if ($NsisInstaller) {
+    New-Item -ItemType Directory -Force -Path $NsisRoot | Out-Null
+    Invoke-Process `
+      -Path $NsisInstaller `
+      -Arguments "/S /D=$NsisRoot" `
+      -Description "Silent NSIS installation"
+    Assert-InstalledPayload -SearchRoot $NsisRoot
+
+    $uninstaller = @(
+      Get-ChildItem -LiteralPath $NsisRoot -File -Filter "uninstall*.exe" -ErrorAction SilentlyContinue
+    ) | Select-Object -First 1
+    if (-not $uninstaller) {
+      throw "NSIS payload is missing its uninstaller."
+    }
+    Invoke-Process -Path $uninstaller.FullName -Arguments "/S" -Description "Silent NSIS uninstall"
+    $deadline = [DateTime]::UtcNow.AddSeconds(60)
+    while ((Test-Path -LiteralPath $NsisRoot) -and [DateTime]::UtcNow -lt $deadline) {
+      Start-Sleep -Milliseconds 250
+    }
+    if (Test-Path -LiteralPath $NsisRoot) {
+      throw "Silent NSIS uninstall left its installation directory behind."
+    }
+    $NsisUninstalled = $true
+  }
+
+  if ($MsiInstaller) {
+    New-Item -ItemType Directory -Force -Path $MsiRoot | Out-Null
+    $msiArguments = "/a `"$MsiInstaller`" /qn TARGETDIR=`"$MsiRoot`""
+    Invoke-Process -Path "msiexec.exe" -Arguments $msiArguments -Description "MSI administrative extraction"
+    Assert-InstalledPayload -SearchRoot $MsiRoot
+  }
+
+  $verifiedKinds = @()
+  if ($NsisInstaller) { $verifiedKinds += "NSIS" }
+  if ($MsiInstaller) { $verifiedKinds += "MSI" }
+  Write-Output "Verified app-local VC runtime and native startup in $($verifiedKinds -join ' and ') payloads."
+} finally {
+  if (-not $NsisUninstalled) {
+    $uninstaller = @(
+      Get-ChildItem -LiteralPath $NsisRoot -File -Filter "uninstall*.exe" -ErrorAction SilentlyContinue
+    ) | Select-Object -First 1
+    if ($uninstaller) {
+      try {
+        Start-Process -FilePath $uninstaller.FullName -ArgumentList "/S" -Wait | Out-Null
+        Start-Sleep -Seconds 2
+      } catch {
+        Write-Warning "Could not run the disposable NSIS uninstaller: $($_.Exception.Message)"
+      }
+    }
+  }
+  if (Test-Path -LiteralPath $ScratchRoot) {
+    Remove-Item -LiteralPath $ScratchRoot -Recurse -Force -ErrorAction SilentlyContinue
+  }
+}

--- a/scripts/verify-windows-vc-runtime.ps1
+++ b/scripts/verify-windows-vc-runtime.ps1
@@ -1,0 +1,256 @@
+<#
+Verifies an installed or staged Oats Windows payload contains a trusted,
+internally consistent app-local Visual C++ runtime and that both native entry
+points can start with those files in their executable directories.
+#>
+param(
+  [Parameter(Mandatory = $true)]
+  [string]$RootRuntimeDirectory,
+  [Parameter(Mandatory = $true)]
+  [string]$LlamaRuntimeDirectory,
+  [string]$SidecarPath,
+  [string]$LlamaServerPath,
+  [string]$TranscriptionAudioPath,
+  [string]$ModelsPath
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$RequiredFiles = @(
+  "vcruntime140.dll",
+  "vcruntime140_1.dll",
+  "msvcp140.dll"
+)
+
+function Assert-TrustedRuntimeDirectory {
+  param([Parameter(Mandatory = $true)][string]$Path)
+
+  $directory = (Resolve-Path -LiteralPath $Path).Path
+  $manifestPath = Join-Path $directory "vc-runtime.json"
+  $manifest = Get-Content -LiteralPath $manifestPath -Raw | ConvertFrom-Json
+  if ($manifest.schemaVersion -ne 1 -or $manifest.architecture -ne "x64") {
+    throw "Invalid VC runtime provenance under '$directory'."
+  }
+
+  foreach ($name in $RequiredFiles) {
+    $file = Join-Path $directory $name
+    if (-not (Test-Path -LiteralPath $file -PathType Leaf)) {
+      throw "Missing app-local VC runtime file '$file'."
+    }
+    $entry = @($manifest.files | Where-Object { $_.name -ieq $name })
+    if ($entry.Count -ne 1) {
+      throw "VC runtime provenance must contain exactly one '$name' entry."
+    }
+    $hash = (Get-FileHash -LiteralPath $file -Algorithm SHA256).Hash.ToLowerInvariant()
+    if ($hash -ne $entry[0].sha256) {
+      throw "VC runtime hash mismatch for '$file'."
+    }
+    $signature = Get-AuthenticodeSignature -LiteralPath $file
+    $subject = if ($signature.SignerCertificate) {
+      $signature.SignerCertificate.Subject
+    } else {
+      ""
+    }
+    if ($signature.Status -ne "Valid" -or $subject -notmatch "(^|,\s*)O=Microsoft Corporation(,|$)") {
+      throw "Invalid Microsoft signature on '$file'."
+    }
+  }
+  return $manifest
+}
+
+function Invoke-NativeProbe {
+  param(
+    [Parameter(Mandatory = $true)][string]$Path,
+    [Parameter(Mandatory = $true)][string]$Arguments
+  )
+
+  $startInfo = [System.Diagnostics.ProcessStartInfo]::new()
+  $startInfo.FileName = $Path
+  $startInfo.Arguments = $Arguments
+  $startInfo.UseShellExecute = $false
+  $startInfo.CreateNoWindow = $true
+  $startInfo.RedirectStandardOutput = $true
+  $startInfo.RedirectStandardError = $true
+  $process = [System.Diagnostics.Process]::new()
+  $process.StartInfo = $startInfo
+  if (-not $process.Start()) {
+    throw "Failed to launch native runtime probe '$Path'."
+  }
+  $stdout = $process.StandardOutput.ReadToEnd()
+  $stderr = $process.StandardError.ReadToEnd()
+  $process.WaitForExit()
+  return [pscustomobject]@{
+    exitCode = $process.ExitCode
+    output = "$stdout`n$stderr".Trim()
+  }
+}
+
+function Assert-AppLocalRuntimeLoaded {
+  param([Parameter(Mandatory = $true)][string]$ServerPath)
+
+  $expectedDirectory = [System.IO.Path]::GetFullPath(
+    [System.IO.Path]::GetDirectoryName($ServerPath)
+  ).TrimEnd("\")
+  $startInfo = [System.Diagnostics.ProcessStartInfo]::new()
+  $startInfo.FileName = $ServerPath
+  $startInfo.Arguments = "--host 127.0.0.1 --port 0"
+  $startInfo.UseShellExecute = $false
+  $startInfo.CreateNoWindow = $true
+  $startInfo.RedirectStandardOutput = $true
+  $startInfo.RedirectStandardError = $true
+  $process = [System.Diagnostics.Process]::new()
+  $process.StartInfo = $startInfo
+
+  try {
+    if (-not $process.Start()) {
+      throw "Failed to launch llama-server for module-resolution verification."
+    }
+    Start-Sleep -Milliseconds 750
+    $process.Refresh()
+    if ($process.HasExited) {
+      $stdout = $process.StandardOutput.ReadToEnd()
+      $stderr = $process.StandardError.ReadToEnd()
+      throw "llama-server exited before module inspection: $stdout $stderr"
+    }
+
+    $modules = @($process.Modules)
+    foreach ($name in $RequiredFiles) {
+      $module = @($modules | Where-Object { $_.ModuleName -ieq $name })
+      if ($module.Count -ne 1) {
+        throw "llama-server did not load exactly one '$name' module."
+      }
+      $actualDirectory = [System.IO.Path]::GetFullPath(
+        [System.IO.Path]::GetDirectoryName($module[0].FileName)
+      ).TrimEnd("\")
+      if (-not $actualDirectory.Equals($expectedDirectory, [System.StringComparison]::OrdinalIgnoreCase)) {
+        throw "llama-server loaded '$name' from '$actualDirectory' instead of its app-local directory."
+      }
+    }
+  } finally {
+    if (-not $process.HasExited) {
+      $process.Kill()
+      $process.WaitForExit()
+    }
+    $process.Dispose()
+  }
+}
+
+function Assert-SidecarTranscription {
+  param(
+    [Parameter(Mandatory = $true)][string]$Sidecar,
+    [Parameter(Mandatory = $true)][string]$Audio,
+    [Parameter(Mandatory = $true)][string]$Models
+  )
+
+  $sidecarDirectory = [System.IO.Path]::GetDirectoryName($Sidecar)
+  $startInfo = [System.Diagnostics.ProcessStartInfo]::new()
+  $startInfo.FileName = $Sidecar
+  $startInfo.Arguments = "--audio `"$Audio`" --models `"$Models`" --format json"
+  $startInfo.UseShellExecute = $false
+  $startInfo.CreateNoWindow = $true
+  $startInfo.RedirectStandardOutput = $true
+  $startInfo.RedirectStandardError = $true
+  $process = [System.Diagnostics.Process]::new()
+  $process.StartInfo = $startInfo
+
+  try {
+    if (-not $process.Start()) {
+      throw "Failed to launch the end-to-end transcription probe."
+    }
+    $stdoutTask = $process.StandardOutput.ReadToEndAsync()
+    $stderrTask = $process.StandardError.ReadToEndAsync()
+    Start-Sleep -Milliseconds 750
+    $process.Refresh()
+    if (-not $process.HasExited) {
+      $modules = @($process.Modules)
+      $sidecarBytes = [System.Text.Encoding]::ASCII.GetString(
+        [System.IO.File]::ReadAllBytes($Sidecar)
+      )
+      $importedRuntimeNames = @(
+        [regex]::Matches($sidecarBytes, "(?i)VCRUNTIME140(?:_1)?\.dll") |
+          ForEach-Object { $_.Value.ToLowerInvariant() } |
+          Select-Object -Unique
+      )
+      foreach ($name in $importedRuntimeNames) {
+        $module = @($modules | Where-Object { $_.ModuleName -ieq $name })
+        if ($module.Count -ne 1) {
+          $loadedRuntimeModules = @(
+            $modules |
+              Where-Object { $_.ModuleName -match "(?i)(vcruntime|msvcp)" } |
+              ForEach-Object { "$($_.ModuleName)=$($_.FileName)" }
+          )
+          throw "ariso-stt did not load exactly one '$name' module during transcription. Loaded runtime modules: $($loadedRuntimeModules -join ', ')"
+        }
+        $actualDirectory = [System.IO.Path]::GetDirectoryName($module[0].FileName)
+        if (-not $actualDirectory.Equals($sidecarDirectory, [System.StringComparison]::OrdinalIgnoreCase)) {
+          throw "ariso-stt loaded '$name' from '$actualDirectory' instead of its app-local directory."
+        }
+      }
+    }
+    if (-not $process.WaitForExit(300000)) {
+      throw "The end-to-end transcription probe exceeded five minutes."
+    }
+    $stdout = $stdoutTask.Result
+    $stderr = $stderrTask.Result
+    if ($process.ExitCode -ne 0) {
+      throw "The end-to-end transcription probe failed: $stderr"
+    }
+    try {
+      $payload = $stdout | ConvertFrom-Json
+    } catch {
+      throw "The transcription probe did not emit valid JSON: $stdout"
+    }
+    if (-not $payload.PSObject.Properties["text"] -and -not $payload.PSObject.Properties["segments"]) {
+      throw "The transcription JSON has neither text nor segments."
+    }
+  } finally {
+    if (-not $process.HasExited) {
+      $process.Kill()
+      $process.WaitForExit()
+    }
+    $process.Dispose()
+  }
+}
+
+$rootManifest = Assert-TrustedRuntimeDirectory -Path $RootRuntimeDirectory
+$llamaManifest = Assert-TrustedRuntimeDirectory -Path $LlamaRuntimeDirectory
+foreach ($name in $RequiredFiles) {
+  $rootHash = (Get-FileHash -LiteralPath (Join-Path $RootRuntimeDirectory $name) -Algorithm SHA256).Hash
+  $llamaHash = (Get-FileHash -LiteralPath (Join-Path $LlamaRuntimeDirectory $name) -Algorithm SHA256).Hash
+  if ($rootHash -ne $llamaHash) {
+    throw "Root and llama copies of '$name' differ."
+  }
+}
+
+if ($SidecarPath) {
+  $sidecar = (Resolve-Path -LiteralPath $SidecarPath).Path
+  $result = Invoke-NativeProbe -Path $sidecar -Arguments "--help"
+  if ($result.exitCode -ne 0 -or $result.output -notmatch "local inference sidecar") {
+    throw "The packaged Windows transcription sidecar failed its startup probe: $($result.output)"
+  }
+}
+
+if ($LlamaServerPath) {
+  $server = (Resolve-Path -LiteralPath $LlamaServerPath).Path
+  $result = Invoke-NativeProbe -Path $server -Arguments "--version"
+  if ($result.exitCode -ne 0 -or [string]::IsNullOrWhiteSpace($result.output)) {
+    throw "The packaged llama server failed its startup probe: $($result.output)"
+  }
+  Assert-AppLocalRuntimeLoaded -ServerPath $server
+}
+
+if ([bool]$TranscriptionAudioPath -xor [bool]$ModelsPath) {
+  throw "Provide both -TranscriptionAudioPath and -ModelsPath for an end-to-end transcription probe."
+}
+if ($TranscriptionAudioPath -and $ModelsPath) {
+  if (-not $SidecarPath) {
+    throw "-SidecarPath is required for an end-to-end transcription probe."
+  }
+  Assert-SidecarTranscription `
+    -Sidecar (Resolve-Path -LiteralPath $SidecarPath).Path `
+    -Audio (Resolve-Path -LiteralPath $TranscriptionAudioPath).Path `
+    -Models (Resolve-Path -LiteralPath $ModelsPath).Path
+}
+
+Write-Output "Verified Microsoft VC runtime $($rootManifest.version) in both app-local directories."

--- a/scripts/verify-windows-vc-runtime.ps1
+++ b/scripts/verify-windows-vc-runtime.ps1
@@ -62,7 +62,8 @@ function Assert-TrustedRuntimeDirectory {
 function Invoke-NativeProbe {
   param(
     [Parameter(Mandatory = $true)][string]$Path,
-    [Parameter(Mandatory = $true)][string]$Arguments
+    [Parameter(Mandatory = $true)][string]$Arguments,
+    [int]$TimeoutMilliseconds = 30000
   )
 
   $startInfo = [System.Diagnostics.ProcessStartInfo]::new()
@@ -77,12 +78,15 @@ function Invoke-NativeProbe {
   if (-not $process.Start()) {
     throw "Failed to launch native runtime probe '$Path'."
   }
-  $stdout = $process.StandardOutput.ReadToEnd()
-  $stderr = $process.StandardError.ReadToEnd()
-  $process.WaitForExit()
+  $stdoutTask = $process.StandardOutput.ReadToEndAsync()
+  $stderrTask = $process.StandardError.ReadToEndAsync()
+  if (-not $process.WaitForExit($TimeoutMilliseconds)) {
+    $process.Kill()
+    throw "Native runtime probe '$Path' timed out after ${TimeoutMilliseconds}ms."
+  }
   return [pscustomobject]@{
     exitCode = $process.ExitCode
-    output = "$stdout`n$stderr".Trim()
+    output = "$($stdoutTask.Result)`n$($stderrTask.Result)".Trim()
   }
 }
 

--- a/src-tauri/tauri.windows.conf.json
+++ b/src-tauri/tauri.windows.conf.json
@@ -1,7 +1,8 @@
 {
   "bundle": {
     "resources": {
-      "binaries/llama": "llama"
+      "binaries/llama": "llama",
+      "binaries/windows-runtime/*": ""
     },
     "windows": {
       "nsis": {


### PR DESCRIPTION
## Summary
- stage Microsoft-signed VC++ runtime DLLs beside the Windows sidecar and llama runtime
- include the app-local runtime in both NSIS and MSI packages, including the NSIS updater payload
- verify provenance, hashes, module resolution, native startup, and installed installer contents in CI

## Verification
- rebuilt and inspected NSIS and MSI payloads locally
- completed a real local transcription using the affected dynamically linked sidecar
- confirmed VCRUNTIME140.dll and VCRUNTIME140_1.dll loaded from the sidecar directory
- confirmed llama-server loaded all three runtime DLLs app-locally
- 623 Vitest tests passed
- release and desktop workflow YAML validated

Closes #278

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Windows builds now bundle the app-local Microsoft Visual C++ runtime alongside existing resources.
  * CI and release pipelines add dedicated Windows steps to verify the app-local Visual C++ runtime and validate NSIS/MSI installer payloads.
* **Bug Fixes**
  * Improved runtime verification robustness with stricter version parsing and bounded native probes with timeout handling.
* **Tests**
  * Windows installer and release validation now automatically runs the new runtime integrity checks during CI/release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->