### PR TITLE
Fix Windows Meetings title bar

### DIFF
--- a/src-tauri/capabilities/library-window-controls.json
+++ b/src-tauri/capabilities/library-window-controls.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../gen/schemas/desktop-schema.json",
+  "identifier": "library-window-controls",
+  "description": "Allow the frameless Windows Meetings titlebar to minimize and maximize its own window",
+  "windows": ["library"],
+  "permissions": [
+    "core:window:allow-minimize",
+    "core:window:allow-toggle-maximize"
+  ]
+}

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -891,46 +891,6 @@ fn waveform_url(
     url
 }
 
-#[cfg(target_os = "windows")]
-const WINDOWS_DEV_SERVER_ADDRESS: &str = "localhost:1420";
-
-#[cfg(target_os = "windows")]
-fn dev_server_accepting_connections(address: &str) -> bool {
-    use std::net::ToSocketAddrs;
-
-    address
-        .to_socket_addrs()
-        .map(|addresses| {
-            addresses.into_iter().any(|address| {
-                std::net::TcpStream::connect_timeout(
-                    &address,
-                    std::time::Duration::from_millis(150),
-                )
-                .is_ok()
-            })
-        })
-        .unwrap_or(false)
-}
-
-/// On Windows, an orphaned `tauri dev` process can outlive Vite. Creating the
-/// recorder webview in that state replaces the pill with WebView2's narrow
-/// ERR_CONNECTION_REFUSED page and marks a recording active even though its
-/// frontend never mounted. Refuse that dev-only creation before mutating any
-/// recorder state. Production uses bundled assets and bypasses this guard.
-fn ensure_waveform_assets_available() -> Result<(), String> {
-    #[cfg(target_os = "windows")]
-    if tauri::is_dev() {
-        if !dev_server_accepting_connections(WINDOWS_DEV_SERVER_ADDRESS) {
-            return Err(
-                "Oats development server is unavailable at http://localhost:1420; restart `npm.cmd run tauri:dev`"
-                    .to_string(),
-            );
-        }
-    }
-
-    Ok(())
-}
-
 /// Shared helper to open the waveform recording window. Used by the
 /// `start_recording_window` command, the tray (Local backend path), and the
 /// auto mic monitor. `auto` adds `auto=1` to the URL and tags the shared
@@ -953,7 +913,6 @@ pub(crate) fn open_waveform_window(
         let _ = existing.set_focus();
         return Ok(());
     }
-    ensure_waveform_assets_available()?;
     // Born hidden (painted-empty) when the meetings window already owns the
     // recorder UI, so the pill never flashes over it. The window is still
     // created visible for getUserMedia; only its painting is suppressed.
@@ -1970,16 +1929,6 @@ mod tests {
             waveform_url(None, true, false, Some("abc"), false),
             "/#/waveform?localAppendId=abc&auto=1"
         );
-    }
-
-    #[cfg(target_os = "windows")]
-    #[test]
-    fn dev_server_probe_distinguishes_listening_and_refused_ports() {
-        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
-        assert!(dev_server_accepting_connections(
-            &listener.local_addr().unwrap().to_string()
-        ));
-        assert!(!dev_server_accepting_connections("127.0.0.1:0"));
     }
 
     #[test]

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1568,16 +1568,23 @@ pub(crate) fn open_library_window(app: &tauri::AppHandle) -> Result<(), String> 
     }
     // Overlay title bar (with the native title hidden) lets the web content
     // extend under the traffic lights, so the in-app panel toggle can sit on
-    // the same row, just to the right of them. Other platforms keep native
-    // window chrome because this AppKit-specific composition has no equivalent
-    // role in the library UI.
+    // the same row, just to the right of them.
     #[cfg(target_os = "macos")]
     let builder =
         WebviewWindowBuilder::new(app, "library", WebviewUrl::App("/#/library".into()))
             .title("Meetings")
             .title_bar_style(tauri::TitleBarStyle::Overlay)
             .hidden_title(true);
-    #[cfg(not(target_os = "macos"))]
+    // Tauri's overlay title-bar style is macOS-only. Its supported Windows
+    // custom-titlebar path is an undecorated window plus webview controls;
+    // shadow(true) restores the Windows 11 border, rounded corners and shadow.
+    #[cfg(target_os = "windows")]
+    let builder =
+        WebviewWindowBuilder::new(app, "library", WebviewUrl::App("/#/library".into()))
+            .title("Meetings")
+            .decorations(false)
+            .shadow(true);
+    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
     let builder =
         WebviewWindowBuilder::new(app, "library", WebviewUrl::App("/#/library".into()))
             .title("Meetings");

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -11,6 +11,12 @@ const APP_USER_AGENT: &str = "ArisoDesktop/0.2.1";
 // tray, and webview requests arrive together.
 static SETTINGS_WINDOW_CREATION: std::sync::Mutex<()> = std::sync::Mutex::new(());
 static LIBRARY_WINDOW_CREATION: std::sync::Mutex<()> = std::sync::Mutex::new(());
+// Bumped on every `present_library_window` call so a stale deferred cleanup
+// task (see below) can detect it has been superseded by a newer presentation
+// and skip touching always-on-top / focus.
+#[cfg(target_os = "windows")]
+static LIBRARY_PRESENTATION_GENERATION: std::sync::atomic::AtomicU64 =
+    std::sync::atomic::AtomicU64::new(0);
 
 pub(crate) fn http_client() -> reqwest::Client {
     reqwest::Client::builder()
@@ -1606,14 +1612,32 @@ fn present_library_window(win: &tauri::WebviewWindow) -> Result<(), String> {
             eprintln!("Initial Meetings window focus was deferred: {error}");
         }
 
+        // Claim this generation before spawning so a second presentation that
+        // starts while this one's cleanup is still pending is detected below,
+        // and the older task's cleanup no longer clears the newer
+        // presentation's always-on-top state.
+        let generation =
+            LIBRARY_PRESENTATION_GENERATION.fetch_add(1, std::sync::atomic::Ordering::SeqCst) + 1;
         let win = win.clone();
         tauri::async_runtime::spawn(async move {
             tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+            if LIBRARY_PRESENTATION_GENERATION.load(std::sync::atomic::Ordering::SeqCst)
+                != generation
+            {
+                // Superseded by a newer presentation call; let its own
+                // deferred task own the cleanup instead.
+                return;
+            }
             if let Err(error) = win.set_focus() {
                 eprintln!("Failed to focus Meetings window after tray dismissal: {error}");
             }
             if let Err(error) = win.set_always_on_top(false) {
-                eprintln!("Failed to restore normal Meetings window z-order: {error}");
+                eprintln!("Failed to restore normal Meetings window z-order: {error}, retrying");
+                if let Err(retry_error) = win.set_always_on_top(false) {
+                    eprintln!(
+                        "Failed to restore normal Meetings window z-order after retry: {retry_error}"
+                    );
+                }
             }
         });
         return Ok(());

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1549,6 +1549,39 @@ pub async fn create_library_window(app: tauri::AppHandle) -> Result<(), String> 
     open_library_window(&app)
 }
 
+/// Make the Meetings window visible and put it at the front of the user's
+/// current workspace. Windows can reject foreground activation while a native
+/// tray menu is still dismissing, so briefly enter the topmost band and retry
+/// focus after the menu has had time to close. The window is then returned to
+/// normal z-order; this is a raise operation, not permanent always-on-top.
+fn present_library_window(win: &tauri::WebviewWindow) -> Result<(), String> {
+    win.unminimize().map_err(|e| e.to_string())?;
+    win.show().map_err(|e| e.to_string())?;
+
+    #[cfg(target_os = "windows")]
+    {
+        win.set_always_on_top(true).map_err(|e| e.to_string())?;
+        if let Err(error) = win.set_focus() {
+            eprintln!("Initial Meetings window focus was deferred: {error}");
+        }
+
+        let win = win.clone();
+        tauri::async_runtime::spawn(async move {
+            tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+            if let Err(error) = win.set_focus() {
+                eprintln!("Failed to focus Meetings window after tray dismissal: {error}");
+            }
+            if let Err(error) = win.set_always_on_top(false) {
+                eprintln!("Failed to restore normal Meetings window z-order: {error}");
+            }
+        });
+        return Ok(());
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    win.set_focus().map_err(|e| e.to_string())
+}
+
 /// Open (or focus) the meetings library window. Shared by the
 /// `create_library_window` command and the macOS dock-icon Reopen handler.
 pub(crate) fn open_library_window(app: &tauri::AppHandle) -> Result<(), String> {
@@ -1560,11 +1593,7 @@ pub(crate) fn open_library_window(app: &tauri::AppHandle) -> Result<(), String> 
     // close and recreated (with fresh data) on the next open. This branch only
     // fires if it is opened again while still visible — just focus it.
     if let Some(win) = app.get_webview_window("library") {
-        // Restore the window if it was minimized/hidden before focusing it.
-        let _ = win.unminimize();
-        let _ = win.show();
-        win.set_focus().map_err(|e| e.to_string())?;
-        return Ok(());
+        return present_library_window(&win);
     }
     // Overlay title bar (with the native title hidden) lets the web content
     // extend under the traffic lights, so the in-app panel toggle can sit on
@@ -1588,14 +1617,14 @@ pub(crate) fn open_library_window(app: &tauri::AppHandle) -> Result<(), String> 
     let builder =
         WebviewWindowBuilder::new(app, "library", WebviewUrl::App("/#/library".into()))
             .title("Meetings");
-    builder
+    let win = builder
         .inner_size(900.0, 600.0)
         .resizable(true)
         .center()
         .skip_taskbar(true)
         .build()
         .map_err(|e| e.to_string())?;
-    Ok(())
+    present_library_window(&win)
 }
 
 #[derive(serde::Deserialize)]

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -885,6 +885,46 @@ fn waveform_url(
     url
 }
 
+#[cfg(target_os = "windows")]
+const WINDOWS_DEV_SERVER_ADDRESS: &str = "localhost:1420";
+
+#[cfg(target_os = "windows")]
+fn dev_server_accepting_connections(address: &str) -> bool {
+    use std::net::ToSocketAddrs;
+
+    address
+        .to_socket_addrs()
+        .map(|addresses| {
+            addresses.into_iter().any(|address| {
+                std::net::TcpStream::connect_timeout(
+                    &address,
+                    std::time::Duration::from_millis(150),
+                )
+                .is_ok()
+            })
+        })
+        .unwrap_or(false)
+}
+
+/// On Windows, an orphaned `tauri dev` process can outlive Vite. Creating the
+/// recorder webview in that state replaces the pill with WebView2's narrow
+/// ERR_CONNECTION_REFUSED page and marks a recording active even though its
+/// frontend never mounted. Refuse that dev-only creation before mutating any
+/// recorder state. Production uses bundled assets and bypasses this guard.
+fn ensure_waveform_assets_available() -> Result<(), String> {
+    #[cfg(target_os = "windows")]
+    if tauri::is_dev() {
+        if !dev_server_accepting_connections(WINDOWS_DEV_SERVER_ADDRESS) {
+            return Err(
+                "Oats development server is unavailable at http://localhost:1420; restart `npm.cmd run tauri:dev`"
+                    .to_string(),
+            );
+        }
+    }
+
+    Ok(())
+}
+
 /// Shared helper to open the waveform recording window. Used by the
 /// `start_recording_window` command, the tray (Local backend path), and the
 /// auto mic monitor. `auto` adds `auto=1` to the URL and tags the shared
@@ -907,6 +947,7 @@ pub(crate) fn open_waveform_window(
         let _ = existing.set_focus();
         return Ok(());
     }
+    ensure_waveform_assets_available()?;
     // Born hidden (painted-empty) when the meetings window already owns the
     // recorder UI, so the pill never flashes over it. The window is still
     // created visible for getUserMedia; only its painting is suppressed.
@@ -1903,6 +1944,16 @@ mod tests {
             waveform_url(None, true, false, Some("abc"), false),
             "/#/waveform?localAppendId=abc&auto=1"
         );
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn dev_server_probe_distinguishes_listening_and_refused_ports() {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        assert!(dev_server_accepting_connections(
+            &listener.local_addr().unwrap().to_string()
+        ));
+        assert!(!dev_server_accepting_connections("127.0.0.1:0"));
     }
 
     #[test]

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -11,12 +11,12 @@ const APP_USER_AGENT: &str = "ArisoDesktop/0.2.1";
 // tray, and webview requests arrive together.
 static SETTINGS_WINDOW_CREATION: std::sync::Mutex<()> = std::sync::Mutex::new(());
 static LIBRARY_WINDOW_CREATION: std::sync::Mutex<()> = std::sync::Mutex::new(());
-// Bumped on every `present_library_window` call so a stale deferred cleanup
-// task (see below) can detect it has been superseded by a newer presentation
-// and skip touching always-on-top / focus.
+// Serializes each temporary Windows z-order presentation with its deferred
+// cleanup. The generation lets a cleanup detect that a newer presentation
+// superseded it, while the mutex prevents either side from changing the
+// topmost state between that validation and the corresponding window calls.
 #[cfg(target_os = "windows")]
-static LIBRARY_PRESENTATION_GENERATION: std::sync::atomic::AtomicU64 =
-    std::sync::atomic::AtomicU64::new(0);
+static LIBRARY_PRESENTATION_GENERATION: std::sync::Mutex<u64> = std::sync::Mutex::new(0);
 
 pub(crate) fn http_client() -> reqwest::Client {
     reqwest::Client::builder()
@@ -1607,23 +1607,25 @@ fn present_library_window(win: &tauri::WebviewWindow) -> Result<(), String> {
 
     #[cfg(target_os = "windows")]
     {
+        let mut presentation_generation = LIBRARY_PRESENTATION_GENERATION
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         win.set_always_on_top(true).map_err(|e| e.to_string())?;
         if let Err(error) = win.set_focus() {
             eprintln!("Initial Meetings window focus was deferred: {error}");
         }
 
-        // Claim this generation before spawning so a second presentation that
-        // starts while this one's cleanup is still pending is detected below,
-        // and the older task's cleanup no longer clears the newer
-        // presentation's always-on-top state.
-        let generation =
-            LIBRARY_PRESENTATION_GENERATION.fetch_add(1, std::sync::atomic::Ordering::SeqCst) + 1;
+        *presentation_generation = presentation_generation.wrapping_add(1);
+        let generation = *presentation_generation;
+        drop(presentation_generation);
+
         let win = win.clone();
         tauri::async_runtime::spawn(async move {
             tokio::time::sleep(std::time::Duration::from_millis(200)).await;
-            if LIBRARY_PRESENTATION_GENERATION.load(std::sync::atomic::Ordering::SeqCst)
-                != generation
-            {
+            let presentation_generation = LIBRARY_PRESENTATION_GENERATION
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            if *presentation_generation != generation {
                 // Superseded by a newer presentation call; let its own
                 // deferred task own the cleanup instead.
                 return;

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -223,7 +223,9 @@ pub fn start_recording(app: &AppHandle) {
 pub fn open_library(app: &AppHandle) {
     let app_async = app.clone();
     tauri::async_runtime::spawn(async move {
-        let _ = crate::commands::create_library_window(app_async).await;
+        if let Err(error) = crate::commands::create_library_window(app_async).await {
+            eprintln!("Failed to present Meetings window: {error}");
+        }
     });
 }
 

--- a/src/views/LibraryView.test.ts
+++ b/src/views/LibraryView.test.ts
@@ -18,10 +18,24 @@ const emitNotificationsSync = vi.fn(() => Promise.resolve());
 const getMeetingPrep = vi.fn();
 const openPrepTab = vi.fn();
 const listPendingUploads = vi.fn(() => Promise.resolve([]));
+const minimizeWindow = vi.fn(() => Promise.resolve());
+const toggleMaximizeWindow = vi.fn(() => Promise.resolve());
+const closeWindow = vi.fn(() => Promise.resolve());
+const isWindowMaximized = vi.fn(() => Promise.resolve(false));
+const onWindowResized = vi.fn(() => Promise.resolve(() => undefined));
 
 vi.mock('@tauri-apps/api/core', () => ({ invoke: (...a: unknown[]) => invoke(...a) }));
 vi.mock('@tauri-apps/api/webviewWindow', () => ({
   getAllWebviewWindows: () => getAllWebviewWindows(),
+}));
+vi.mock('@tauri-apps/api/window', () => ({
+  getCurrentWindow: () => ({
+    minimize: () => minimizeWindow(),
+    toggleMaximize: () => toggleMaximizeWindow(),
+    close: () => closeWindow(),
+    isMaximized: () => isWindowMaximized(),
+    onResized: (handler: () => void) => onWindowResized(handler),
+  }),
 }));
 
 // In-test event bus standing in for Tauri's app-wide events: `listen` records
@@ -136,6 +150,8 @@ beforeEach(() => {
   invoke.mockResolvedValue(undefined);
   getMeetingPrep.mockResolvedValue(null);
   listPendingUploads.mockResolvedValue([]);
+  isWindowMaximized.mockResolvedValue(false);
+  onWindowResized.mockResolvedValue(() => undefined);
   readRecordingNote.mockResolvedValue('');
   writeRecordingNote.mockResolvedValue(undefined);
   backendId.mockReturnValue('local');
@@ -152,6 +168,62 @@ afterEach(() => {
 });
 
 describe('LibraryView', () => {
+  it('integrates the sidebar toggle and native-equivalent controls into Windows title chrome', async () => {
+    vi.spyOn(window.navigator, 'userAgent', 'get').mockReturnValue('Mozilla/5.0 (Windows NT 10.0; Win64; x64)');
+    listMeetings.mockResolvedValue([]);
+
+    const wrapper = mount(LibraryView);
+    await flushPromises();
+
+    const titlebar = wrapper.get('.titlebar--windows');
+    expect(titlebar.text()).toContain('Meetings');
+    expect(titlebar.find('.panel-toggle').exists()).toBe(true);
+    expect(titlebar.findAll('.window-control')).toHaveLength(3);
+
+    await titlebar.get('.panel-toggle').trigger('click');
+    expect(wrapper.find('.sidebar').exists()).toBe(false);
+  });
+
+  it('wires the Windows titlebar controls to the current Tauri window', async () => {
+    vi.spyOn(window.navigator, 'userAgent', 'get').mockReturnValue('Mozilla/5.0 (Windows NT 10.0; Win64; x64)');
+    listMeetings.mockResolvedValue([]);
+
+    const wrapper = mount(LibraryView);
+    await flushPromises();
+
+    await wrapper.get('[aria-label="Minimize window"]').trigger('click');
+    await wrapper.get('[aria-label="Maximize window"]').trigger('click');
+    await wrapper.get('[aria-label="Close window"]').trigger('click');
+
+    expect(minimizeWindow).toHaveBeenCalledOnce();
+    expect(toggleMaximizeWindow).toHaveBeenCalledOnce();
+    expect(closeWindow).toHaveBeenCalledOnce();
+  });
+
+  it('shows a restore control when the Windows library is maximized', async () => {
+    vi.spyOn(window.navigator, 'userAgent', 'get').mockReturnValue('Mozilla/5.0 (Windows NT 10.0; Win64; x64)');
+    isWindowMaximized.mockResolvedValue(true);
+    listMeetings.mockResolvedValue([]);
+
+    const wrapper = mount(LibraryView);
+    await flushPromises();
+
+    expect(wrapper.find('[aria-label="Restore window"]').exists()).toBe(true);
+    expect(wrapper.find('[aria-label="Maximize window"]').exists()).toBe(false);
+  });
+
+  it('keeps custom Windows controls out of the macOS overlay titlebar', async () => {
+    vi.spyOn(window.navigator, 'userAgent', 'get').mockReturnValue('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)');
+    listMeetings.mockResolvedValue([]);
+
+    const wrapper = mount(LibraryView);
+    await flushPromises();
+
+    expect(wrapper.find('.titlebar--windows').exists()).toBe(false);
+    expect(wrapper.find('.window-controls').exists()).toBe(false);
+    expect(wrapper.find('.panel-toggle').exists()).toBe(true);
+  });
+
   it('shows an empty state when there are no meetings', async () => {
     listMeetings.mockResolvedValue([]);
     const wrapper = mount(LibraryView);

--- a/src/views/LibraryView.vue
+++ b/src/views/LibraryView.vue
@@ -1,8 +1,18 @@
 <template>
-  <div class="library">
-    <!-- Transparent drag region across the top, holding the panel toggle next
-         to the native traffic lights. -->
-    <div class="titlebar" data-tauri-drag-region>
+  <div class="library" :class="{ 'library--windows': isWindows }">
+    <!-- macOS overlays this row beside the native traffic lights. Windows uses
+         it as the complete titlebar, including native-equivalent controls. -->
+    <div
+      class="titlebar"
+      :class="{ 'titlebar--windows': isWindows }"
+      data-tauri-drag-region
+      @dblclick.self="toggleLibraryWindowMaximize"
+    >
+      <div v-if="isWindows" class="titlebar-brand" data-tauri-drag-region>
+        <img class="titlebar-logo" :src="oatsLogo" alt="" data-tauri-drag-region />
+        <span class="titlebar-title" data-tauri-drag-region>Meetings</span>
+      </div>
+      <span v-if="isWindows" class="titlebar-divider" aria-hidden="true" />
       <button
         class="panel-toggle"
         :aria-pressed="leftPanelVisible"
@@ -57,6 +67,40 @@
           {{ recordingStarting ? 'Starting recording…' : 'Start recording' }}
         </span>
       </button>
+      <div v-if="isWindows" class="window-controls">
+        <button
+          class="window-control"
+          type="button"
+          aria-label="Minimize window"
+          title="Minimize"
+          @click="minimizeLibraryWindow"
+        >
+          <svg viewBox="0 0 12 12" aria-hidden="true"><path d="M1.5 6.5h9" /></svg>
+        </button>
+        <button
+          class="window-control"
+          type="button"
+          :aria-label="libraryWindowMaximized ? 'Restore window' : 'Maximize window'"
+          :title="libraryWindowMaximized ? 'Restore' : 'Maximize'"
+          @click="toggleLibraryWindowMaximize"
+        >
+          <svg v-if="libraryWindowMaximized" viewBox="0 0 12 12" aria-hidden="true">
+            <path d="M3.5 3.5v-2h7v7h-2M1.5 3.5h7v7h-7z" />
+          </svg>
+          <svg v-else viewBox="0 0 12 12" aria-hidden="true">
+            <rect x="1.5" y="1.5" width="9" height="9" />
+          </svg>
+        </button>
+        <button
+          class="window-control window-control--close"
+          type="button"
+          aria-label="Close window"
+          title="Close"
+          @click="closeLibraryWindow"
+        >
+          <svg viewBox="0 0 12 12" aria-hidden="true"><path d="m2 2 8 8M10 2 2 10" /></svg>
+        </button>
+      </div>
     </div>
 
     <aside v-if="leftPanelVisible" class="sidebar">
@@ -182,6 +226,7 @@
 import { ref, computed, watch, nextTick, onMounted, onUnmounted } from 'vue';
 import { invoke } from '@tauri-apps/api/core';
 import { emit, listen, type UnlistenFn } from '@tauri-apps/api/event';
+import { getCurrentWindow } from '@tauri-apps/api/window';
 import { getAllWebviewWindows } from '@tauri-apps/api/webviewWindow';
 import { getActiveBackend, timestampTitle, BACKEND_CHANGED_EVENT, type Backend, type MeetingListItem } from '../composables/useBackend';
 import { timestampFromLocalRecordingId } from '../composables/localRecordingId';
@@ -204,6 +249,7 @@ import AriJoinConfirmDialog from './AriJoinConfirmDialog.vue';
 import { decideStartRecording } from '../composables/decideStartRecording';
 import { useRecordingStartChoice } from '../composables/useRecordingStartChoice';
 import RecordingStartChoiceDialog from './RecordingStartChoiceDialog.vue';
+import oatsLogo from '../assets/oats-dark.svg';
 
 const meetings = ref<MeetingListItem[]>([]);
 const loading = ref(true);
@@ -216,6 +262,7 @@ const recordingPhase = ref<RecorderPhase | null>(null);
 // capture and must not unlock a second recorder underneath it.
 const recorderOwnsLifecycle = ref(false);
 const leftPanelVisible = ref(true);
+const libraryWindowMaximized = ref(false);
 const selectedItem = ref<MeetingListItem | null>(null);
 // Tracks the row the user intentionally selected; auto-load and recorder-driven
 // selections must not override Today's "record the live meeting" behavior.
@@ -276,7 +323,26 @@ const activeView = ref<'today' | 'meetings'>('meetings');
 const isMac = computed(() =>
   typeof navigator !== 'undefined' && navigator.platform.toUpperCase().includes('MAC')
 );
+const isWindows = computed(() =>
+  typeof navigator !== 'undefined' && /Windows/i.test(navigator.userAgent)
+);
 const searchShortcutLabel = computed(() => (isMac.value ? '⌘K' : 'Ctrl K'));
+
+const libraryWindow = getCurrentWindow();
+async function syncLibraryWindowMaximized(): Promise<void> {
+  libraryWindowMaximized.value = await libraryWindow.isMaximized();
+}
+async function minimizeLibraryWindow(): Promise<void> {
+  await libraryWindow.minimize();
+}
+async function toggleLibraryWindowMaximize(): Promise<void> {
+  if (!isWindows.value) return;
+  await libraryWindow.toggleMaximize();
+  await syncLibraryWindowMaximized();
+}
+async function closeLibraryWindow(): Promise<void> {
+  await libraryWindow.close();
+}
 
 // An in-progress local recording has no list row yet (the entry is created on
 // finalize). Synthesize one under the id the finalized recording will use, so
@@ -869,6 +935,7 @@ let unlistenRecordingReveal: UnlistenFn | null = null;
 let unlistenVaultChanged: UnlistenFn | null = null;
 let unlistenBackendChanged: UnlistenFn | null = null;
 let unlistenPrepOpen: UnlistenFn | null = null;
+let unlistenWindowResized: UnlistenFn | null = null;
 
 // Recover the attached meeting for a recording that started before this
 // library window existed. The `recording://started` event is one-shot, so a
@@ -885,6 +952,14 @@ async function recoverActiveRecording(): Promise<void> {
 }
 
 onMounted(() => {
+  if (isWindows.value) {
+    void syncLibraryWindowMaximized();
+    void libraryWindow.onResized(() => {
+      void syncLibraryWindowMaximized();
+    }).then((un) => {
+      unlistenWindowResized = un;
+    });
+  }
   void loadMeetings(true)
     .then(() => recoverActiveRecording())
     // A prep notification click that opened this window queued its prep before
@@ -948,6 +1023,7 @@ onUnmounted(() => {
   unlistenVaultChanged?.();
   unlistenBackendChanged?.();
   unlistenPrepOpen?.();
+  unlistenWindowResized?.();
 });
 </script>
 
@@ -962,7 +1038,7 @@ onUnmounted(() => {
   box-sizing: border-box;
 }
 
-/* Transparent title-bar overlay (panel toggle by the traffic lights). */
+/* macOS transparent overlay; Windows promotes this row to full custom chrome. */
 .titlebar {
   position: absolute;
   top: 0;
@@ -975,6 +1051,38 @@ onUnmounted(() => {
   align-items: center;
   padding: 3px 5px 0 78px;
   background: transparent;
+}
+.titlebar--windows {
+  height: 40px;
+  padding: 0;
+  background: rgba(247, 246, 244, 0.98);
+  border-bottom: 1px solid #e4e2de;
+  box-shadow: 0 1px 0 rgba(255, 255, 255, 0.72) inset;
+  user-select: none;
+}
+.titlebar-brand {
+  height: 100%;
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  padding-left: 12px;
+  color: #363431;
+}
+.titlebar-logo {
+  width: 18px;
+  height: 18px;
+  object-fit: contain;
+}
+.titlebar-title {
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+}
+.titlebar-divider {
+  width: 1px;
+  height: 18px;
+  margin-left: 11px;
+  background: #d8d5d0;
 }
 .panel-toggle {
   display: flex;
@@ -992,6 +1100,50 @@ onUnmounted(() => {
 }
 .panel-toggle:hover { background: #ecebe8; color: #1c1c1c; }
 .panel-toggle[aria-pressed='true'] { color: #1c1c1c; }
+.titlebar--windows .panel-toggle {
+  width: 34px;
+  height: 30px;
+  margin-left: 5px;
+  border-radius: 7px;
+}
+.titlebar--windows .add-btn {
+  height: 26px;
+  margin-right: 9px;
+  border-radius: 13px;
+}
+.window-controls {
+  align-self: stretch;
+  display: flex;
+}
+.window-control {
+  width: 46px;
+  height: 40px;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: #3d3b38;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: default;
+  transition: background 80ms ease, color 80ms ease;
+}
+.window-control:hover { background: #e6e3df; }
+.window-control--close:hover { background: #c42b1c; color: #ffffff; }
+.titlebar--windows .panel-toggle:focus-visible,
+.titlebar--windows .add-btn:focus-visible,
+.window-control:focus-visible {
+  outline: 2px solid #3b6fc4;
+  outline-offset: -3px;
+}
+.window-control svg {
+  width: 11px;
+  height: 11px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 1;
+  shape-rendering: crispEdges;
+}
 
 /* Sidebar */
 .sidebar {
@@ -1003,6 +1155,7 @@ onUnmounted(() => {
   flex-direction: column;
   min-height: 0;
 }
+.library--windows .sidebar { padding-top: 52px; }
 .sidebar-head {
   display: flex;
   align-items: center;
@@ -1272,6 +1425,7 @@ onUnmounted(() => {
   flex-direction: column;
   min-height: 0;
 }
+.library--windows .detail-wrap { padding-top: 52px; }
 .detail-card {
   flex: 1;
   min-height: 0;


### PR DESCRIPTION

<img width="921" height="620" alt="Screenshot 2026-08-04 at 10 33 05 AM" src="https://github.com/user-attachments/assets/f1b5b0cf-2e5f-4981-bc38-1a8ca4ef95d4" />


## Summary

- replace the Windows native Meetings chrome with a modern integrated Tauri title bar
- place the sidebar toggle, recording action, and native-equivalent window controls in one 40px row
- preserve the existing macOS overlay behavior
- scope minimize/maximize permissions to the library window

Fixes #272

## Verification

- 627 frontend tests pass
- production frontend build passes
- Windows x64 Rust/Tauri compile passes in CI
- NSIS and MSI packaging passes in CI
- live Windows smoke test confirms responsive sidebar collapse/restore and maximize/restore geometry
- live CDP screenshots reviewed at 900x600 and maximized 2560x1600

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features

* Added a branded custom title bar for Windows with drag, minimize, maximize/restore, and close controls.
* Added responsive Library window layout with synchronized maximized-state behavior.
* Added improved Library window presentation when opened, including reliable restoration, focus, and visibility.
* Added Windows-specific native styling while preserving the macOS overlay title bar and standard decorations on other platforms.

## Bug Fixes

* Improved cleanup of window resize handling when leaving the Library view.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->