### PR TITLE
fix(windows): guarantee a single recorder pill

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -940,7 +940,22 @@ pub(crate) fn open_waveform_window(
         let _ = picker.close();
     }
     if let Some(existing) = app.get_webview_window("waveform") {
+        // Backfill the lifecycle claim for a registered window that still owns
+        // capture, upload, retry, or its native close transition.
+        let _ = app
+            .state::<crate::recording_state::RecordingState>()
+            .try_claim_window();
         let _ = existing.set_focus();
+        return Ok(());
+    }
+    let recording_state = app.state::<crate::recording_state::RecordingState>();
+    if !recording_state.try_claim_window() {
+        // Another launcher is between its preflight check and native window
+        // registration. Treat this request as idempotent instead of creating
+        // a second recorder pill.
+        if let Some(existing) = app.get_webview_window("waveform") {
+            let _ = existing.set_focus();
+        }
         return Ok(());
     }
     // Born hidden (painted-empty) when the meetings window already owns the
@@ -948,7 +963,7 @@ pub(crate) fn open_waveform_window(
     // created visible for getUserMedia; only its painting is suppressed.
     let pill_hidden = !crate::recorder_pill::should_show_now(app);
     let url = waveform_url(meeting_id, auto, pill_hidden, local_append_id.as_deref(), force_new);
-    let win = WebviewWindowBuilder::new(app, "waveform", WebviewUrl::App(url.into()))
+    let win = match WebviewWindowBuilder::new(app, "waveform", WebviewUrl::App(url.into()))
         .title("")
         // Fixed size: room for the expanded pill plus its CSS shadow. The pill
         // itself is anchored to the bottom and grows upward within this window.
@@ -970,7 +985,25 @@ pub(crate) fn open_waveform_window(
         .shadow(false)
         .skip_taskbar(true)
         .build()
-        .map_err(|e| e.to_string())?;
+    {
+        Ok(win) => win,
+        Err(error) => {
+            recording_state.release_window_claim();
+            return Err(error.to_string());
+        }
+    };
+
+    // Capture may stop before upload/close completes. Keep the one-window
+    // claim until this native window is actually destroyed.
+    let app_for_event = app.clone();
+    win.on_window_event(move |event| {
+        if let tauri::WindowEvent::Destroyed = event {
+            let state = app_for_event.state::<crate::recording_state::RecordingState>();
+            state.clear();
+            state.release_window_claim();
+            let _ = app_for_event.emit("recording://state", false);
+        }
+    });
 
     // The application menu is useful on normal Windows windows, but inheriting
     // it here adds a File/Edit/View/Window strip to an otherwise frameless
@@ -998,18 +1031,6 @@ pub(crate) fn open_waveform_window(
     app.state::<crate::recording_state::RecordingState>()
         .set(source, meeting_id);
     let _ = app.emit("recording://state", true);
-
-    // If the window is destroyed without a clean stop (crash / force-close),
-    // clear the shared flag so the monitor can recover and re-arm.
-    let app_for_event = app.clone();
-    win.on_window_event(move |event| {
-        if let tauri::WindowEvent::Destroyed = event {
-            app_for_event
-                .state::<crate::recording_state::RecordingState>()
-                .clear();
-            let _ = app_for_event.emit("recording://state", false);
-        }
-    });
 
     crate::tray::set_menu(app, true, false);
 

--- a/src-tauri/src/recording_state.rs
+++ b/src-tauri/src/recording_state.rs
@@ -25,6 +25,9 @@ pub struct RecordingState {
     /// set via `set_tray_recording` from the recorder window. The pill
     /// visibility watcher must not hide the window before this point.
     capture: AtomicBool,
+    /// Process-wide ownership of the recorder pill window. Acquired before
+    /// native window construction and released only after destruction.
+    window_claimed: AtomicBool,
 }
 
 impl RecordingState {
@@ -58,6 +61,18 @@ impl RecordingState {
 
     pub fn capture_active(&self) -> bool {
         self.capture.load(Ordering::Relaxed)
+    }
+
+    /// Claim the one recorder-pill window slot. Unlike recording-active state,
+    /// this remains held while the window is uploading or closing.
+    pub fn try_claim_window(&self) -> bool {
+        self.window_claimed
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_ok()
+    }
+
+    pub fn release_window_claim(&self) {
+        self.window_claimed.store(false, Ordering::Release);
     }
 }
 
@@ -108,5 +123,46 @@ mod tests {
         s.set(RecordingSource::Manual, Some(7));
         s.clear();
         assert_eq!(s.active_meeting_id(), None);
+    }
+
+    #[test]
+    fn recorder_window_claim_is_exclusive_until_destroyed() {
+        let s = RecordingState::new();
+        assert!(s.try_claim_window());
+        assert!(!s.try_claim_window());
+
+        // Stopping capture does not release the window: it may still own an
+        // upload, retry, or native close transition.
+        s.clear();
+        assert!(!s.try_claim_window());
+
+        s.release_window_claim();
+        assert!(s.try_claim_window());
+    }
+
+    #[test]
+    fn concurrent_recorder_window_claim_has_exactly_one_winner() {
+        use std::sync::{Arc, Barrier};
+
+        const CONTENDERS: usize = 16;
+        let state = Arc::new(RecordingState::new());
+        let barrier = Arc::new(Barrier::new(CONTENDERS));
+        let handles: Vec<_> = (0..CONTENDERS)
+            .map(|_| {
+                let state = Arc::clone(&state);
+                let barrier = Arc::clone(&barrier);
+                std::thread::spawn(move || {
+                    barrier.wait();
+                    state.try_claim_window()
+                })
+            })
+            .collect();
+
+        let winners = handles
+            .into_iter()
+            .map(|handle| handle.join().unwrap())
+            .filter(|won| *won)
+            .count();
+        assert_eq!(winners, 1);
     }
 }


### PR DESCRIPTION
## What changed
- add an atomic, process-wide ownership claim before constructing the recorder waveform window
- keep the claim through capture stop, upload/retry, and native close; release it only when the window is destroyed
- make concurrent recorder launch requests idempotent and focus the existing pill when registered

## Why
The prior label lookup was not an atomic guard: two launch sources could both pass it before Tauri registered the native `waveform` window, producing two interactive recorder pills.

## Validation
- `cargo test --manifest-path src-tauri/Cargo.toml -- --test-threads=1` (262 passed, 3 ignored)
- Windows Tauri smoke with fake microphone: 20 simultaneous starts produced 1 waveform WebView; another 20 starts while active still produced 1

Follow-up to #297 and #300.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recording window handling to prevent duplicate windows from opening.
  * Made simultaneous attempts to open the recording window safe and predictable.
  * Ensured recording state is properly cleared when the window closes.
  * Prevented stale window ownership from blocking future recording sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->