### PR TITLE
feat: acquire Google Calendar via an additive second OAuth hop

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -745,6 +745,7 @@ pub async fn connect_google_calendar(
             "scopes": ["calendar-readonly"],
             "redirect": desktop_auth_redirect(port, &nonce),
         }))
+        .timeout(std::time::Duration::from_secs(30))
         .send()
         .await
         .map_err(|e| e.to_string())?;

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -254,6 +254,17 @@ impl BrowserFlow {
             BrowserFlow::CalendarConnect => "calendar-connect-result",
         }
     }
+
+    /// The loopback success page for this flow. Connect runs while the user is
+    /// already signed in, so it must not claim a sign-in happened; it also
+    /// stays neutral about the grant, because the browser hop reaches this page
+    /// whether or not the user left Calendar ticked on the consent screen.
+    fn callback_ok_response(self) -> &'static str {
+        match self {
+            BrowserFlow::SignIn => CALLBACK_SIGNED_IN_RESPONSE,
+            BrowserFlow::CalendarConnect => CALLBACK_DONE_RESPONSE,
+        }
+    }
 }
 
 struct PendingSignIn {
@@ -454,13 +465,34 @@ fn parse_loopback_callback(request_line: &str) -> Option<(LoopbackDelivery, Stri
     Some((delivery, nonce?))
 }
 
-// Loopback responses. The success page must never echo the token.
-const CALLBACK_OK_RESPONSE: &str = "HTTP/1.1 200 OK\r\nContent-Type: text/html; charset=utf-8\r\nConnection: close\r\n\r\n\
-<!doctype html><html><head><title>oats</title></head>\
-<body style=\"font-family:-apple-system,system-ui,sans-serif;background:#f5f5f7;\
-display:flex;align-items:center;justify-content:center;height:100vh;margin:0\">\
-<div style=\"text-align:center\"><h2>You&rsquo;re signed in</h2>\
-<p>You can close this tab and return to oats.</p></div></body></html>";
+// Loopback responses. The success page must never echo the token, and its
+// wording must match the flow that opened the browser — see
+// `BrowserFlow::callback_ok_response`.
+macro_rules! callback_ok_response {
+    ($heading:literal, $body:literal) => {
+        concat!(
+            "HTTP/1.1 200 OK\r\nContent-Type: text/html; charset=utf-8\r\nConnection: close\r\n\r\n",
+            "<!doctype html><html><head><title>oats</title></head>",
+            "<body style=\"font-family:-apple-system,system-ui,sans-serif;background:#f5f5f7;",
+            "display:flex;align-items:center;justify-content:center;height:100vh;margin:0\">",
+            "<div style=\"text-align:center\"><h2>",
+            $heading,
+            "</h2><p>",
+            $body,
+            "</p></div></body></html>"
+        )
+    };
+}
+
+const CALLBACK_SIGNED_IN_RESPONSE: &str = callback_ok_response!(
+    "You&rsquo;re signed in",
+    "You can close this tab and return to oats."
+);
+
+const CALLBACK_DONE_RESPONSE: &str = callback_ok_response!(
+    "You can close this tab",
+    "oats has the result. Return to the app to continue."
+);
 
 const CALLBACK_NOT_FOUND_RESPONSE: &str =
     "HTTP/1.1 404 Not Found\r\nConnection: close\r\nContent-Length: 0\r\n\r\n";
@@ -471,6 +503,7 @@ const CALLBACK_NOT_FOUND_RESPONSE: &str =
 async fn accept_loopback_callback(
     listener: &tokio::net::TcpListener,
     expected_nonce: &str,
+    flow: BrowserFlow,
 ) -> Result<LoopbackDelivery, String> {
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
@@ -504,7 +537,7 @@ async fn accept_loopback_callback(
                 .map(|(delivery, _)| delivery);
 
             let response = if matched.is_some() {
-                CALLBACK_OK_RESPONSE
+                flow.callback_ok_response()
             } else {
                 CALLBACK_NOT_FOUND_RESPONSE
             };
@@ -533,31 +566,33 @@ async fn run_browser_sign_in(
     listener: tokio::net::TcpListener,
     nonce: String,
 ) {
-    let result =
-        match tokio::time::timeout(SIGN_IN_TIMEOUT, accept_loopback_callback(&listener, &nonce))
-            .await
-        {
-            Ok(Ok(LoopbackDelivery::Token(token))) => {
-                exchange_token_for_session(window.app_handle(), &token).await
-            }
-            // Sign-in requires a magic-link token; a status-only callback on
-            // this attempt's nonce is not one.
-            Ok(Ok(LoopbackDelivery::Status(_))) => SignInResult {
-                success: None,
-                session_token: None,
-                error: Some("Sign-in callback carried no token".into()),
-            },
-            Ok(Err(err)) => SignInResult {
-                success: None,
-                session_token: None,
-                error: Some(err),
-            },
-            Err(_) => SignInResult {
-                success: None,
-                session_token: None,
-                error: Some("Sign-in timed out — please try again".into()),
-            },
-        };
+    let result = match tokio::time::timeout(
+        SIGN_IN_TIMEOUT,
+        accept_loopback_callback(&listener, &nonce, BrowserFlow::SignIn),
+    )
+    .await
+    {
+        Ok(Ok(LoopbackDelivery::Token(token))) => {
+            exchange_token_for_session(window.app_handle(), &token).await
+        }
+        // Sign-in requires a magic-link token; a status-only callback on
+        // this attempt's nonce is not one.
+        Ok(Ok(LoopbackDelivery::Status(_))) => SignInResult {
+            success: None,
+            session_token: None,
+            error: Some("Sign-in callback carried no token".into()),
+        },
+        Ok(Err(err)) => SignInResult {
+            success: None,
+            session_token: None,
+            error: Some(err),
+        },
+        Err(_) => SignInResult {
+            success: None,
+            session_token: None,
+            error: Some("Sign-in timed out — please try again".into()),
+        },
+    };
     if retire_sign_in_attempt(attempt_id) {
         let _ = window.emit(BrowserFlow::SignIn.result_event(), result);
     }
@@ -716,23 +751,25 @@ async fn run_calendar_connect(
     listener: tokio::net::TcpListener,
     nonce: String,
 ) {
-    let result =
-        match tokio::time::timeout(SIGN_IN_TIMEOUT, accept_loopback_callback(&listener, &nonce))
-            .await
-        {
-            Ok(Ok(LoopbackDelivery::Status(status))) => CalendarConnectResult {
-                status: Some(status),
-                error: None,
-            },
-            // A token on this attempt's nonce means the sign-in callback landed
-            // here. Never exchange it — this flow already holds a session, and
-            // the token belongs to the sign-in attempt that minted the nonce.
-            Ok(Ok(LoopbackDelivery::Token(_))) => {
-                calendar_connect_error("Unexpected sign-in callback during calendar connect")
-            }
-            Ok(Err(err)) => calendar_connect_error(err),
-            Err(_) => calendar_connect_error("Connecting Calendar timed out — please try again"),
-        };
+    let result = match tokio::time::timeout(
+        SIGN_IN_TIMEOUT,
+        accept_loopback_callback(&listener, &nonce, BrowserFlow::CalendarConnect),
+    )
+    .await
+    {
+        Ok(Ok(LoopbackDelivery::Status(status))) => CalendarConnectResult {
+            status: Some(status),
+            error: None,
+        },
+        // A token on this attempt's nonce means the sign-in callback landed
+        // here. Never exchange it — this flow already holds a session, and
+        // the token belongs to the sign-in attempt that minted the nonce.
+        Ok(Ok(LoopbackDelivery::Token(_))) => {
+            calendar_connect_error("Unexpected sign-in callback during calendar connect")
+        }
+        Ok(Err(err)) => calendar_connect_error(err),
+        Err(_) => calendar_connect_error("Connecting Calendar timed out — please try again"),
+    };
     if retire_sign_in_attempt(attempt_id) {
         let _ = window.emit(BrowserFlow::CalendarConnect.result_event(), result);
     }
@@ -2319,7 +2356,7 @@ mod tests {
         let port = listener.local_addr().unwrap().port();
 
         let accept = tokio::spawn(async move {
-            accept_loopback_callback(&listener, "goodnonce").await
+            accept_loopback_callback(&listener, "goodnonce", BrowserFlow::SignIn).await
         });
 
         let send = |req: String| async move {
@@ -2339,6 +2376,8 @@ mod tests {
         assert!(real.starts_with("HTTP/1.1 200"));
         // The success page never echoes the token.
         assert!(!real.contains("tok123"));
+        // Sign-in is the one flow whose page may claim a sign-in happened.
+        assert!(real.contains("re signed in"));
 
         assert_eq!(
             accept.await.unwrap().unwrap(),
@@ -2354,7 +2393,7 @@ mod tests {
         let port = listener.local_addr().unwrap().port();
 
         let accept = tokio::spawn(async move {
-            accept_loopback_callback(&listener, "goodnonce").await
+            accept_loopback_callback(&listener, "goodnonce", BrowserFlow::CalendarConnect).await
         });
 
         let mut conn = tokio::net::TcpStream::connect(("127.0.0.1", port)).await.unwrap();
@@ -2364,6 +2403,12 @@ mod tests {
         let mut resp = String::new();
         conn.read_to_string(&mut resp).await.unwrap();
         assert!(resp.starts_with("HTTP/1.1 200"));
+        // The connect hop runs while the user is already signed in, so its page
+        // must not report a sign-in, and it must stay neutral about the grant —
+        // the browser lands here even when Calendar was left unticked.
+        assert!(!resp.contains("signed in"));
+        assert!(!resp.contains("Calendar"));
+        assert!(resp.contains("You can close this tab"));
 
         assert_eq!(
             accept.await.unwrap().unwrap(),

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -341,6 +341,39 @@ fn retire_sign_in_attempt(id: u64) -> bool {
     }
 }
 
+/// Owns the slot for the stretch between `begin_sign_in_attempt` and the
+/// moment the loopback listener task takes over. Every fallible step in that
+/// prologue — bind, prepare-state, URL validation, opening the browser — would
+/// otherwise leave the attempt parked in the slot on the way out, and a later
+/// `cancel_google_sign_in` would emit a result for a flow that already died.
+/// Call `release` once the listener task exists; until then, any early return
+/// retires the attempt on drop.
+struct SignInAttemptGuard(Option<u64>);
+
+impl SignInAttemptGuard {
+    fn begin(flow: BrowserFlow) -> Self {
+        Self(Some(begin_sign_in_attempt(flow)))
+    }
+
+    fn id(&self) -> u64 {
+        self.0.expect("attempt id read after release")
+    }
+
+    /// Hand the attempt to the listener task: it now owns retiring the slot,
+    /// so dropping this guard must no longer do it.
+    fn release(mut self) -> u64 {
+        self.0.take().expect("attempt released twice")
+    }
+}
+
+impl Drop for SignInAttemptGuard {
+    fn drop(&mut self) {
+        if let Some(id) = self.0 {
+            retire_sign_in_attempt(id);
+        }
+    }
+}
+
 /// Constant-time-ish nonce check: comparing SHA-256 digests instead of the
 /// raw strings keeps a local process from recovering the nonce byte-by-byte
 /// through comparison timing.
@@ -542,8 +575,10 @@ pub async fn google_sign_in(window: tauri::WebviewWindow) -> Result<SignInResult
     // prepare-state is in flight still has something in the slot to cancel,
     // instead of being silently dropped because no listener task exists yet.
     // This also supersedes any still-pending attempt (e.g. the user closed
-    // the browser tab and clicked Sign in again).
-    let attempt_id = begin_sign_in_attempt(BrowserFlow::SignIn);
+    // the browser tab and clicked Sign in again). The guard retires it again
+    // if any step below fails before the listener task takes ownership.
+    let attempt = SignInAttemptGuard::begin(BrowserFlow::SignIn);
+    let attempt_id = attempt.id();
 
     // Bind before prepare-state so the advertised port is already ours.
     let listener = tokio::net::TcpListener::bind(("127.0.0.1", 0))
@@ -617,6 +652,7 @@ pub async fn google_sign_in(window: tauri::WebviewWindow) -> Result<SignInResult
     // Step 3: Wait for the browser to hit the loopback callback. If this
     // attempt was superseded or canceled while the browser was opening,
     // `attach_sign_in_handle` aborts the task instead of letting it run.
+    let attempt_id = attempt.release();
     let handle =
         tauri::async_runtime::spawn(run_browser_sign_in(attempt_id, window, listener, nonce));
     attach_sign_in_handle(attempt_id, handle);
@@ -725,7 +761,10 @@ pub async fn connect_google_calendar(
         return Err("Not signed in".into());
     };
 
-    let attempt_id = begin_sign_in_attempt(BrowserFlow::CalendarConnect);
+    // As in `google_sign_in`: the guard hands the slot back if any step below
+    // fails before the listener task takes ownership of the attempt.
+    let attempt = SignInAttemptGuard::begin(BrowserFlow::CalendarConnect);
+    let attempt_id = attempt.id();
 
     let listener = tokio::net::TcpListener::bind(("127.0.0.1", 0))
         .await
@@ -777,6 +816,7 @@ pub async fn connect_google_calendar(
         .open_url(body.redirect_url, None::<&str>)
         .map_err(|e| e.to_string())?;
 
+    let attempt_id = attempt.release();
     let handle =
         tauri::async_runtime::spawn(run_calendar_connect(attempt_id, window, listener, nonce));
     attach_sign_in_handle(attempt_id, handle);
@@ -2147,6 +2187,44 @@ mod tests {
         assert!(retire_sign_in_attempt(superseded_id));
         assert!(!sign_in_attempt_active(superseded_id));
         assert!(!retire_sign_in_attempt(superseded_id));
+    }
+
+    #[test]
+    fn attempt_guard_retires_the_slot_when_the_prologue_fails() {
+        // Every fallible step between begin and the listener task's spawn —
+        // bind, prepare-state, URL validation, open_url — used to leave the
+        // attempt parked in the slot, so a later cancel emitted a result for
+        // a flow that had already failed.
+        let id = {
+            let attempt = SignInAttemptGuard::begin(BrowserFlow::CalendarConnect);
+            let id = attempt.id();
+            assert!(sign_in_attempt_active(id));
+            id // guard drops here, as it would on an early `?` return
+        };
+        assert!(!sign_in_attempt_active(id));
+        assert!(abort_pending_sign_in().is_none());
+    }
+
+    #[test]
+    fn released_attempt_survives_the_guard_going_out_of_scope() {
+        // Once the listener task owns the attempt, the guard must keep its
+        // hands off: retiring here would strand the frontend's waiter.
+        let id = {
+            let attempt = SignInAttemptGuard::begin(BrowserFlow::SignIn);
+            attempt.release()
+        };
+        assert!(sign_in_attempt_active(id));
+        assert!(abort_pending_sign_in() == Some(BrowserFlow::SignIn));
+    }
+
+    #[test]
+    fn attempt_guard_drop_never_retires_a_newer_attempt() {
+        // A superseded prologue failing late must not clear the winner's slot.
+        let stale = SignInAttemptGuard::begin(BrowserFlow::SignIn);
+        let winner = begin_sign_in_attempt(BrowserFlow::CalendarConnect);
+        drop(stale);
+        assert!(sign_in_attempt_active(winner));
+        assert!(retire_sign_in_attempt(winner));
     }
 
     #[tokio::test]

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -239,8 +239,26 @@ const SIGN_IN_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(300)
 /// request, not just once the loopback listener task exists — so a cancel
 /// that arrives while prepare-state is in flight still has something to
 /// cancel instead of being silently dropped.
+/// Which browser flow owns the slot. Cancel must resolve the frontend promise
+/// that is actually waiting, and the two flows listen on different events.
+#[derive(Clone, Copy, PartialEq)]
+pub(crate) enum BrowserFlow {
+    SignIn,
+    CalendarConnect,
+}
+
+impl BrowserFlow {
+    fn result_event(self) -> &'static str {
+        match self {
+            BrowserFlow::SignIn => "oauth-result",
+            BrowserFlow::CalendarConnect => "calendar-connect-result",
+        }
+    }
+}
+
 struct PendingSignIn {
     id: u64,
+    flow: BrowserFlow,
     handle: Option<tauri::async_runtime::JoinHandle<()>>,
 }
 
@@ -256,7 +274,7 @@ fn abort_pending_handle(handle: tauri::async_runtime::JoinHandle<()>) {
 /// Register a new attempt and take the slot, aborting whatever attempt (with
 /// or without a listener task yet) was previously in it. Returns the new
 /// attempt's id, checked at each subsequent await via `sign_in_attempt_active`.
-fn begin_sign_in_attempt() -> u64 {
+fn begin_sign_in_attempt(flow: BrowserFlow) -> u64 {
     let id = SIGN_IN_ATTEMPT.fetch_add(1, std::sync::atomic::Ordering::SeqCst) + 1;
     let mut slot = PENDING_SIGN_IN.lock().unwrap();
     if let Some(prev) = slot.take() {
@@ -264,7 +282,11 @@ fn begin_sign_in_attempt() -> u64 {
             abort_pending_handle(handle);
         }
     }
-    *slot = Some(PendingSignIn { id, handle: None });
+    *slot = Some(PendingSignIn {
+        id,
+        flow,
+        handle: None,
+    });
     id
 }
 
@@ -285,17 +307,19 @@ fn attach_sign_in_handle(id: u64, handle: tauri::async_runtime::JoinHandle<()>) 
     }
 }
 
-/// Cancel whatever sign-in attempt is pending, if any. Returns true if there
-/// was one (whether or not its listener task existed yet).
-fn abort_pending_sign_in() -> bool {
+/// Cancel whatever browser attempt is pending, if any. Returns the flow that
+/// was cancelled so the caller emits on the event its waiter is listening to —
+/// cancelling a calendar connect with an `oauth-result` would leave the
+/// frontend promise hanging until the timeout.
+fn abort_pending_sign_in() -> Option<BrowserFlow> {
     match PENDING_SIGN_IN.lock().unwrap().take() {
         Some(p) => {
             if let Some(handle) = p.handle {
                 abort_pending_handle(handle);
             }
-            true
+            Some(p.flow)
         }
-        None => false,
+        None => None,
     }
 }
 
@@ -354,9 +378,18 @@ fn validate_browser_auth_url(url: &Url) -> Result<(), String> {
     }
 }
 
-/// Parse an HTTP request line (`GET /callback?token=…&nonce=… HTTP/1.1`) from
-/// the loopback listener. Returns `(token, nonce)` for well-formed callbacks.
-fn parse_loopback_callback(request_line: &str) -> Option<(String, String)> {
+/// What a loopback callback delivered. Sign-in returns a magic-link token;
+/// the Workspace connect hop returns only a status marker and no secret.
+#[derive(Debug, PartialEq)]
+pub(crate) enum LoopbackDelivery {
+    Token(String),
+    Status(String),
+}
+
+/// Parse an HTTP request line (`GET /callback?token=…&nonce=… HTTP/1.1`, or
+/// `?status=…&nonce=…` for the connect hop) from the loopback listener.
+/// Returns `(delivery, nonce)` for well-formed callbacks.
+fn parse_loopback_callback(request_line: &str) -> Option<(LoopbackDelivery, String)> {
     let mut parts = request_line.split_whitespace();
     if parts.next() != Some("GET") {
         return None;
@@ -367,15 +400,25 @@ fn parse_loopback_callback(request_line: &str) -> Option<(String, String)> {
         return None;
     }
     let mut token = None;
+    let mut status = None;
     let mut nonce = None;
     for (key, value) in url.query_pairs() {
         match key.as_ref() {
             "token" if !value.is_empty() => token = Some(value.into_owned()),
+            "status" if !value.is_empty() => status = Some(value.into_owned()),
             "nonce" if !value.is_empty() => nonce = Some(value.into_owned()),
             _ => {}
         }
     }
-    Some((token?, nonce?))
+    // A token always wins: a callback carrying one is a sign-in delivery even
+    // if it also carries a status, so a status parameter can never downgrade
+    // sign-in into the token-less path.
+    let delivery = match (token, status) {
+        (Some(token), _) => LoopbackDelivery::Token(token),
+        (None, Some(status)) => LoopbackDelivery::Status(status),
+        (None, None) => return None,
+    };
+    Some((delivery, nonce?))
 }
 
 // Loopback responses. The success page must never echo the token.
@@ -395,7 +438,7 @@ const CALLBACK_NOT_FOUND_RESPONSE: &str =
 async fn accept_loopback_callback(
     listener: &tokio::net::TcpListener,
     expected_nonce: &str,
-) -> Result<String, String> {
+) -> Result<LoopbackDelivery, String> {
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
     loop {
@@ -425,7 +468,7 @@ async fn accept_loopback_callback(
 
             let matched = parse_loopback_callback(&request_line)
                 .filter(|(_, nonce)| nonce_matches(nonce, expected_nonce))
-                .map(|(token, _)| token);
+                .map(|(delivery, _)| delivery);
 
             let response = if matched.is_some() {
                 CALLBACK_OK_RESPONSE
@@ -438,8 +481,8 @@ async fn accept_loopback_callback(
         })
         .await;
 
-        if let Ok(Some(token)) = handled {
-            return Ok(token);
+        if let Ok(Some(delivery)) = handled {
+            return Ok(delivery);
         }
     }
 }
@@ -461,7 +504,16 @@ async fn run_browser_sign_in(
         match tokio::time::timeout(SIGN_IN_TIMEOUT, accept_loopback_callback(&listener, &nonce))
             .await
         {
-            Ok(Ok(token)) => exchange_token_for_session(window.app_handle(), &token).await,
+            Ok(Ok(LoopbackDelivery::Token(token))) => {
+                exchange_token_for_session(window.app_handle(), &token).await
+            }
+            // Sign-in requires a magic-link token; a status-only callback on
+            // this attempt's nonce is not one.
+            Ok(Ok(LoopbackDelivery::Status(_))) => SignInResult {
+                success: None,
+                session_token: None,
+                error: Some("Sign-in callback carried no token".into()),
+            },
             Ok(Err(err)) => SignInResult {
                 success: None,
                 session_token: None,
@@ -474,7 +526,7 @@ async fn run_browser_sign_in(
             },
         };
     if retire_sign_in_attempt(attempt_id) {
-        let _ = window.emit("oauth-result", result);
+        let _ = window.emit(BrowserFlow::SignIn.result_event(), result);
     }
 }
 
@@ -491,7 +543,7 @@ pub async fn google_sign_in(window: tauri::WebviewWindow) -> Result<SignInResult
     // instead of being silently dropped because no listener task exists yet.
     // This also supersedes any still-pending attempt (e.g. the user closed
     // the browser tab and clicked Sign in again).
-    let attempt_id = begin_sign_in_attempt();
+    let attempt_id = begin_sign_in_attempt(BrowserFlow::SignIn);
 
     // Bind before prepare-state so the advertised port is already ours.
     let listener = tokio::net::TcpListener::bind(("127.0.0.1", 0))
@@ -581,17 +633,158 @@ pub async fn google_sign_in(window: tauri::WebviewWindow) -> Result<SignInResult
 /// frontend's pending `oauth-result` wait with the silent-cancel error.
 #[tauri::command]
 pub async fn cancel_google_sign_in(window: tauri::WebviewWindow) -> Result<(), String> {
-    if abort_pending_sign_in() {
-        let _ = window.emit(
-            "oauth-result",
-            SignInResult {
-                success: None,
-                session_token: None,
-                error: Some(SIGN_IN_CANCELED.into()),
-            },
-        );
+    match abort_pending_sign_in() {
+        Some(BrowserFlow::SignIn) => {
+            let _ = window.emit(
+                BrowserFlow::SignIn.result_event(),
+                SignInResult {
+                    success: None,
+                    session_token: None,
+                    error: Some(SIGN_IN_CANCELED.into()),
+                },
+            );
+        }
+        Some(BrowserFlow::CalendarConnect) => {
+            let _ = window.emit(
+                BrowserFlow::CalendarConnect.result_event(),
+                calendar_connect_error(SIGN_IN_CANCELED),
+            );
+        }
+        None => {}
     }
     Ok(())
+}
+
+/// Outcome of the Workspace connect hop. `status` mirrors the marker the API's
+/// callback put on the loopback URL: "connected", or "no_calendar_scope" when
+/// the user unticked Calendar on the granular-consent screen.
+#[derive(Clone, Serialize)]
+pub struct CalendarConnectResult {
+    pub status: Option<String>,
+    pub error: Option<String>,
+}
+
+fn calendar_connect_error(message: impl Into<String>) -> CalendarConnectResult {
+    CalendarConnectResult {
+        status: None,
+        error: Some(message.into()),
+    }
+}
+
+/// Wait for the connect callback and report via `calendar-connect-result`.
+/// Mirrors `run_browser_sign_in`, but nothing secret crosses the loopback —
+/// only the status marker — so there is no token to exchange.
+async fn run_calendar_connect(
+    attempt_id: u64,
+    window: tauri::WebviewWindow,
+    listener: tokio::net::TcpListener,
+    nonce: String,
+) {
+    let result =
+        match tokio::time::timeout(SIGN_IN_TIMEOUT, accept_loopback_callback(&listener, &nonce))
+            .await
+        {
+            Ok(Ok(LoopbackDelivery::Status(status))) => CalendarConnectResult {
+                status: Some(status),
+                error: None,
+            },
+            // A token on this attempt's nonce means the sign-in callback landed
+            // here. Never exchange it — this flow already holds a session, and
+            // the token belongs to the sign-in attempt that minted the nonce.
+            Ok(Ok(LoopbackDelivery::Token(_))) => {
+                calendar_connect_error("Unexpected sign-in callback during calendar connect")
+            }
+            Ok(Err(err)) => calendar_connect_error(err),
+            Err(_) => calendar_connect_error("Connecting Calendar timed out — please try again"),
+        };
+    if retire_sign_in_attempt(attempt_id) {
+        let _ = window.emit(BrowserFlow::CalendarConnect.result_event(), result);
+    }
+}
+
+/// Second hop of desktop Google auth: acquire Calendar read access through the
+/// authenticated Workspace connect flow, which sets `include_granted_scopes`
+/// and is therefore additive — it can never narrow an existing grant the way
+/// sign-in would. Only run when `/desktop/google-calendar-status` reports
+/// Calendar missing.
+#[tauri::command]
+pub async fn connect_google_calendar(
+    window: tauri::WebviewWindow,
+) -> Result<CalendarConnectResult, String> {
+    use tauri_plugin_opener::OpenerExt;
+
+    let app = window.app_handle().clone();
+
+    // Offline mode must make no network calls at all. Calendar sync is an
+    // Ariso-cloud feature, so this is unreachable in Local by design.
+    if active_backend(&app) == "local" {
+        return Err("Calendar connect is unavailable on the Local backend".into());
+    }
+
+    let Some(session_token) = get_session_token(&app) else {
+        return Err("Not signed in".into());
+    };
+
+    let attempt_id = begin_sign_in_attempt(BrowserFlow::CalendarConnect);
+
+    let listener = tokio::net::TcpListener::bind(("127.0.0.1", 0))
+        .await
+        .map_err(|e| format!("bind loopback listener: {e}"))?;
+    let port = listener.local_addr().map_err(|e| e.to_string())?.port();
+    let nonce = random_nonce()?;
+
+    // Authenticated, unlike sign-in's prepare-state: the API resolves the
+    // caller's Google Workspace MCP server row from the session.
+    let client = http_client();
+    let response = client
+        .post(format!("{}/oauth2/prepare-state", api_base_url()))
+        .header(CONTENT_TYPE, "application/json")
+        .header(AUTHORIZATION, format!("Bearer {session_token}"))
+        .json(&serde_json::json!({
+            "integration": "googleWorkspace",
+            "scopes": ["calendar-readonly"],
+            "redirect": desktop_auth_redirect(port, &nonce),
+        }))
+        .send()
+        .await
+        .map_err(|e| e.to_string())?;
+
+    if !sign_in_attempt_active(attempt_id) {
+        return Ok(calendar_connect_error(SIGN_IN_CANCELED));
+    }
+
+    if !response.status().is_success() {
+        let status = response.status().as_u16();
+        return Ok(calendar_connect_error(format!("API returned {status}")));
+    }
+
+    let body: PrepareStateResponse = response.json().await.map_err(|e| e.to_string())?;
+
+    if !sign_in_attempt_active(attempt_id) {
+        return Ok(calendar_connect_error(SIGN_IN_CANCELED));
+    }
+
+    let auth_url = Url::parse(&body.redirect_url).map_err(|e| e.to_string())?;
+    validate_browser_auth_url(&auth_url)?;
+
+    if !sign_in_attempt_active(attempt_id) {
+        return Ok(calendar_connect_error(SIGN_IN_CANCELED));
+    }
+
+    window
+        .opener()
+        .open_url(body.redirect_url, None::<&str>)
+        .map_err(|e| e.to_string())?;
+
+    let handle =
+        tauri::async_runtime::spawn(run_calendar_connect(attempt_id, window, listener, nonce));
+    attach_sign_in_handle(attempt_id, handle);
+
+    // The frontend listens for "calendar-connect-result".
+    Ok(CalendarConnectResult {
+        status: None,
+        error: None,
+    })
 }
 
 async fn exchange_token_for_session(
@@ -1905,27 +2098,45 @@ mod tests {
 
     #[test]
     fn sign_in_attempt_cancel_during_prepare_is_not_dropped() {
-        let id = begin_sign_in_attempt();
+        let id = begin_sign_in_attempt(BrowserFlow::SignIn);
         assert!(sign_in_attempt_active(id));
 
         // Cancel arrives before the loopback listener task exists (still
         // awaiting prepare-state) — it must still find something to cancel
         // instead of silently no-oping.
-        assert!(abort_pending_sign_in());
+        assert!(abort_pending_sign_in().is_some());
         assert!(!sign_in_attempt_active(id));
 
         // A cancel with nothing pending is a no-op, not an error.
-        assert!(!abort_pending_sign_in());
+        assert!(abort_pending_sign_in().is_none());
+    }
+
+    #[test]
+    fn cancel_reports_the_flow_that_was_pending() {
+        // Cancel must resolve the promise that is actually waiting: the two
+        // flows listen on different events, so emitting an oauth-result over a
+        // pending calendar connect would hang the frontend until the timeout.
+        begin_sign_in_attempt(BrowserFlow::SignIn);
+        assert!(abort_pending_sign_in() == Some(BrowserFlow::SignIn));
+
+        begin_sign_in_attempt(BrowserFlow::CalendarConnect);
+        assert!(abort_pending_sign_in() == Some(BrowserFlow::CalendarConnect));
+
+        assert_eq!(BrowserFlow::SignIn.result_event(), "oauth-result");
+        assert_eq!(
+            BrowserFlow::CalendarConnect.result_event(),
+            "calendar-connect-result"
+        );
     }
 
     #[test]
     fn retire_sign_in_attempt_only_clears_the_matching_slot() {
-        let id = begin_sign_in_attempt();
+        let id = begin_sign_in_attempt(BrowserFlow::SignIn);
 
         // A superseded attempt's retire is a no-op — its slot is already gone
         // (or belongs to a newer attempt), so it must not clear the winner's
         // state or report success.
-        let superseded_id = begin_sign_in_attempt();
+        let superseded_id = begin_sign_in_attempt(BrowserFlow::SignIn);
         assert!(!retire_sign_in_attempt(id));
         assert!(sign_in_attempt_active(superseded_id));
 
@@ -1939,11 +2150,11 @@ mod tests {
 
     #[tokio::test]
     async fn sign_in_attempt_out_of_order_completion_supersedes_cleanly() {
-        let first_id = begin_sign_in_attempt();
+        let first_id = begin_sign_in_attempt(BrowserFlow::SignIn);
         // A second attempt starts (e.g. the user retried) before the first's
         // prepare-state call returned, superseding it before it ever got a
         // listener handle.
-        let second_id = begin_sign_in_attempt();
+        let second_id = begin_sign_in_attempt(BrowserFlow::SignIn);
         assert!(!sign_in_attempt_active(first_id));
         assert!(sign_in_attempt_active(second_id));
 
@@ -1962,7 +2173,7 @@ mod tests {
         attach_sign_in_handle(second_id, handle);
         assert!(sign_in_attempt_active(second_id));
 
-        assert!(abort_pending_sign_in());
+        assert!(abort_pending_sign_in().is_some());
         assert!(!sign_in_attempt_active(second_id));
     }
 
@@ -1970,12 +2181,39 @@ mod tests {
     fn parse_loopback_callback_extracts_token_and_nonce() {
         assert_eq!(
             parse_loopback_callback("GET /callback?token=tok123&nonce=n456 HTTP/1.1"),
-            Some(("tok123".into(), "n456".into()))
+            Some((LoopbackDelivery::Token("tok123".into()), "n456".into()))
         );
         // Percent-encoded values are decoded.
         assert_eq!(
             parse_loopback_callback("GET /callback?token=a%2Bb&nonce=n HTTP/1.1"),
-            Some(("a+b".into(), "n".into()))
+            Some((LoopbackDelivery::Token("a+b".into()), "n".into()))
+        );
+    }
+
+    #[test]
+    fn parse_loopback_callback_accepts_token_less_status_delivery() {
+        // The Workspace connect hop delivers no token, only a status marker.
+        assert_eq!(
+            parse_loopback_callback("GET /callback?status=connected&nonce=n456 HTTP/1.1"),
+            Some((LoopbackDelivery::Status("connected".into()), "n456".into()))
+        );
+        // Granular consent lets the user untick Calendar and still complete.
+        assert_eq!(
+            parse_loopback_callback("GET /callback?status=no_calendar_scope&nonce=n HTTP/1.1"),
+            Some((
+                LoopbackDelivery::Status("no_calendar_scope".into()),
+                "n".into()
+            ))
+        );
+    }
+
+    #[test]
+    fn parse_loopback_callback_prefers_token_over_status() {
+        // A status parameter must never downgrade a sign-in delivery into the
+        // token-less path, or a forged status could strand the exchange.
+        assert_eq!(
+            parse_loopback_callback("GET /callback?token=tok&status=connected&nonce=n HTTP/1.1"),
+            Some((LoopbackDelivery::Token("tok".into()), "n".into()))
         );
     }
 
@@ -1987,6 +2225,10 @@ mod tests {
         assert_eq!(parse_loopback_callback("GET /callback?token=t HTTP/1.1"), None);
         assert_eq!(parse_loopback_callback("GET /callback?nonce=n HTTP/1.1"), None);
         assert_eq!(parse_loopback_callback("GET /callback?token=&nonce=n HTTP/1.1"), None);
+        // A status delivery still requires the nonce, and an empty status is
+        // no more acceptable than an empty token.
+        assert_eq!(parse_loopback_callback("GET /callback?status=connected HTTP/1.1"), None);
+        assert_eq!(parse_loopback_callback("GET /callback?status=&nonce=n HTTP/1.1"), None);
         assert_eq!(parse_loopback_callback(""), None);
     }
 
@@ -2019,7 +2261,35 @@ mod tests {
         // The success page never echoes the token.
         assert!(!real.contains("tok123"));
 
-        assert_eq!(accept.await.unwrap().unwrap(), "tok123");
+        assert_eq!(
+            accept.await.unwrap().unwrap(),
+            LoopbackDelivery::Token("tok123".into())
+        );
+    }
+
+    #[tokio::test]
+    async fn accept_loopback_callback_returns_token_less_status_delivery() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        let listener = tokio::net::TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+
+        let accept = tokio::spawn(async move {
+            accept_loopback_callback(&listener, "goodnonce").await
+        });
+
+        let mut conn = tokio::net::TcpStream::connect(("127.0.0.1", port)).await.unwrap();
+        conn.write_all(b"GET /callback?status=connected&nonce=goodnonce HTTP/1.1\r\n\r\n")
+            .await
+            .unwrap();
+        let mut resp = String::new();
+        conn.read_to_string(&mut resp).await.unwrap();
+        assert!(resp.starts_with("HTTP/1.1 200"));
+
+        assert_eq!(
+            accept.await.unwrap().unwrap(),
+            LoopbackDelivery::Status("connected".into())
+        );
     }
 
     #[test]

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -190,6 +190,7 @@ fn main() {
         .invoke_handler(tauri::generate_handler![
             commands::google_sign_in,
             commands::cancel_google_sign_in,
+            commands::connect_google_calendar,
             commands::check_session,
             commands::sign_out,
             commands::api_request,

--- a/src/tauri.calendar.test.ts
+++ b/src/tauri.calendar.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ensureCalendarAccess decides whether the second (Workspace connect) OAuth hop
+// runs. Firing it when Calendar is already granted would put a consent screen in
+// front of the user on every sign-in, which is the exact failure the conditional
+// design exists to avoid.
+
+const invoke = vi.fn();
+// The real connect_google_calendar returns immediately and delivers its result
+// over the "calendar-connect-result" event once the browser hop completes, so
+// the mock has to fire the listener rather than resolve the invoke call.
+const hoisted = vi.hoisted(() => ({
+  emit: null as null | ((payload: unknown) => void),
+}));
+
+vi.mock('@tauri-apps/api/core', () => ({ invoke: (...a: unknown[]) => invoke(...a) }));
+vi.mock('@tauri-apps/api/webviewWindow', () => ({
+  getCurrentWebviewWindow: () => ({
+    listen: (_event: string, cb: (e: { payload: unknown }) => void) => {
+      hoisted.emit = (payload: unknown) => cb({ payload });
+      return Promise.resolve(() => {
+        hoisted.emit = null;
+      });
+    },
+  }),
+}));
+
+import { auth } from './tauri';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  hoisted.emit = null;
+});
+
+/** Route api_request to a status payload; connect_google_calendar to a result. */
+function mockBackend(opts: {
+  status?: unknown;
+  statusCode?: number;
+  connect?: unknown;
+}) {
+  invoke.mockImplementation((cmd: string) => {
+    if (cmd === 'api_request') {
+      return Promise.resolve({ status: opts.statusCode ?? 200, data: opts.status });
+    }
+    if (cmd === 'connect_google_calendar') {
+      const payload = opts.connect ?? {};
+      // An immediate error short-circuits in the wrapper; anything else arrives
+      // on the event after the browser round-trip.
+      if (!(payload as { error?: string }).error) {
+        queueMicrotask(() => hoisted.emit?.(payload));
+      }
+      return Promise.resolve(payload);
+    }
+    return Promise.resolve({});
+  });
+}
+
+describe('auth.ensureCalendarAccess', () => {
+  it('does not run the connect hop when Calendar is already granted', async () => {
+    mockBackend({ status: { connected: true } });
+
+    const result = await auth.ensureCalendarAccess();
+
+    expect(result).toEqual({ connected: true });
+    expect(invoke).not.toHaveBeenCalledWith('connect_google_calendar');
+  });
+
+  it('runs the connect hop when Calendar read scope is missing', async () => {
+    mockBackend({
+      status: { connected: false, reason: 'no_calendar_scope' },
+      connect: { status: 'connected' },
+    });
+
+    const result = await auth.ensureCalendarAccess();
+
+    expect(invoke).toHaveBeenCalledWith('connect_google_calendar');
+    expect(result).toEqual({ connected: true });
+  });
+
+  it('runs the connect hop when no credential exists at all', async () => {
+    mockBackend({
+      status: { connected: false, reason: 'no_credential' },
+      connect: { status: 'connected' },
+    });
+
+    await auth.ensureCalendarAccess();
+
+    expect(invoke).toHaveBeenCalledWith('connect_google_calendar');
+  });
+
+  it('reports not-connected when the user unticks Calendar on the consent screen', async () => {
+    // Granular consent lets the grant complete without Calendar. Claiming
+    // success here would contradict the API and re-prompt on the next sign-in.
+    mockBackend({
+      status: { connected: false, reason: 'no_calendar_scope' },
+      connect: { status: 'no_calendar_scope' },
+    });
+
+    const result = await auth.ensureCalendarAccess();
+
+    expect(result).toEqual({ connected: false, reason: 'no_calendar_scope' });
+  });
+
+  it('surfaces a connect-hop error rather than reporting success', async () => {
+    mockBackend({
+      status: { connected: false, reason: 'no_server' },
+      connect: { error: 'API returned 500' },
+    });
+
+    await expect(auth.ensureCalendarAccess()).rejects.toThrow('API returned 500');
+  });
+
+  it('throws instead of connecting when the status check fails', async () => {
+    mockBackend({ status: null, statusCode: 401 });
+
+    await expect(auth.ensureCalendarAccess()).rejects.toThrow('calendar status: 401');
+    expect(invoke).not.toHaveBeenCalledWith('connect_google_calendar');
+  });
+});

--- a/src/tauri.calendar.test.ts
+++ b/src/tauri.calendar.test.ts
@@ -116,4 +116,15 @@ describe('auth.ensureCalendarAccess', () => {
     await expect(auth.ensureCalendarAccess()).rejects.toThrow('calendar status: 401');
     expect(invoke).not.toHaveBeenCalledWith('connect_google_calendar');
   });
+
+  it('throws a legible error when a 200 carries an undecodable body', async () => {
+    // api_request keeps the real status and falls back to null when the body
+    // is not JSON, so `.connected` would blow up with a TypeError.
+    mockBackend({ status: null, statusCode: 200 });
+
+    await expect(auth.ensureCalendarAccess()).rejects.toThrow(
+      'calendar status: malformed response'
+    );
+    expect(invoke).not.toHaveBeenCalledWith('connect_google_calendar');
+  });
 });

--- a/src/tauri.ts
+++ b/src/tauri.ts
@@ -81,6 +81,12 @@ export const auth = {
     if (res.status !== 200) {
       throw new Error(`calendar status: ${res.status}`);
     }
+    // api_request falls back to null when the body does not decode as JSON,
+    // keeping the real status — so a 200 can still arrive shapeless. Fail with
+    // a legible message instead of a TypeError on `.connected` downstream.
+    if (typeof res.data !== 'object' || res.data === null) {
+      throw new Error('calendar status: malformed response');
+    }
     return res.data as CalendarStatus;
   },
 

--- a/src/tauri.ts
+++ b/src/tauri.ts
@@ -17,6 +17,16 @@ interface SessionResult {
   sessionToken: string;
 }
 
+interface CalendarConnectResult {
+  status?: string;
+  error?: string;
+}
+
+/** Why the desktop app has no Calendar read access, per the API. */
+export type CalendarStatus =
+  | { connected: true }
+  | { connected: false; reason?: string };
+
 interface ApiResponse {
   status: number;
   data: unknown;
@@ -63,6 +73,66 @@ export const auth = {
 
   async cancelSignIn(): Promise<void> {
     await invoke('cancel_google_sign_in');
+  },
+
+  /** Whether the API already holds Calendar read access for this user. */
+  async calendarStatus(): Promise<CalendarStatus> {
+    const res = await api.request('GET', '/desktop/google-calendar-status');
+    if (res.status !== 200) {
+      throw new Error(`calendar status: ${res.status}`);
+    }
+    return res.data as CalendarStatus;
+  },
+
+  /**
+   * Second hop of desktop Google auth. Sign-in cannot widen an existing grant
+   * without dropping the scopes already on file, so Calendar is acquired here
+   * through the additive Workspace connect flow. Mirrors googleSignIn(), but
+   * the loopback carries no token — only a status marker.
+   */
+  async connectGoogleCalendar(): Promise<CalendarConnectResult> {
+    let resolveResult: (result: CalendarConnectResult) => void;
+    const resultPromise = new Promise<CalendarConnectResult>((resolve) => {
+      resolveResult = resolve;
+    });
+
+    const unlisten = await getCurrentWebviewWindow().listen<CalendarConnectResult>(
+      'calendar-connect-result',
+      (event) => {
+        resolveResult(event.payload);
+      }
+    );
+
+    try {
+      const immediate = await invoke<CalendarConnectResult>('connect_google_calendar');
+      if (immediate.error) {
+        return { error: immediate.error };
+      }
+      return await resultPromise;
+    } finally {
+      unlisten();
+    }
+  },
+
+  /**
+   * Run the Calendar hop only when the API says access is missing.
+   *
+   * Callers invoke this right after a sign-in, never on plain app launch, so a
+   * user who declines Calendar on the granular-consent screen is not
+   * re-prompted every time they open the app — only next time they sign in.
+   */
+  async ensureCalendarAccess(): Promise<CalendarStatus> {
+    const status = await auth.calendarStatus();
+    if (status.connected) {
+      return status;
+    }
+    const result = await auth.connectGoogleCalendar();
+    if (result.error) {
+      throw new Error(result.error);
+    }
+    return result.status === 'connected'
+      ? { connected: true }
+      : { connected: false, reason: result.status };
   },
 
   async checkSession(): Promise<{ sessionToken: string } | null> {

--- a/src/views/OnboardingView.vue
+++ b/src/views/OnboardingView.vue
@@ -16,8 +16,9 @@
           <path fill="#FBBC05" d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" />
           <path fill="#EA4335" d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" />
         </svg>
-        <span v-if="!isSigningIn">Sign in with Google</span>
-        <span v-else>Continue in your browser…</span>
+        <span v-if="isConnectingCalendar">Connecting your calendar…</span>
+        <span v-else-if="isSigningIn">Continue in your browser…</span>
+        <span v-else>Sign in with Google</span>
       </button>
 
       <p v-if="isSigningIn" class="subheading">
@@ -56,6 +57,7 @@ const currentStep = ref(0);
 const step = computed(() => ONBOARDING_STEPS[currentStep.value]);
 
 const isSigningIn = ref(false);
+const isConnectingCalendar = ref(false);
 const errorMessage = ref('');
 
 // Persist the "finished onboarding" flag once, at the end of the flow, then
@@ -106,6 +108,17 @@ async function handleGoogleSignIn() {
     void emit(AUTH_SIGNED_IN_EVENT).catch((err) => {
       console.warn('Failed to broadcast desktop sign-in', err);
     });
+    // Sign-in alone may not carry Calendar: a user who already granted Google
+    // Workspace keeps their broader grant, which might not cover Calendar.
+    // Non-fatal — onboarding completes either way, and Settings can retry.
+    isConnectingCalendar.value = true;
+    try {
+      await auth.ensureCalendarAccess();
+    } catch (err) {
+      console.warn('Could not connect Google Calendar during onboarding', err);
+    } finally {
+      isConnectingCalendar.value = false;
+    }
     await finishOnboarding({ openSettings: true });
   } catch (error) {
     errorMessage.value = error instanceof Error ? error.message : 'Sign in failed';

--- a/src/views/SettingsView.test.ts
+++ b/src/views/SettingsView.test.ts
@@ -367,6 +367,28 @@ describe('SettingsView account avatar', () => {
     expect(wrapper.find('div.avatar').exists()).toBe(false);
   });
 
+  it('hides the sign-in button once signed in', async () => {
+    // Regression: the Connect Calendar block was inserted between the
+    // signed-in v-if and the sign-in v-else, which silently re-paired the
+    // v-else to it — so the sign-in button rendered next to Sign Out.
+    mockSignedIn(null);
+    const wrapper = mount(SettingsView);
+    await flushPromises();
+
+    expect(wrapper.find('.sign-in-container').exists()).toBe(false);
+    expect(wrapper.text()).not.toContain('Sign in with Google');
+    expect(wrapper.text()).toContain('Sign Out');
+  });
+
+  it('shows the sign-in button when signed out', async () => {
+    checkSession.mockResolvedValue(null);
+    const wrapper = mount(SettingsView);
+    await flushPromises();
+
+    expect(wrapper.find('.sign-in-container').exists()).toBe(true);
+    expect(wrapper.text()).toContain('Sign in with Google');
+  });
+
   it('falls back to the initials circle when there is no Google avatar', async () => {
     mockSignedIn(null);
     const wrapper = mount(SettingsView);

--- a/src/views/SettingsView.vue
+++ b/src/views/SettingsView.vue
@@ -204,7 +204,7 @@
           </p>
           <button
             :disabled="isConnectingCalendar"
-            class="sign-out-btn"
+            class="secondary-btn"
             @click="refreshCalendarAccess"
           >
             {{ isConnectingCalendar ? 'Continue in your browser…' : 'Connect Calendar' }}
@@ -1382,7 +1382,9 @@ async function handleSignOut() {
 
 .calendar-connect-text {
   font-size: 12px;
-  color: #9ca3af;
+  /* The file's muted 12px colour (.account-email, .setting-hint): 5.0:1 on the
+     white card, where #9ca3af managed only 2.5:1 — under the WCAG AA floor. */
+  color: #6f6f6f;
   margin: 0;
 }
 

--- a/src/views/SettingsView.vue
+++ b/src/views/SettingsView.vue
@@ -179,7 +179,10 @@
     <section v-if="backend === 'ariso'" class="section">
       <h2 class="section-title">Account</h2>
       <div class="card">
-        <div v-if="isSignedIn" class="account-info">
+        <!-- template wrapper so the sign-in v-else stays adjacent to this
+             v-if: an element between them would silently re-pair the v-else. -->
+        <template v-if="isSignedIn">
+        <div class="account-info">
           <img
             v-if="avatarUrl"
             class="avatar"
@@ -195,7 +198,7 @@
           </div>
           <button class="sign-out-btn" @click="handleSignOut">Sign Out</button>
         </div>
-        <div v-if="isSignedIn && calendarConnected === false" class="calendar-connect">
+        <div v-if="calendarConnected === false" class="calendar-connect">
           <p class="calendar-connect-text">
             Calendar isn’t connected, so oats can’t see your meetings.
           </p>
@@ -207,6 +210,7 @@
             {{ isConnectingCalendar ? 'Continue in your browser…' : 'Connect Calendar' }}
           </button>
         </div>
+        </template>
         <div v-else class="sign-in-container">
           <button
             :disabled="isSigningIn"

--- a/src/views/SettingsView.vue
+++ b/src/views/SettingsView.vue
@@ -195,6 +195,18 @@
           </div>
           <button class="sign-out-btn" @click="handleSignOut">Sign Out</button>
         </div>
+        <div v-if="isSignedIn && calendarConnected === false" class="calendar-connect">
+          <p class="calendar-connect-text">
+            Calendar isn’t connected, so oats can’t see your meetings.
+          </p>
+          <button
+            :disabled="isConnectingCalendar"
+            class="sign-out-btn"
+            @click="refreshCalendarAccess"
+          >
+            {{ isConnectingCalendar ? 'Continue in your browser…' : 'Connect Calendar' }}
+          </button>
+        </div>
         <div v-else class="sign-in-container">
           <button
             :disabled="isSigningIn"
@@ -475,6 +487,9 @@ import {
 
 const isSignedIn = ref(false);
 const isSigningIn = ref(false);
+const isConnectingCalendar = ref(false);
+// null = not checked this session; false = checked and missing.
+const calendarConnected = ref<boolean | null>(null);
 const errorMessage = ref('');
 const displayName = ref('');
 const email = ref('');
@@ -1169,10 +1184,32 @@ async function handleGoogleSignIn() {
     void emitNotificationsSync().catch((err) => {
       console.warn('Failed to sync notifications after sign-in', err);
     });
+    // Sign-in may not carry Calendar — a user who already granted Google
+    // Workspace keeps their broader grant, which might not cover it.
+    await refreshCalendarAccess();
   } catch (error) {
     errorMessage.value = error instanceof Error ? error.message : 'Sign in failed';
   } finally {
     isSigningIn.value = false;
+  }
+}
+
+/**
+ * Acquire Calendar if the API says it is missing. Deliberately not run on mount
+ * or window focus: the connect hop opens a browser consent screen, so it fires
+ * only on an explicit sign-in or a click of Connect below.
+ */
+async function refreshCalendarAccess() {
+  isConnectingCalendar.value = true;
+  calendarConnected.value = null;
+  try {
+    const status = await auth.ensureCalendarAccess();
+    calendarConnected.value = status.connected;
+  } catch (err) {
+    console.warn('Could not connect Google Calendar', err);
+    calendarConnected.value = false;
+  } finally {
+    isConnectingCalendar.value = false;
   }
 }
 
@@ -1329,6 +1366,20 @@ async function handleSignOut() {
 
 .sign-out-btn:hover {
   text-decoration: underline;
+}
+
+.calendar-connect {
+  margin-top: 12px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.calendar-connect-text {
+  font-size: 12px;
+  color: #9ca3af;
+  margin: 0;
 }
 
 .sign-in-container {


### PR DESCRIPTION
Desktop sign-in can't widen an existing Google grant without dropping scopes already on file, so a user who granted Gmail but not Calendar could never gain Calendar.

Fix: acquire Calendar through the authenticated Workspace connect flow (additive, sets `include_granted_scopes`), run only when `/desktop/google-calendar-status` reports it missing — after an explicit sign-in or a click of **Connect Calendar** in Settings, never on launch.

- `parse_loopback_callback` returns a `LoopbackDelivery` enum so the connect hop's token-less `?status=…` callback is accepted; a token always wins over a status.
- `BrowserFlow` marker on the pending-attempt slot so Cancel resolves the promise that's actually waiting.
- No capability added or widened; nothing secret crosses the loopback. Gated on a session + cloud backend, unreachable in Local mode.

Tests: 273 Rust, 629 frontend, `vite:build` clean. Hop 2 not yet exercised against the live server — the case to try is an account with Gmail but no Calendar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Google Calendar connection during onboarding and from Settings.
  - Added Calendar connection status indicators, controls, and retry options.
  - Calendar access is checked after sign-in when needed.
  - Added clear loading and error states for Calendar connection.

- **Bug Fixes**
  - Improved handling of canceled, failed, timed-out, or outdated OAuth attempts.
  - OAuth completion messages now reflect the sign-in or Calendar connection flow.
  - Signed-in users correctly see account controls instead of the sign-in option.
  - Calendar connection errors no longer block onboarding completion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
