### PR TITLE
fix(ci): set and read issue type via REST, not gh-version-dependent flags

### DIFF
--- a/.github/workflows/feature-shaping.yml
+++ b/.github/workflows/feature-shaping.yml
@@ -73,7 +73,9 @@ jobs:
         id: check
         run: |
           set -euo pipefail
-          type=$(gh issue view "$ISSUE" --repo "$REPO" --json issueType --jq '.issueType.name // ""')
+          # REST, not `gh issue view --json issueType`: that field needs a recent
+          # gh, and the self-hosted runner lags behind.
+          type=$(gh api "repos/$REPO/issues/$ISSUE" --jq '.type.name // ""')
           echo "Issue #$ISSUE type: ${type:-<none>}"
           if [ "$type" != "Feature" ]; then
             echo "proceed=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -174,10 +174,15 @@ jobs:
       # Let this fail the job. Swallowing the error would report a successful
       # triage while the issue stays untyped — and would also skip the failure
       # handler below, so nothing would ever say so.
+      # Use the REST API, not `gh issue edit --type`. That flag only exists in
+      # recent gh releases and the self-hosted runner lags behind — it failed
+      # with "unknown flag: --type" on the first live run. The `type` field on
+      # the issues REST endpoint carries no such version coupling.
       - name: Set issue type
         run: |
           set -euo pipefail
-          gh issue edit "$ISSUE" --repo "$REPO" --type "${{ steps.verdict.outputs.type }}"
+          gh api -X PATCH "repos/$REPO/issues/$ISSUE" \
+            -f type="${{ steps.verdict.outputs.type }}" >/dev/null
           echo "Set issue #$ISSUE type to ${{ steps.verdict.outputs.type }}"
 
       # Without this a failed run is completely invisible: the issue sits


### PR DESCRIPTION
## What does this PR do?

Fixes the one step that failed on the first live run of the new issue automation.

Triage on #304 failed at `Set issue type` with `unknown flag: --type`. The self-hosted runner's `gh` predates `gh issue edit --type` — that flag was verified against local gh 2.96.0 and assumed to match the runner, which it does not.

Both call sites now use the REST API, which has no coupling to the runner's `gh` release:

- `issue-triage.yml` — `gh api -X PATCH repos/{repo}/issues/{n} -f type=Bug`
- `feature-shaping.yml` — reads `.type.name` from the same endpoint instead of `gh issue view --json issueType`

The shaping one was a latent failure of the same kind, and a worse one: its "is this a Feature?" check would have thrown, and because that step sets a `proceed` output consumed by everything after it, both the proceed branch *and* the skip branch would have been skipped. Every `/shape` would have gone silent apart from the 👀 reaction.

## Type of change

- [x] `fix:` — bug fix

## How was this tested?

`gh api -X PATCH repos/ariso-ai/oats/issues/304 -f type=Bug` returned `{"number":304,"type":"Bug"}`, and the read path returns `Bug`. #304 is correctly typed now. actionlint clean.

Everything upstream of the failure already worked on the live run: the `issues: opened` trigger fired, the agent classified correctly, and posted an analysis citing real code — `blobToBytes` in `useBackend.ts:226-227`, and the missing timeout in `run_transcribe` versus `run_notes`'s `NOTES_TIMEOUT`. The step failed loudly rather than silently reporting success, which is the behavior CodeRabbit asked for on #303.