### PR TITLE
fix(recorder): let a pending upload hand off the recorder window

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1038,14 +1038,27 @@ pub(crate) fn open_waveform_window(
                 let app_for_reopen = app_for_event.clone();
                 tauri::async_runtime::spawn(async move {
                     // This event and Tauri's own deregistration of the window
-                    // race. Wait for the label to actually be free, otherwise
-                    // the re-open below would rediscover the dying window and
-                    // queue a second yield that nothing is left to answer.
+                    // race. Wait for the label to actually be free before
+                    // re-opening.
+                    let mut freed = false;
                     for _ in 0..YIELD_REOPEN_POLLS {
                         if app_for_reopen.get_webview_window("waveform").is_none() {
+                            freed = true;
                             break;
                         }
                         tokio::time::sleep(YIELD_REOPEN_POLL_INTERVAL).await;
+                    }
+                    // Give up rather than re-open into a still-registered
+                    // label: that would rediscover the dying window, emit a
+                    // second yield nothing is left to answer, and leave a
+                    // queued request that only expires — or worse, gets
+                    // honored later by an unrelated close.
+                    if !freed {
+                        eprintln!(
+                            "waveform: window still registered {}ms after Destroyed; dropping the queued re-open",
+                            (YIELD_REOPEN_POLLS as u128) * YIELD_REOPEN_POLL_INTERVAL.as_millis()
+                        );
+                        return;
                     }
                     // Window creation must happen on the main thread.
                     let app_main = app_for_reopen.clone();

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -921,12 +921,27 @@ fn waveform_url(
     url
 }
 
+/// How long a queued recording waits for the incumbent pill to stand down
+/// before the request is dropped. The recorder answers `recorder://yield` from
+/// an idle post-upload state, so this only needs to cover event delivery plus
+/// the window close; a pill that is genuinely busy never answers at all.
+const YIELD_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(3);
+
+/// Bound on waiting for the `"waveform"` label to be free after the incumbent
+/// pill's `Destroyed` event, before re-opening in its place.
+const YIELD_REOPEN_POLLS: u32 = 20;
+const YIELD_REOPEN_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(25);
+
 /// Shared helper to open the waveform recording window. Used by the
 /// `start_recording_window` command, the tray (Local backend path), and the
 /// auto mic monitor. `auto` adds `auto=1` to the URL and tags the shared
 /// `RecordingState` as an auto recording. `force_new` adds `forceNew=1`,
 /// telling the recorder to skip the 5-minute auto-append window and always
 /// dock to a brand-new recording id.
+///
+/// Only one recorder pill exists at a time. When one is already up this
+/// negotiates a handoff rather than no-opping: see the `recorder://yield`
+/// exchange below.
 pub(crate) fn open_waveform_window(
     app: &tauri::AppHandle,
     meeting_id: Option<i64>,
@@ -942,10 +957,25 @@ pub(crate) fn open_waveform_window(
     if let Some(existing) = app.get_webview_window("waveform") {
         // Backfill the lifecycle claim for a registered window that still owns
         // capture, upload, retry, or its native close transition.
-        let _ = app
-            .state::<crate::recording_state::RecordingState>()
-            .try_claim_window();
+        let state = app.state::<crate::recording_state::RecordingState>();
+        let _ = state.try_claim_window();
         let _ = existing.set_focus();
+        // The pill outlives capture: it lingers through the upload and stays up
+        // indefinitely on a failed one so the user can retry. Such a stale pill
+        // must not silently swallow a new recording (#313), so ask it to stand
+        // down and re-open once it's actually gone (see the Destroyed handler
+        // below). It refuses while still capturing or uploading — then the
+        // queued request expires and the focus above is all that happens,
+        // which is the pre-existing behavior.
+        let token = state.queue_reopen(meeting_id, local_append_id, force_new, auto);
+        let _ = app.emit("recorder://yield", ());
+        let app_for_expiry = app.clone();
+        tauri::async_runtime::spawn(async move {
+            tokio::time::sleep(YIELD_TIMEOUT).await;
+            app_for_expiry
+                .state::<crate::recording_state::RecordingState>()
+                .expire_reopen(token);
+        });
         return Ok(());
     }
     let recording_state = app.state::<crate::recording_state::RecordingState>();
@@ -1002,6 +1032,36 @@ pub(crate) fn open_waveform_window(
             state.clear();
             state.release_window_claim();
             let _ = app_for_event.emit("recording://state", false);
+            // A recording was requested while this pill still held the window
+            // slot and it has now stood down, so honor that request.
+            if let Some(next) = state.take_reopen() {
+                let app_for_reopen = app_for_event.clone();
+                tauri::async_runtime::spawn(async move {
+                    // This event and Tauri's own deregistration of the window
+                    // race. Wait for the label to actually be free, otherwise
+                    // the re-open below would rediscover the dying window and
+                    // queue a second yield that nothing is left to answer.
+                    for _ in 0..YIELD_REOPEN_POLLS {
+                        if app_for_reopen.get_webview_window("waveform").is_none() {
+                            break;
+                        }
+                        tokio::time::sleep(YIELD_REOPEN_POLL_INTERVAL).await;
+                    }
+                    // Window creation must happen on the main thread.
+                    let app_main = app_for_reopen.clone();
+                    let _ = app_for_reopen.run_on_main_thread(move || {
+                        if let Err(error) = open_waveform_window(
+                            &app_main,
+                            next.meeting_id,
+                            next.local_append_id,
+                            next.force_new,
+                            next.auto,
+                        ) {
+                            eprintln!("waveform: re-open after yield failed: {error}");
+                        }
+                    });
+                });
+            }
         }
     });
 

--- a/src-tauri/src/recording_state.rs
+++ b/src-tauri/src/recording_state.rs
@@ -4,13 +4,27 @@
 //! avoid self-triggering off a manual recording — regardless of which PID
 //! macOS attributes our own capture to.
 
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Mutex;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum RecordingSource {
     Manual,
     Auto,
+}
+
+/// A recorder-window open request deferred behind the yield handshake: the
+/// previous pill still held the one window slot, so this waits for it to be
+/// destroyed. See `commands::open_waveform_window`.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PendingOpen {
+    pub meeting_id: Option<i64>,
+    pub local_append_id: Option<String>,
+    pub force_new: bool,
+    pub auto: bool,
+    /// Identifies this request so a timed-out yield only drops its own entry,
+    /// never a newer one queued in the meantime.
+    pub token: u64,
 }
 
 #[derive(Default)]
@@ -28,6 +42,11 @@ pub struct RecordingState {
     /// Process-wide ownership of the recorder pill window. Acquired before
     /// native window construction and released only after destruction.
     window_claimed: AtomicBool,
+    /// A recording requested while the window slot was still held, waiting for
+    /// the incumbent pill to stand down. At most one: a newer request replaces
+    /// an older one rather than queueing two recordings.
+    pending_open: Mutex<Option<PendingOpen>>,
+    next_open_token: AtomicU64,
 }
 
 impl RecordingState {
@@ -73,6 +92,44 @@ impl RecordingState {
 
     pub fn release_window_claim(&self) {
         self.window_claimed.store(false, Ordering::Release);
+    }
+
+    /// Queue a recorder-window open to run once the incumbent pill is
+    /// destroyed. Replaces any earlier queued request (newest intent wins) and
+    /// returns the token identifying this one.
+    pub fn queue_reopen(
+        &self,
+        meeting_id: Option<i64>,
+        local_append_id: Option<String>,
+        force_new: bool,
+        auto: bool,
+    ) -> u64 {
+        let token = self.next_open_token.fetch_add(1, Ordering::Relaxed);
+        *self.pending_open.lock().unwrap() = Some(PendingOpen {
+            meeting_id,
+            local_append_id,
+            force_new,
+            auto,
+            token,
+        });
+        token
+    }
+
+    /// Claim the queued request, if any, leaving the slot empty.
+    pub fn take_reopen(&self) -> Option<PendingOpen> {
+        self.pending_open.lock().unwrap().take()
+    }
+
+    /// Drop a queued request the pill never honored (it refused to yield
+    /// because it was still capturing or uploading). No-op once the request has
+    /// been taken, or once a newer one has replaced it.
+    pub fn expire_reopen(&self, token: u64) -> bool {
+        let mut slot = self.pending_open.lock().unwrap();
+        if slot.as_ref().map(|p| p.token) == Some(token) {
+            *slot = None;
+            return true;
+        }
+        false
     }
 }
 
@@ -138,6 +195,49 @@ mod tests {
 
         s.release_window_claim();
         assert!(s.try_claim_window());
+    }
+
+    #[test]
+    fn queued_reopen_round_trips_and_empties_the_slot() {
+        let s = RecordingState::new();
+        assert_eq!(s.take_reopen(), None);
+
+        let token = s.queue_reopen(Some(42), Some("rec-1".into()), true, false);
+        let queued = s.take_reopen().expect("a request was queued");
+        assert_eq!(queued.meeting_id, Some(42));
+        assert_eq!(queued.local_append_id.as_deref(), Some("rec-1"));
+        assert!(queued.force_new);
+        assert!(!queued.auto);
+        assert_eq!(queued.token, token);
+
+        // Taking is destructive: the destroyed pill must not re-open twice.
+        assert_eq!(s.take_reopen(), None);
+    }
+
+    #[test]
+    fn expiring_a_reopen_only_drops_its_own_request() {
+        let s = RecordingState::new();
+        let stale = s.queue_reopen(None, None, false, false);
+
+        // A second request supersedes the first, so the first's timeout must
+        // not cancel the recording the user just asked for.
+        let fresh = s.queue_reopen(Some(7), None, false, true);
+        assert!(!s.expire_reopen(stale));
+        assert_eq!(s.take_reopen().map(|p| p.meeting_id), Some(Some(7)));
+
+        // Nothing left to expire once the request has been honored.
+        assert!(!s.expire_reopen(fresh));
+    }
+
+    #[test]
+    fn expiring_a_reopen_clears_a_refused_yield() {
+        let s = RecordingState::new();
+        let token = s.queue_reopen(Some(1), None, false, false);
+
+        // The pill refused to stand down (still capturing or uploading), so the
+        // request must not survive to hijack an unrelated later close.
+        assert!(s.expire_reopen(token));
+        assert_eq!(s.take_reopen(), None);
     }
 
     #[test]

--- a/src-tauri/src/recording_state.rs
+++ b/src-tauri/src/recording_state.rs
@@ -104,8 +104,9 @@ impl RecordingState {
         force_new: bool,
         auto: bool,
     ) -> u64 {
+        let mut pending_open = self.pending_open.lock().unwrap();
         let token = self.next_open_token.fetch_add(1, Ordering::Relaxed);
-        *self.pending_open.lock().unwrap() = Some(PendingOpen {
+        *pending_open = Some(PendingOpen {
             meeting_id,
             local_append_id,
             force_new,
@@ -264,5 +265,36 @@ mod tests {
             .filter(|won| *won)
             .count();
         assert_eq!(winners, 1);
+    }
+
+    #[test]
+    fn concurrent_queue_reopen_leaves_the_highest_token_queued() {
+        use std::sync::{Arc, Barrier};
+
+        const CONTENDERS: u64 = 16;
+        let state = Arc::new(RecordingState::new());
+        let barrier = Arc::new(Barrier::new(CONTENDERS as usize));
+        let handles: Vec<_> = (0..CONTENDERS)
+            .map(|_| {
+                let state = Arc::clone(&state);
+                let barrier = Arc::clone(&barrier);
+                std::thread::spawn(move || {
+                    barrier.wait();
+                    state.queue_reopen(None, None, false, false)
+                })
+            })
+            .collect();
+
+        let max_token = handles
+            .into_iter()
+            .map(|handle| handle.join().unwrap())
+            .max()
+            .unwrap();
+
+        // Token allocation and slot replacement happen under the same lock, so
+        // whichever request acquired the lock last also holds the highest
+        // token — an earlier allocation can never overwrite a later one.
+        let queued = state.take_reopen().expect("a request was queued");
+        assert_eq!(queued.token, max_token);
     }
 }

--- a/src/views/WaveformView.test.ts
+++ b/src/views/WaveformView.test.ts
@@ -893,3 +893,82 @@ describe('WaveformView vertical pill', () => {
     wrapper.unmount();
   });
 });
+
+// A pending upload used to block starting a new recording outright: the failed
+// pill kept the one recorder window alive, and every entry point no-opped into
+// focusing it (#313). The native side now asks the incumbent pill to stand down.
+describe('WaveformView recorder://yield handshake', () => {
+  it('yields the recorder window from a failed pill, leaving the buffer for the sidebar', async () => {
+    stopRecording.mockResolvedValue(new Blob(['x'], { type: 'audio/mpeg' }));
+    finalizeRecording.mockRejectedValue(new Error('boom'));
+    const wrapper = mount(WaveformView);
+    await flushPromises();
+    await wrapper.find('.stop-btn').trigger('click');
+    await flushPromises();
+    expect(wrapper.find('.status-icon.err').exists()).toBe(true);
+
+    emitEvent.mockClear();
+    eventHandlers['recorder://yield']?.({ payload: undefined });
+    await flushPromises();
+
+    expect(closeWin).toHaveBeenCalled();
+    const last = emitEvent.mock.calls.filter(([n]) => n === 'recorder://state').at(-1);
+    expect((last?.[1] as { phase: string }).phase).toBe('closed');
+    // The audio stays on disk so Pending uploads can still retry it — this is a
+    // handoff, not a discard.
+    expect(discardPendingAudio).not.toHaveBeenCalled();
+  });
+
+  it('yields the recorder window from the success pill without waiting out its close timer', async () => {
+    stopRecording.mockResolvedValue(new Blob(['x'], { type: 'audio/mpeg' }));
+    finalizeRecording.mockResolvedValue({ backend: 'local' });
+    const wrapper = mount(WaveformView);
+    await flushPromises();
+    await wrapper.find('.stop-btn').trigger('click');
+    await flushPromises();
+
+    eventHandlers['recorder://yield']?.({ payload: undefined });
+    await flushPromises();
+
+    expect(closeWin).toHaveBeenCalled();
+    wrapper.unmount();
+  });
+
+  it('refuses to yield while still capturing', async () => {
+    const wrapper = mount(WaveformView);
+    await flushPromises();
+
+    eventHandlers['recorder://yield']?.({ payload: undefined });
+    await flushPromises();
+
+    // Killing a live recording to make room for a new one would lose audio.
+    expect(closeWin).not.toHaveBeenCalled();
+    wrapper.unmount();
+  });
+
+  it('refuses to yield while an upload is in flight', async () => {
+    stopRecording.mockResolvedValue(new Blob(['x'], { type: 'audio/mpeg' }));
+    let settleUpload: (r: { backend: string }) => void = () => {};
+    finalizeRecording.mockReturnValue(
+      new Promise((resolve) => {
+        settleUpload = resolve;
+      }),
+    );
+    const wrapper = mount(WaveformView);
+    await flushPromises();
+    void wrapper.find('.stop-btn').trigger('click');
+    await flushPromises();
+
+    eventHandlers['recorder://yield']?.({ payload: undefined });
+    await flushPromises();
+
+    // Tearing the window down here can strand a buffer whose upload already
+    // succeeded (the post-upload discard runs in this window), which the next
+    // retry would then upload a second time.
+    expect(closeWin).not.toHaveBeenCalled();
+
+    settleUpload({ backend: 'local' });
+    await flushPromises();
+    wrapper.unmount();
+  });
+});

--- a/src/views/WaveformView.vue
+++ b/src/views/WaveformView.vue
@@ -393,6 +393,7 @@ async function applyPillVisibility(hidden: boolean) {
 
 let unlistenPillVisible: UnlistenFn | null = null;
 let unlistenPendingUploaded: UnlistenFn | null = null;
+let unlistenYield: UnlistenFn | null = null;
 let unlistenPause: UnlistenFn | null = null;
 let unlistenResume: UnlistenFn | null = null;
 let unlistenStop: UnlistenFn | null = null;
@@ -766,6 +767,34 @@ async function handlePendingUploadSucceeded() {
   await closeWindow();
 }
 
+// A new recording was requested while this window still holds the one recorder
+// slot (see open_waveform_window). Stand down so it can take over — the native
+// side re-opens a fresh pill once this one is destroyed.
+//
+// Only from a settled post-upload state. The stopped audio is already buffered
+// on disk (finalizeRecording persists it before attempting the upload), so the
+// Pending uploads sidebar owns the retry from here; drop the in-memory copy
+// WITHOUT discarding the buffer, exactly like handlePendingUploadSucceeded.
+//
+// Refusing while capture or a finalize is still in flight is the point. Tearing
+// the window down mid-upload can strand a buffer whose upload actually
+// succeeded — discardAudio runs here, after the request resolves — and the next
+// retry would upload it a second time. `inFlightFinalize` covers the finalize
+// that outlived its 120s UI timeout and left a 'failed' pill up while still
+// running; it clears when that work truly settles, so the block is temporary.
+// A refusal leaves the pre-existing behavior: the request expires natively and
+// this pill just took focus.
+async function handleYield() {
+  if (uploadResult.value === null || isUploading.value || inFlightFinalize) return;
+  if (closeTimer) {
+    clearTimeout(closeTimer);
+    closeTimer = null;
+  }
+  stoppedBlob.value = null;
+  stoppedMeta.value = null;
+  await closeWindow();
+}
+
 // Keep the failed recording's audio and resume capturing into a fresh buffer.
 // The next stop concatenates the held blob with the new segment (see handleStop).
 async function resumeFailed() {
@@ -815,6 +844,7 @@ onMounted(async () => {
   });
 
   unlistenPendingUploaded = await listen('pending-upload://succeeded', handlePendingUploadSucceeded);
+  unlistenYield = await listen('recorder://yield', handleYield);
 
   unlistenPause = await listen('tray://pause-recording', handlePause);
   unlistenResume = await listen('tray://resume-recording', handleResume);
@@ -940,6 +970,7 @@ onUnmounted(() => {
   if (closeTimer) clearTimeout(closeTimer);
   unlistenPillVisible?.();
   unlistenPendingUploaded?.();
+  unlistenYield?.();
   unlistenPause?.();
   unlistenResume?.();
   unlistenStop?.();


### PR DESCRIPTION
Fixes #313.

## The bug

Only one recorder pill exists at a time, and `open_waveform_window` gated on that window merely *existing* — if one was found it refocused it and returned `Ok(())`:

```rust
if let Some(existing) = app.get_webview_window("waveform") {
    let _ = ...try_claim_window();
    let _ = existing.set_focus();
    return Ok(());   // silent no-op
}
```

But the pill outlives capture by design. It lingers through the upload, and on a failed one it stays up **indefinitely** so the user can Retry / Resume / Discard. A stale pill in that state swallowed every new recording request — from the tray, the notification's "Take notes", the picker and the library alike.

`RecordingState::is_active()` already knew the difference (it's cleared on stop, before finalize); `open_waveform_window` just never consulted it.

## The fix

A **yield handshake**. When a pill is already up, the request is queued and `recorder://yield` is emitted; the recorder stands down from a settled post-upload state, and the native side re-opens a fresh pill once the old one is destroyed. All four entry points funnel through this one helper, so they all get the fix.

Standing down is safe because the audio is already durable — `finalizeRecording` persists the mp3 to `pending-uploads` *before* attempting the upload. The in-memory copy is dropped **without** discarding the on-disk buffer (the same handoff `handlePendingUploadSucceeded` already performs), so the Pending uploads sidebar owns the retry from there.

## Deliberate limitation

The recorder **refuses to yield while capture or a finalize is still in flight**. Tearing the window down mid-upload can strand a buffer whose upload actually succeeded — the post-upload `discardAudio()` runs in that window *after* the request resolves — and the next retry would upload it a second time. A refusal simply leaves the previous behavior: the request expires and the pill took focus.

So a *pending/failed* upload no longer blocks a new recording (the indefinite blocker, and what the issue describes), but a genuinely in-flight one still does for up to 120s. Closing that gap means moving the Ariso upload into Rust so it survives window close — worth a follow-up issue rather than smuggling into this one.

One more thing I chose not to assume: the re-open waits for the `"waveform"` label to actually be free rather than trusting that Tauri deregisters the window before `Destroyed` fires. Otherwise it would rediscover the dying window and queue a second yield that nothing is left to answer.

## Verification

Automated:
- Rust: 275 passed, 3 ignored — 3 new `recording_state` tests (queue/take round trip, token-scoped expiry, refused-yield cleanup)
- Frontend: 53 files / 678 tests passed — 4 new tests: yields from the failed pill *without* discarding the buffer, yields from the success pill, refuses while capturing, refuses mid-upload
- `cargo clippy --all-targets` clean

In the running app (`tauri:dev:debug` via the MCP server), three consecutive failed uploads:

| Round | `recorder://yield` → pill destroyed | → new recording live |
|---|---|---|
| 1 | 39 ms | 83 ms |
| 2 | 21 ms | 71 ms |
| 3 | 14 ms | 64 ms |

Each round logged the full handshake (`yield` → `recording://state false` → `recording://state true` + `recording://started`) and brought up a fresh pill in a clean webview context. After all three handoffs, `pending.list()` and `~/.ariso/pending-uploads/` still held all three recordings (180s / 120s / 60s) — the handoff discards nothing. A request issued during live capture was correctly refused: `yield` emitted, no destroy, capture kept running, request expired after 3s.

Caveat on the runtime check: the upload failures were injected at the backend seam (after the genuine `pending.bufferAudio` disk write), so the finalize → fail → failed-pill → yield → re-open chain is real production code, but the network failure itself was synthetic. The mid-upload refusal path is covered by unit tests only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Waveform windows can now reopen smoothly when another recorder window is already active.
  * Recorder handoffs are queued and automatically retried once the existing window closes.
  * Pending reopen requests expire after a short timeout when the handoff is not accepted.

* **Bug Fixes**
  * Failed recordings remain available for upload retry during recorder handoffs.
  * Active recordings and in-progress uploads are protected from premature closure.
  * Waveform windows now close only after recording finalization or upload activity has settled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->