### PR TITLE
fix(ui): make the recorder waveform actually react to audio

### DIFF
--- a/src/views/RecorderStrip.vue
+++ b/src/views/RecorderStrip.vue
@@ -23,7 +23,7 @@
           :key="i"
           class="bar"
           :class="{ paused: state.isPaused }"
-          :style="{ height: `${Math.max(12, Math.min(100, Math.sqrt(level) * 150))}%` }"
+          :style="{ height: `${barHeightPercent(level)}%` }"
         />
       </div>
       <span class="timer">{{ formattedDuration }}</span>
@@ -54,6 +54,7 @@
 <script setup lang="ts">
 import { computed, ref, watch, onMounted, onUnmounted } from 'vue';
 import { emit, listen, type UnlistenFn } from '@tauri-apps/api/event';
+import { barHeightPercent } from './waveformBars';
 
 /** Mirror of the recording running in the (hidden) waveform window. This
  *  component renders `recorder://state` broadcasts and sends the same tray
@@ -175,7 +176,7 @@ onUnmounted(() => {
   display: flex;
   align-items: center;
   gap: 4px;
-  height: 18px;
+  height: 20px;
 }
 
 .bar {

--- a/src/views/WaveformView.vue
+++ b/src/views/WaveformView.vue
@@ -49,7 +49,7 @@
             :key="i"
             class="bar"
             :class="{ paused: recorder.isPaused.value }"
-            :style="{ height: `${Math.max(12, Math.min(100, Math.sqrt(level) * 150))}%` }"
+            :style="{ height: `${barHeightPercent(level)}%` }"
           />
         </div>
 
@@ -121,7 +121,7 @@ import { loadRecordingEnabled } from '../composables/useRecordingPermissions';
 import { isSilenceDetectionEnabled } from '../composables/useSilenceDetection';
 import { isMeetingEndReminderEnabled } from '../composables/useMeetingEndReminder';
 import { deriveRecordingMode } from './recordingSettings';
-import { centerWeightedBars } from './waveformBars';
+import { barHeightPercent, centerWeightedBars } from './waveformBars';
 import { shouldPromptSilence, shouldAutoStopAfterPrompt } from '../composables/silenceWatch';
 import {
   shouldPromptMeetingEnd,
@@ -1000,18 +1000,20 @@ html, body {
 .pill:active { cursor: grabbing; } /* closed/grabbing hand while pressed */
 
 .logo {
-  width: 28px;
-  height: 28px;
+  width: 24px;
+  height: 24px;
   object-fit: contain;
   flex-shrink: 0;
 }
 
+/* The height the bars travel through: tall enough that the difference between
+   quiet and loud reads at a glance from across the desk. */
 .bars {
   display: flex;
   align-items: center;
   justify-content: center;
   gap: 4px;
-  height: 18px;
+  height: 22px;
   margin-top: 7px;
   flex-shrink: 0;
 }

--- a/src/views/waveformBars.test.ts
+++ b/src/views/waveformBars.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { bucketLevels, centerWeightedBars } from './waveformBars';
+import { barHeightPercent, bucketLevels, centerWeightedBars } from './waveformBars';
 
 describe('bucketLevels', () => {
   it('returns the requested number of bars', () => {
@@ -43,5 +43,39 @@ describe('centerWeightedBars', () => {
 
   it('returns zeros for empty input', () => {
     expect(centerWeightedBars([], 3)).toEqual([0, 0, 0]);
+  });
+});
+
+describe('barHeightPercent', () => {
+  it('rests at the floor for silence and room tone', () => {
+    expect(barHeightPercent(0)).toBe(8);
+    expect(barHeightPercent(0.25)).toBe(8);
+  });
+
+  it('fills the bar once the level is loud, and clamps beyond it', () => {
+    expect(barHeightPercent(0.7)).toBe(100);
+    expect(barHeightPercent(1)).toBe(100);
+  });
+
+  it('spends most of its travel on ordinary speech levels', () => {
+    // The failure this guards against: a curve so hot that everyday speech
+    // pins the bars at the ceiling, leaving nothing visibly moving.
+    const quiet = barHeightPercent(0.35);
+    const talking = barHeightPercent(0.45);
+    const loud = barHeightPercent(0.6);
+    expect(quiet).toBeGreaterThan(8);
+    expect(quiet).toBeLessThan(talking);
+    expect(talking).toBeLessThan(loud);
+    expect(loud).toBeLessThan(100);
+    // Each step is a change you can actually see, not a few percent.
+    expect(talking - quiet).toBeGreaterThan(10);
+    expect(loud - talking).toBeGreaterThan(10);
+  });
+
+  it('rises monotonically across the whole level range', () => {
+    const heights = Array.from({ length: 21 }, (_, i) => barHeightPercent(i / 20));
+    for (let i = 1; i < heights.length; i++) {
+      expect(heights[i]).toBeGreaterThanOrEqual(heights[i - 1]);
+    }
   });
 });

--- a/src/views/waveformBars.ts
+++ b/src/views/waveformBars.ts
@@ -45,3 +45,26 @@ export function centerWeightedBars(levels: number[], buckets: number): number[] 
   }
   return out;
 }
+
+/** Bar height as a percentage of the waveform's box. The floor keeps a silent
+ *  recorder legible as a row of dots rather than nothing at all. */
+const MIN_HEIGHT_PCT = 8;
+const MAX_HEIGHT_PCT = 100;
+
+/** Levels are `getByteFrequencyData` bytes / 255 — a dB scale where 0 is
+ *  −100 dB and 1 is −30 dB — so the band speech actually occupies is narrow
+ *  and sits well up the scale. Mapping it to the full bar height is what makes
+ *  the waveform react: a curve with real gain below `FULL_LEVEL` (the old
+ *  `sqrt(level) * 150` reached 100% at 0.44) left the bars pinned at the
+ *  ceiling, twitching. Anything at or under `SILENCE_LEVEL` is room tone. */
+const SILENCE_LEVEL = 0.25;
+const FULL_LEVEL = 0.7;
+/** Exponent < 1 lifts quiet speech so ordinary talking spends most of the
+ *  bar's travel instead of hugging the floor. */
+const CURVE = 0.65;
+
+export function barHeightPercent(level: number): number {
+  const normalized = (level - SILENCE_LEVEL) / (FULL_LEVEL - SILENCE_LEVEL);
+  const shaped = Math.min(1, Math.max(0, normalized)) ** CURVE;
+  return MIN_HEIGHT_PCT + shaped * (MAX_HEIGHT_PCT - MIN_HEIGHT_PCT);
+}


### PR DESCRIPTION
The recording pill's bars barely moved while talking.

## Cause

The level→height curve — `Math.sqrt(level) * 150`, inlined in both the pill and the library strip — reached 100% at a level of **0.44**. Levels come from `getByteFrequencyData`, which is a dB scale where `0` is −100 dB and `1` is −30 dB, so room tone already sits mid-scale and ordinary speech pinned every bar at the ceiling. The result read as a twitch, not a waveform.

## Fix

- Extract a shared `barHeightPercent()` into `waveformBars.ts` (both renderers had the magic numbers copy-pasted). It gates room tone at or below `0.25` to a resting floor, then spends the full bar height on `0.25–0.70` with a mild lifting curve — speech now sweeps roughly 30%→90%.
- More room to travel: pill bars 18px→22px, strip bars 18px→20px.
- Shrink the pill's logo 28px→24px, as asked. It also frees exactly the 4px the taller bars take, so the collapsed pill keeps its current height.

## Testing

`npm test` — 674 tests pass, including four new cases on the curve: the floor, the ceiling clamp, monotonicity across the range, and (guarding this regression directly) that quiet/talking/loud each differ by more than 10 percentage points. `npm run vite:build` is clean.

**Not verified by measurement:** the `0.25`/`0.70` endpoints are derived from the Web Audio dB mapping, not sampled from a live mic. If speech still tops out or sits low on some setups, those two constants are the dial to turn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved waveform visualization with more consistent bar scaling across audio levels.
  - Waveform bars now remain visible during silence and respond smoothly to speech volume.

- **Style**
  - Increased waveform display height for improved readability.
  - Reduced the logo size in the waveform view.

- **Tests**
  - Added coverage for silence handling, loud-level limits, progression, and consistent scaling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->