### PR TITLE
fix(ci): publish Windows artifacts to R2 instead of silently skipping

### DIFF
--- a/.github/workflows/release-windows.yaml
+++ b/.github/workflows/release-windows.yaml
@@ -50,13 +50,23 @@ concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: false
 
+# Every gate below on a boolean input goes through `format('{0}', …) == 'true'`
+# rather than testing the input directly. `type: boolean` only yields a real
+# boolean when a human ticks the checkbox in the UI; a REST/`gh workflow run`
+# dispatch delivers inputs as strings, and in an Actions expression EVERY
+# non-empty string is truthy — including 'false'. So `if: ${{ !inputs.skip_publish }}`
+# reads `!'false'` → `!true` → false and silently skips, which is exactly how
+# run 30753377275 signed a release and then published nothing while reporting
+# success. `format` stringifies both shapes to 'true'/'false' first, so the
+# comparison is correct whether the value arrived as a boolean or a string.
+
 jobs:
   # The default packaging path. It and the unsigned `package-windows` job below
   # are mutually exclusive on `inputs.sign` and upload the SAME artifact name,
   # so `sign-windows-updater` consumes whichever one ran without caring which.
   package-windows-authenticode:
     name: Build and Authenticode-sign x64 NSIS and MSI installers
-    if: ${{ inputs.sign }}
+    if: ${{ format('{0}', inputs.sign) == 'true' }}
     runs-on: windows-latest
     # SSL.com credentials are isolated from Apple/R2/updater-key credentials.
     # In particular, this job cannot produce a Tauri .sig before Authenticode.
@@ -289,7 +299,7 @@ jobs:
     # The escape hatch for shipping while eSigner is down. Mutually exclusive
     # with the Authenticode job above, and uploads the same artifact name so the
     # rest of the pipeline is identical either way.
-    if: ${{ !inputs.sign }}
+    if: ${{ format('{0}', inputs.sign) != 'true' }}
     runs-on: windows-latest
     permissions:
       contents: read
@@ -508,7 +518,16 @@ jobs:
     needs: sign-windows-updater
     # `skip_publish` stops here: the run still leaves a fully signed, verified
     # installer on the `windows-release-bundle` artifact for inspection.
-    if: ${{ !inputs.skip_publish }}
+    #
+    # The upstream result is asserted explicitly rather than left to implicit
+    # skip propagation. `sign-windows-updater` already overrides its own gate
+    # with `!cancelled()` to tolerate the packaging job it did not use being
+    # skipped, and this job must not inherit any of that reasoning second-hand —
+    # it publishes only when the updater signature genuinely succeeded.
+    if: >-
+      ${{ !cancelled()
+      && needs.sign-windows-updater.result == 'success'
+      && format('{0}', inputs.skip_publish) != 'true' }}
     # Linux, not macOS: this job only downloads an artifact and talks to R2, and
     # the hosted Ubuntu image already ships bash 5, jq, and the AWS CLI.
     runs-on: ubuntu-latest
@@ -601,3 +620,44 @@ jobs:
           body: |
 
             **Windows** — [Download x64 installer](https://pub-dd2807d512d34e55b8a863f675ea8e6e.r2.dev/desktop/oats-windows-x86_64.exe)
+
+  # The assertion that run 30753377275 was missing. That run Authenticode-signed
+  # a release, generated the updater signature, skipped the publish job on a
+  # miscast boolean, and reported SUCCESS — so nothing anywhere said the release
+  # had shipped no Windows bytes. Unless a dry run was explicitly requested, a
+  # green `Release (Windows)` must mean the artifacts are on R2, and this job is
+  # what makes that true.
+  verify-published:
+    name: Verify Windows artifacts reached R2
+    needs: [package-windows, package-windows-authenticode, sign-windows-updater, publish-windows]
+    if: ${{ always() && format('{0}', inputs.skip_publish) != 'true' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Require a successful publish
+        env:
+          PACKAGE_SIGNED: ${{ needs.package-windows-authenticode.result }}
+          PACKAGE_UNSIGNED: ${{ needs.package-windows.result }}
+          SIGN: ${{ needs.sign-windows-updater.result }}
+          PUBLISH: ${{ needs.publish-windows.result }}
+        run: |
+          if [[ "$PUBLISH" == "success" ]]; then
+            echo "Windows artifacts published to R2."
+            exit 0
+          fi
+
+          echo "This run did not publish Windows artifacts to R2." >&2
+          echo >&2
+          echo "  package-windows-authenticode: ${PACKAGE_SIGNED}" >&2
+          echo "  package-windows (unsigned):   ${PACKAGE_UNSIGNED}" >&2
+          echo "  sign-windows-updater:         ${SIGN}" >&2
+          echo "  publish-windows:              ${PUBLISH}" >&2
+          echo >&2
+          if [[ "$PUBLISH" == "skipped" && "$SIGN" == "success" ]]; then
+            echo "The signing chain succeeded but publish was skipped — check the" >&2
+            echo "'if' gate on publish-windows before re-dispatching." >&2
+          else
+            echo "Fix the failing job above, then re-dispatch the same tag." >&2
+          fi
+          exit 1

--- a/.github/workflows/release-windows.yaml
+++ b/.github/workflows/release-windows.yaml
@@ -627,10 +627,16 @@ jobs:
   # had shipped no Windows bytes. Unless a dry run was explicitly requested, a
   # green `Release (Windows)` must mean the artifacts are on R2, and this job is
   # what makes that true.
+  #
+  # `!cancelled()`, not `always()`: a cancelled run is not green, so the
+  # assertion is not needed there, and `always()` would fire anyway and blame a
+  # deliberate cancellation on the publish gate. Naming a status check function
+  # is what waives the implicit `success()` on `needs`, so this still runs when
+  # a dependency failed OR was skipped — which is the only case that matters.
   verify-published:
     name: Verify Windows artifacts reached R2
     needs: [package-windows, package-windows-authenticode, sign-windows-updater, publish-windows]
-    if: ${{ always() && format('{0}', inputs.skip_publish) != 'true' }}
+    if: ${{ !cancelled() && format('{0}', inputs.skip_publish) != 'true' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -128,7 +128,14 @@ jobs:
           # failure the summary exists to prevent.
           DISPATCHED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 
-          gh workflow run release-windows.yaml --ref main --raw-field tag="$TAG"
+          # sign/skip_publish are passed explicitly even though these are the
+          # workflow's declared defaults. This is the release path: it must
+          # always Authenticode-sign AND publish to R2, so the intent belongs in
+          # the call rather than in a default another edit could flip.
+          gh workflow run release-windows.yaml --ref main \
+            --raw-field tag="$TAG" \
+            --raw-field sign=true \
+            --raw-field skip_publish=false
 
           # Dispatch is asynchronous; give the run a moment to appear so the
           # summary can link straight to it. Never fail the release over this —


### PR DESCRIPTION
## The bug

`publish-windows` was gated on:

```yaml
if: ${{ !inputs.skip_publish }}
```

`type: boolean` only yields a real boolean when a human ticks the checkbox in the UI. A REST / `gh workflow run` dispatch delivers inputs as **strings**, and [every non-empty string is truthy in an Actions expression](https://docs.github.com/en/actions/reference/workflows-and-actions/expressions) — including `'false'`. So the gate evaluated `!'false'` → `!true` → **false**.

With `skip_publish` defaulting to `false`, that gate was *always* false. `publish-windows` has never run since the Windows split landed.

## Evidence

[Run 30753377275](https://github.com/ariso-ai/oats/actions/runs/30753377275) Authenticode-signed v0.19.0, generated the updater signature, skipped publish, and reported **success**. Its three gates pin the cause — only one of them discriminates between the two hypotheses:

| job | gate | if boolean | if string | observed |
|---|---|---|---|---|
| `package-windows-authenticode` | `inputs.sign` | run | run | ran |
| `package-windows` | `!inputs.sign` | skip | skip | skipped |
| `publish-windows` | `!inputs.skip_publish` | **run** | **skip** | **skipped** |

Its single `needs` (`sign-windows-updater`) succeeded, so nothing else could have skipped it.

`inputs.sign` had the same bug in both directions: `-f sign=false` arrived as the truthy string `'false'`, so the Authenticode job ran anyway and the unsigned emergency path never did.

## Live impact

- `desktop/latest-windows-x86_64.json` → **404**
- `desktop/oats-windows-x86_64.exe` → **200** (19 MB, `Last-Modified: Thu, 30 Jul 2026 19:53:47 GMT` — uploaded by hand, pre-0.19.0)

A publicly downloadable Windows installer with no updater manifest. Those clients fall through to the macOS-only `latest.json`, and per `tauri-plugin-updater-2.10.1/src/updater.rs` the missing platform key yields a hard `Error::TargetNotFound` — an update-check *error* on every poll, not a clean "no update available".

## The fix

Every boolean gate stringifies before comparing, which is correct whether the value arrives as a boolean or a string:

```yaml
if: ${{ format('{0}', inputs.sign) == 'true' }}          # authenticode
if: ${{ format('{0}', inputs.sign) != 'true' }}          # unsigned — exact complement
if: >-                                                   # publish
  ${{ !cancelled()
  && needs.sign-windows-updater.result == 'success'
  && format('{0}', inputs.skip_publish) != 'true' }}
```

Verified over all four input shapes (`true`/`false` × boolean/string): the two `sign` gates are exact complements, so exactly one packaging job always runs; publish skips only on a genuine `true`.

Also in this PR:

- **`publish-windows` asserts the upstream result explicitly** rather than relying on implicit skip propagation, so it cannot inherit `sign-windows-updater`'s own `!cancelled()` override second-hand.
- **`release.yaml` passes `sign=true` / `skip_publish=false` explicitly.** This is the release path — it must always sign and publish, so the intent belongs in the call rather than in a default a later edit could flip.
- **New `verify-published` job** (`always()`): unless a dry run was requested, it fails the run when `publish-windows` did not succeed, printing every job's result. A green `Release (Windows)` that shipped nothing is exactly what hid this bug.

## Verification

- `actionlint` clean on both workflows.
- Gate truth table checked over all four input shapes.
- Not runnable before merge: `workflow_dispatch` requires the workflow on the default branch, and the `release` / `windows-release` environments only allow `main` + `v*`.

## After merge

This is a `fix(ci):`, so release-please will cut a patch — that release will exercise the corrected path end to end. If you'd rather not wait, re-dispatch v0.19.0 directly:

```shell
gh workflow run release-windows.yaml --ref main -f tag=v0.19.0
```

Either way, that publish is what finally creates `desktop/latest-windows-x86_64.json` and clears the update-check error for anyone running the hand-uploaded installer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows release handling for manually triggered workflows.
  * Ensured unsigned and non-publishing builds are selected correctly when requested.
  * Added validation to detect unsuccessful or skipped Windows publication steps and report the resulting release status clearly.

* **Release Process**
  * Automated releases now explicitly request signing and publishing for Windows builds.
  * Added safeguards to prevent releases from being marked successful unless required signing and publishing steps complete.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->