### PR TITLE
fix(ci): don't post an empty triage comment on Task issues

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -134,7 +134,12 @@ jobs:
           # jq -r on a JSON string yields the decoded text; write it to a file
           # rather than a step output so the body is never shell-expanded.
           jq -r '.comment // ""' "$RUNNER_TEMP/triage.json" > "$RUNNER_TEMP/triage-comment.md"
-          if [ -s "$RUNNER_TEMP/triage-comment.md" ]; then
+          # Test for non-whitespace content, not file size. `jq -r` terminates
+          # its output with a newline, so an empty comment still yields a
+          # 1-byte file and `-s` would call it non-empty — which posted a bare
+          # "🤖 Automated triage." on every Task issue, exactly the noise the
+          # empty-comment case exists to avoid.
+          if [ -n "$(tr -d '[:space:]' < "$RUNNER_TEMP/triage-comment.md")" ]; then
             has_comment=true
           else
             has_comment=false


### PR DESCRIPTION
## What does this PR do?

Triage is meant to set the issue type and post nothing when the model returns an empty comment — the expected outcome for a `Task`. The live run on #307 posted a bare "🤖 Automated triage." instead.

`jq -r` terminates its output with a newline, so an empty comment still writes a 1-byte file and `[ -s ]` reports it as non-empty. The `has_comment` check now tests for non-whitespace content.

## Type of change

- [x] `fix:` — bug fix

## How was this tested?

Ran both the old and new predicate against `{"comment":""}`, `{"comment":"   "}`, a real comment, and a payload with no `comment` key at all. Old: `true/true/true/true`. New: `false/false/true/false`. actionlint clean.

Found by the live test run on #307, which classified correctly as `Task` — only the comment suppression was wrong.