### PR TITLE
fix(ui): make the meeting picker's meetings look clickable

### DIFF
--- a/src/views/MeetingPickerRow.test.ts
+++ b/src/views/MeetingPickerRow.test.ts
@@ -1,0 +1,80 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+
+import MeetingPickerRow from './MeetingPickerRow.vue';
+
+describe('MeetingPickerRow', () => {
+  it('renders the title and the local start time', () => {
+    const wrapper = mount(MeetingPickerRow, {
+      props: { title: 'Standup', startAt: '2026-06-01T09:00:00Z' },
+    });
+    const expected = new Date('2026-06-01T09:00:00Z').toLocaleTimeString(undefined, {
+      hour: 'numeric',
+      minute: '2-digit',
+    });
+    expect(wrapper.text()).toContain('Standup');
+    expect(wrapper.text()).toContain(expected);
+  });
+
+  it('falls back to "Untitled meeting" for a blank title', () => {
+    const wrapper = mount(MeetingPickerRow, {
+      props: { title: '', startAt: '2026-06-01T09:00:00Z' },
+    });
+    expect(wrapper.text()).toContain('Untitled meeting');
+  });
+
+  it('renders no time for an unparseable start', () => {
+    const wrapper = mount(MeetingPickerRow, {
+      props: { title: 'Standup', startAt: 'not-a-date' },
+    });
+    expect(wrapper.find('.meeting-time').text()).toBe('');
+  });
+
+  it('is a plain card by default and takes the featured treatment on request', () => {
+    const plain = mount(MeetingPickerRow, {
+      props: { title: 'Standup', startAt: '2026-06-01T09:00:00Z' },
+    });
+    expect(plain.classes()).not.toContain('meeting-row--featured');
+    expect(plain.find('.meeting-badge').exists()).toBe(false);
+
+    const featured = mount(MeetingPickerRow, {
+      props: {
+        title: 'Standup',
+        startAt: '2026-06-01T09:00:00Z',
+        featured: true,
+        badge: 'Up next',
+      },
+    });
+    expect(featured.classes()).toContain('meeting-row--featured');
+    expect(featured.find('.meeting-badge').text()).toContain('Up next');
+  });
+
+  it('shows the live dot only while the meeting is happening now', () => {
+    const upNext = mount(MeetingPickerRow, {
+      props: { title: 'Standup', startAt: '2026-06-01T09:00:00Z', badge: 'Up next' },
+    });
+    expect(upNext.find('.live-dot').exists()).toBe(false);
+
+    const live = mount(MeetingPickerRow, {
+      props: {
+        title: 'Standup',
+        startAt: '2026-06-01T09:00:00Z',
+        badge: 'Happening now',
+        live: true,
+      },
+    });
+    expect(live.find('.live-dot').exists()).toBe(true);
+  });
+
+  it('emits choose on click, and not when disabled', async () => {
+    const wrapper = mount(MeetingPickerRow, {
+      props: { title: 'Standup', startAt: '2026-06-01T09:00:00Z' },
+    });
+    await wrapper.trigger('click');
+    expect(wrapper.emitted('choose')).toHaveLength(1);
+
+    await wrapper.setProps({ disabled: true });
+    expect(wrapper.attributes('disabled')).toBeDefined();
+  });
+});

--- a/src/views/MeetingPickerRow.vue
+++ b/src/views/MeetingPickerRow.vue
@@ -1,0 +1,150 @@
+<template>
+  <button
+    class="meeting-row"
+    :class="{ 'meeting-row--featured': featured }"
+    type="button"
+    :disabled="disabled"
+    @click="emit('choose')"
+  >
+    <span v-if="badge" class="meeting-badge">
+      <span v-if="live" class="live-dot" aria-hidden="true" />
+      {{ badge }}
+    </span>
+    <span class="meeting-title">{{ title || 'Untitled meeting' }}</span>
+    <span class="meeting-time">{{ formattedTime }}</span>
+  </button>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+
+// One selectable meeting in the picker. `featured` is the picker's recommended
+// choice (happening now / up next / the meeting the Library asked us to
+// continue) and carries the primary, filled treatment — the plain rows are the
+// quieter white cards around it.
+const props = withDefaults(
+  defineProps<{
+    title: string;
+    startAt: string;
+    badge?: string | null;
+    live?: boolean;
+    featured?: boolean;
+    disabled?: boolean;
+  }>(),
+  { badge: null, live: false, featured: false, disabled: false }
+);
+
+const emit = defineEmits<{ choose: [] }>();
+
+const formattedTime = computed(() => {
+  const d = new Date(props.startAt);
+  if (Number.isNaN(d.getTime())) return '';
+  return d.toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' });
+});
+</script>
+
+<style scoped>
+.meeting-row {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  width: 100%;
+  box-sizing: border-box;
+  padding: 11px 13px;
+  border: 1px solid #e7e5e2;
+  border-radius: 12px;
+  background: #ffffff;
+  color: #1c1c1c;
+  font-family: inherit;
+  text-align: left;
+  cursor: pointer;
+  transition: transform 0.1s, box-shadow 0.1s, background 0.12s, border-color 0.12s;
+}
+
+/* Rest is flat; hover lifts the card off the backdrop so the row reads as a
+   target rather than a line of text. */
+.meeting-row:not(:disabled):hover {
+  border-color: #d6d6d6;
+  box-shadow: 2px 2px 0 #e7e5e2;
+  transform: translate(-1px, -1px);
+}
+
+.meeting-row:focus-visible {
+  outline: 2px solid #1c1c1c;
+  outline-offset: 2px;
+}
+
+.meeting-row:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+/* The recommended meeting takes the primary treatment (same idiom as
+   .btn-primary): filled, with the hard shadow that presses in on hover. */
+.meeting-row--featured {
+  border-color: #1c1c1c;
+  background: #1c1c1c;
+  color: #f7f6f4;
+  box-shadow: 2px 2px 0 #e7e5e2;
+}
+
+.meeting-row--featured:not(:disabled):hover {
+  border-color: #1c1c1c;
+  box-shadow: 1px 1px 0 #e7e5e2;
+  transform: translate(1px, 1px);
+}
+
+.meeting-row--featured:focus-visible {
+  outline-color: #6f6f6f;
+}
+
+.meeting-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 1.2px;
+  color: #9a9a96;
+}
+
+.live-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: #d96a5a;
+  animation: live-pulse 1.6s ease-in-out infinite;
+}
+
+.meeting-title {
+  font-size: 15px;
+  font-weight: 500;
+  color: inherit;
+  line-height: 1.25;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.meeting-time {
+  font-size: 12px;
+  color: #6f6f6f;
+}
+
+.meeting-row--featured .meeting-badge,
+.meeting-row--featured .meeting-time {
+  color: rgba(247, 246, 244, 0.72);
+}
+
+@keyframes live-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.35; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .live-dot { animation: none; }
+  .meeting-row { transition: none; }
+}
+</style>

--- a/src/views/MeetingPickerView.test.ts
+++ b/src/views/MeetingPickerView.test.ts
@@ -290,4 +290,32 @@ describe('MeetingPickerView — forced default from the Library', () => {
       window.location.hash = prevHash;
     }
   });
+
+  it('"View all" keeps the forced meeting when it is a past meeting outside today\'s list', async () => {
+    listScheduledMeetings.mockResolvedValue([
+      { id: 9, title: 'Other Meeting', start_at: new Date().toISOString() },
+    ]);
+    getMeetingNotes.mockResolvedValue({ id: 5, title: 'Past Sync', start_at: '2026-06-01T09:00:00Z' });
+    const prevHash = window.location.hash;
+    window.location.hash = '#/meeting-picker?defaultMeetingId=5';
+    try {
+      const wrapper = mount(MeetingPickerView);
+      await flushPromises();
+
+      await byText(wrapper, 'View all ▾')!.trigger('click');
+      await flushPromises();
+
+      // The forced "Continue" meeting (id 5) isn't in today's list, but expanding
+      // must not drop it — it should still be choosable, just as a regular row.
+      expect(wrapper.text()).toContain('Past Sync');
+      expect(wrapper.text()).toContain('Other Meeting');
+      const pastSyncRow = wrapper.findAll('.meeting-row').find((r) => r.text().includes('Past Sync'));
+      expect(pastSyncRow).toBeTruthy();
+      await pastSyncRow!.trigger('click');
+      await flushPromises();
+      expect(invoke).toHaveBeenCalledWith('start_recording_window', { meetingId: 5 });
+    } finally {
+      window.location.hash = prevHash;
+    }
+  });
 });

--- a/src/views/MeetingPickerView.test.ts
+++ b/src/views/MeetingPickerView.test.ts
@@ -114,6 +114,74 @@ describe('MeetingPickerView — record a new meeting', () => {
   });
 });
 
+describe('MeetingPickerView — the recommended meeting is the primary target', () => {
+  it('features the happening-now meeting and keeps it primary after expanding', async () => {
+    const now = Date.now();
+    listScheduledMeetings.mockResolvedValue([
+      { id: 1, title: 'Standup', start_at: new Date(now).toISOString() },
+      { id: 2, title: 'Later Thing', start_at: new Date(now + 3 * 60 * 60_000).toISOString() },
+    ]);
+    const wrapper = mount(MeetingPickerView);
+    await flushPromises();
+
+    // Collapsed: just the pick, carrying the primary treatment.
+    let rows = wrapper.findAll('.meeting-row');
+    expect(rows).toHaveLength(1);
+    expect(rows[0].classes()).toContain('meeting-row--featured');
+    expect(wrapper.text()).toContain('Happening now');
+
+    await byText(wrapper, 'View all ▾')!.trigger('click');
+    await flushPromises();
+
+    // Expanded: still primary, and the other rows stay quiet.
+    rows = wrapper.findAll('.meeting-row');
+    expect(rows).toHaveLength(2);
+    const standup = rows.find((r) => r.text().includes('Standup'))!;
+    const later = rows.find((r) => r.text().includes('Later Thing'))!;
+    expect(standup.classes()).toContain('meeting-row--featured');
+    expect(standup.find('.live-dot').exists()).toBe(true);
+    expect(later.classes()).not.toContain('meeting-row--featured');
+    expect(later.find('.meeting-badge').exists()).toBe(false);
+  });
+
+  it('badges the soonest meeting "Up next" when nothing is happening now', async () => {
+    const now = Date.now();
+    listScheduledMeetings.mockResolvedValue([
+      { id: 1, title: 'Later Thing', start_at: new Date(now + 3 * 60 * 60_000).toISOString() },
+      { id: 2, title: 'Soon Thing', start_at: new Date(now + 30 * 60_000).toISOString() },
+    ]);
+    const wrapper = mount(MeetingPickerView);
+    await flushPromises();
+
+    await byText(wrapper, 'View all ▾')!.trigger('click');
+    await flushPromises();
+
+    const rows = wrapper.findAll('.meeting-row');
+    const soon = rows.find((r) => r.text().includes('Soon Thing'))!;
+    expect(soon.classes()).toContain('meeting-row--featured');
+    expect(soon.find('.meeting-badge').text()).toContain('Up next');
+    // "Up next" is not live, so no pulsing dot.
+    expect(soon.find('.live-dot').exists()).toBe(false);
+  });
+
+  it('does not fade an edge the list has not scrolled past', async () => {
+    listScheduledMeetings.mockResolvedValue([
+      { id: 1, title: 'Standup', start_at: new Date().toISOString() },
+    ]);
+    const wrapper = mount(MeetingPickerView);
+    await flushPromises();
+
+    await byText(wrapper, 'View all ▾')!.trigger('click');
+    await flushPromises();
+
+    // An unconditional top fade dissolved the first meeting's title into the
+    // backdrop before the user scrolled at all.
+    const list = wrapper.find('.meeting-list');
+    expect(list.classes()).not.toContain('is-faded-top');
+    expect(list.classes()).not.toContain('is-faded-bottom');
+  });
+});
+
 describe('MeetingPickerView — Ari-join gate', () => {
   it('flagged meeting shows confirm dialog and only records on "Record anyway"', async () => {
     listScheduledMeetings.mockResolvedValue([

--- a/src/views/MeetingPickerView.vue
+++ b/src/views/MeetingPickerView.vue
@@ -23,44 +23,60 @@
       <template v-if="!showAll">
         <template v-if="forcedDefault">
           <p class="section-label">Continue meeting</p>
-          <button class="meeting-row" :disabled="isChoosing" @click="choose(forcedDefault.id)">
-            <span class="meeting-title">{{ forcedDefault.title || 'Untitled meeting' }}</span>
-            <span class="meeting-time">{{ formatTime(forcedDefault.start_at) }}</span>
-          </button>
+          <MeetingPickerRow
+            :title="forcedDefault.title"
+            :start-at="forcedDefault.start_at"
+            featured
+            :disabled="isChoosing"
+            @choose="choose(forcedDefault.id)"
+          />
         </template>
         <template v-else>
           <p v-if="defaultMeeting.kind !== 'none'" class="section-label">
-            {{ defaultMeeting.kind === 'current' ? 'Happening now' : 'Up next' }}
+            {{ featuredLabel }}
           </p>
-          <button
+          <MeetingPickerRow
             v-if="defaultMeeting.featured"
-            class="meeting-row"
+            :title="defaultMeeting.featured.title || ''"
+            :start-at="defaultMeeting.featured.start_at"
+            featured
+            :live="isHappeningNow"
             :disabled="isChoosing"
-            @click="choose(defaultMeeting.featured.id)"
-          >
-            <span class="meeting-title">{{ defaultMeeting.featured.title || 'Untitled meeting' }}</span>
-            <span class="meeting-time">{{ formatTime(defaultMeeting.featured.start_at) }}</span>
-          </button>
+            @choose="choose(defaultMeeting.featured.id)"
+          />
           <p v-else class="section-label">No meeting happening now</p>
         </template>
       </template>
 
-      <!-- Expanded: full flat list of today's meetings (shared by both cases) -->
-      <ul v-else class="meeting-list">
-        <li v-for="m in meetings" :key="m.id">
-          <button class="meeting-row" :disabled="isChoosing" @click="choose(m.id)">
-            <span class="meeting-title">{{ m.title || 'Untitled meeting' }}</span>
-            <span class="meeting-time">{{ formatTime(m.start_at) }}</span>
-          </button>
+      <!-- Expanded: full flat list of today's meetings (shared by both cases).
+           The recommended meeting keeps its primary treatment here so expanding
+           adds options instead of flattening the pick into anonymous rows. -->
+      <ul
+        v-else
+        ref="listEl"
+        class="meeting-list"
+        :class="{ 'is-faded-top': fadeTop, 'is-faded-bottom': fadeBottom }"
+        @scroll="updateFades"
+      >
+        <li v-for="row in decoratedMeetings" :key="row.meeting.id">
+          <MeetingPickerRow
+            :title="row.meeting.title || ''"
+            :start-at="row.meeting.start_at"
+            :badge="row.badge"
+            :live="row.live"
+            :featured="row.featured"
+            :disabled="isChoosing"
+            @choose="choose(row.meeting.id)"
+          />
         </li>
       </ul>
 
-      <button class="link-btn" type="button" @click="showAll = !showAll">
+      <button class="link-btn" type="button" @click="toggleShowAll">
         {{ showAll ? 'View less ▴' : 'View all ▾' }}
       </button>
     </template>
 
-    <div class="new-meeting">
+    <div class="new-meeting" :class="{ 'new-meeting--divided': state === 'list' }">
       <button
         v-if="!showTitlePrompt"
         class="skip-btn"
@@ -111,6 +127,7 @@ import { parseDefaultMeetingId } from '../composables/parseDefaultMeetingId';
 import { arisoTruthy, shouldConfirmAriJoin } from '../composables/autoJoin';
 import { useAriJoinConfirm } from '../composables/useAriJoinConfirm';
 import AriJoinConfirmDialog from './AriJoinConfirmDialog.vue';
+import MeetingPickerRow from './MeetingPickerRow.vue';
 
 type PickerState = 'loading' | 'list' | 'empty' | 'error';
 
@@ -124,6 +141,9 @@ const showTitlePrompt = ref(false);
 const titleDraft = ref('');
 const createError = ref<string | null>(null);
 const titleInput = ref<HTMLInputElement | null>(null);
+const listEl = ref<HTMLElement | null>(null);
+const fadeTop = ref(false);
+const fadeBottom = ref(false);
 const now = new Date();
 
 // A meeting the Library asked us to feature as the default choice (the meeting
@@ -141,12 +161,56 @@ function todayBoundsLocal(): { startDate: Date; endDate: Date } {
   return { startDate: start, endDate: end };
 }
 
-function formatTime(iso: string): string {
-  const d = new Date(iso);
-  return d.toLocaleTimeString(undefined, {
-    hour: 'numeric',
-    minute: '2-digit',
-  });
+// The primary treatment belongs to exactly one meeting: the forced "Continue"
+// meeting when the Library sent us one, else the heuristic pick. Everything
+// else stays a quiet card.
+const featuredId = computed(
+  () => forcedDefault.value?.id ?? defaultMeeting.value.featured?.id ?? null
+);
+
+// Only the heuristic pick can be live — a forced Continue meeting is whatever
+// the Library had open, which is often already over.
+const isHappeningNow = computed(
+  () => !forcedDefault.value && defaultMeeting.value.kind === 'current'
+);
+
+const featuredLabel = computed(() => {
+  if (forcedDefault.value) return 'Continue';
+  return isHappeningNow.value ? 'Happening now' : 'Up next';
+});
+
+// Expanded rows carry the label inline, since a section heading can't attach to
+// one row in the middle of a list the way it does in the collapsed view.
+const decoratedMeetings = computed(() =>
+  meetings.value.map((m) => {
+    const featured = m.id === featuredId.value;
+    return {
+      meeting: m,
+      featured,
+      badge: featured ? featuredLabel.value : null,
+      live: featured && isHappeningNow.value,
+    };
+  })
+);
+
+// Only fade an edge the list actually scrolls past — an unconditional top fade
+// dissolves the first meeting's title into the backdrop before you scroll.
+function updateFades(): void {
+  const el = listEl.value;
+  if (!el) {
+    fadeTop.value = false;
+    fadeBottom.value = false;
+    return;
+  }
+  const max = el.scrollHeight - el.clientHeight;
+  fadeTop.value = el.scrollTop > 1;
+  fadeBottom.value = max > 1 && el.scrollTop < max - 1;
+}
+
+async function toggleShowAll(): Promise<void> {
+  showAll.value = !showAll.value;
+  await nextTick();
+  updateFades();
 }
 
 async function choose(meetingId: number | null): Promise<void> {
@@ -347,63 +411,32 @@ onMounted(async () => {
   font-size: 12px;
 }
 
-/* Scrollable list with the same top/bottom fade as the Meetings window. */
+/* Scrollable list, with the Meetings-window fade applied only to an edge that
+   is actually scrolled past (see updateFades). Horizontal padding leaves room
+   for the rows' hover shadow and focus ring, which overflow-x would clip. */
 .meeting-list {
   flex: 1;
   min-height: 0;
   overflow-y: auto;
   list-style: none;
   margin: 0;
-  padding: 6px;
+  padding: 4px 6px;
   display: flex;
   flex-direction: column;
   gap: 6px;
-  -webkit-mask-image: linear-gradient(to bottom, transparent 0, #000 24px, #000 calc(100% - 24px), transparent 100%);
-  mask-image: linear-gradient(to bottom, transparent 0, #000 24px, #000 calc(100% - 24px), transparent 100%);
+  --fade-top: 0px;
+  --fade-bottom: 0px;
+  -webkit-mask-image: linear-gradient(to bottom, transparent 0, #000 var(--fade-top), #000 calc(100% - var(--fade-bottom)), transparent 100%);
+  mask-image: linear-gradient(to bottom, transparent 0, #000 var(--fade-top), #000 calc(100% - var(--fade-bottom)), transparent 100%);
 }
+.meeting-list.is-faded-top { --fade-top: 18px; }
+.meeting-list.is-faded-bottom { --fade-bottom: 18px; }
 .meeting-list::-webkit-scrollbar { width: 6px; }
 .meeting-list::-webkit-scrollbar-thumb { background: #d6d6d6; border-radius: 3px; }
 
-.meeting-row {
-  display: flex;
-  flex-direction: column;
-  gap: 3px;
-  width: 100%;
-  padding: 10px 12px;
-  border: 1px solid transparent;
-  border-radius: 12px;
-  background: transparent;
-  color: #1c1c1c;
-  font-family: inherit;
-  text-align: left;
-  cursor: pointer;
-  transition: background 0.12s;
-}
-
-.meeting-row:hover {
-  background: rgba(0, 0, 0, 0.03);
-}
-
-.meeting-row:disabled,
 .skip-btn:disabled {
   opacity: 0.6;
   cursor: not-allowed;
-}
-
-.meeting-title {
-  font-size: 15px;
-  font-weight: 500;
-  color: #1c1c1c;
-  line-height: 1.25;
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.meeting-time {
-  font-size: 12px;
-  color: #6f6f6f;
 }
 
 .new-meeting {
@@ -411,6 +444,14 @@ onMounted(async () => {
   display: flex;
   flex-direction: column;
   gap: 8px;
+}
+
+/* A hairline keeps "record something else" legible as the fallback path below
+   the list, rather than competing with it. */
+.new-meeting--divided {
+  margin-top: 12px;
+  padding-top: 12px;
+  border-top: 1px solid #e7e5e2;
 }
 
 .title-input {
@@ -480,23 +521,30 @@ onMounted(async () => {
   color: #d96a5a;
 }
 
+/* Secondary by design: the meetings above are the primary choice, so this keeps
+   a target's shape but drops the fill and the raised shadow. */
 .skip-btn {
   padding: 10px 14px;
   border-radius: 12px;
-  border: 1px solid #d6d6d6;
-  background: #ffffff;
-  box-shadow: 2px 2px 0 #e7e5e2;
-  color: #1c1c1c;
+  border: 1px solid #e0dedb;
+  background: transparent;
+  color: #4a4a4a;
   font-family: inherit;
   font-size: 13px;
   font-weight: 600;
   cursor: pointer;
-  transition: transform 0.1s, box-shadow 0.1s;
+  transition: background 0.12s, border-color 0.12s, color 0.12s;
 }
 
-.skip-btn:hover {
-  box-shadow: 1px 1px 0 #e7e5e2;
-  transform: translate(1px, 1px);
+.skip-btn:not(:disabled):hover {
+  background: rgba(0, 0, 0, 0.03);
+  border-color: #d6d6d6;
+  color: #1c1c1c;
+}
+
+.skip-btn:focus-visible {
+  outline: 2px solid #1c1c1c;
+  outline-offset: 2px;
 }
 
 @keyframes spin {

--- a/src/views/MeetingPickerView.vue
+++ b/src/views/MeetingPickerView.vue
@@ -179,10 +179,21 @@ const featuredLabel = computed(() => {
   return isHappeningNow.value ? 'Happening now' : 'Up next';
 });
 
+// forcedDefault may be a past meeting outside today's list (see the comment
+// above its declaration) — without this, expanding the list would drop the
+// "Continue" meeting instead of just demoting it to a regular row.
+const expandedMeetings = computed<ScheduledMeeting[]>(() => {
+  const forced = forcedDefault.value;
+  if (!forced || meetings.value.some((m) => m.id === forced.id)) {
+    return meetings.value;
+  }
+  return [forced, ...meetings.value];
+});
+
 // Expanded rows carry the label inline, since a section heading can't attach to
 // one row in the middle of a list the way it does in the collapsed view.
 const decoratedMeetings = computed(() =>
-  meetings.value.map((m) => {
+  expandedMeetings.value.map((m) => {
     const featured = m.id === featuredId.value;
     return {
       meeting: m,


### PR DESCRIPTION
## Problem

In the meeting picker, the meetings don't read as clickable. All the visual weight lands on **Record a new meeting** — the only element on screen with a surface, a border *and* a hard shadow — while the meetings above it were transparent rows with a 3% black hover tint. The fallback path looked like the primary one, and when a meeting is happening now, that meeting *is* the primary action.

Two contributing bugs:

- The `Happening now` / `Up next` label lived inside `v-if="!showAll"`, so hitting **View all** discarded `pickDefaultMeeting`'s answer and flattened everything into an undifferentiated list — nothing was primary precisely when there was most to choose from.
- The list's mask applied a 24px top fade unconditionally, dissolving the **first meeting's title** into the backdrop before the user had scrolled at all. (That's the orphan `4:27 PM` with no title above it in the screenshot below.)

## Change

**Rows are targets.** Meetings are white cards with a border that lift on hover. Extracted into `MeetingPickerRow` — the three call sites (forced "Continue", heuristic pick, expanded list) each carried their own copy of the row markup, so this removes the duplication rather than adding a fourth variant.

**The recommendation is genuinely primary.** The featured meeting takes the treatment `.btn-primary` already uses in this view — `#1c1c1c` fill, cream text, the hard shadow that presses in on hover — plus an uppercase badge and a pulsing dot while it's live. It **keeps** that treatment after "View all": `decoratedMeetings` carries the badge onto the matching row, so expanding adds options instead of throwing the pick away.

**The CTA steps back.** `.skip-btn` drops its fill and raised shadow for a bordered ghost, separated by a hairline so it reads as "or do something else" rather than the headline action.

**The fade follows the scroll.** `updateFades()` sets `is-faded-top` / `is-faded-bottom` from real scroll position, driving `--fade-top` / `--fade-bottom` in the mask. The first title is only faded once you've actually scrolled past it.

Also: `:focus-visible` rings on the rows and the CTA (the view had none anywhere), and `prefers-reduced-motion` on the live dot.

## Notes for review

- **Badge vs section label.** Collapsed keeps the existing `<p class="section-label">` above the single row; expanded moves the label inline into the row, because a section heading can't attach to one row in the middle of a list. Both read from one `featuredLabel` computed, so the strings aren't duplicated.
- **`Continue` vs `Continue meeting`.** With a forced default from the Library the inline badge reads `Continue`, not `Continue meeting` — [`MeetingPickerView.test.ts`](src/views/MeetingPickerView.test.ts) asserts the section header disappears on expand, and I kept that contract instead of rewriting the test around it.
- **No existing component to reuse.** `UpNextCard`'s rows are a different shape (title left / time right, inside a card, `MeetingListItem` from `useBackend`, Library window). `AriWillJoinTag` / `MeetingCanceledTag` are pastel pill chips — they'd clash inside the dark featured row, and neither is a generic tag component. The row's inline `toLocaleTimeString` matches how the other seven views in `src/views/` format a clock; there's no shared helper today and adding one is a wider refactor than this PR.

## Testing

`npm test` — 687 pass. Eight new cases: `MeetingPickerRow` in isolation ([`MeetingPickerRow.test.ts`](src/views/MeetingPickerRow.test.ts)), plus picker-level coverage that the pick stays `meeting-row--featured` through expand, that "Up next" gets no live dot, and that neither fade class is set before scrolling.

`vue-tsc` is clean on the changed files. (It reports pre-existing errors in `WaveformView.test.ts` and in the untouched mock block at the top of `MeetingPickerView.test.ts`; both predate this branch.)

**Not verified in the real window** — this machine has no Rust toolchain, so `tauri dev` doesn't run here. I checked it against the real component in a browser harness with a stubbed Tauri bridge. Layout and color are faithful; WKWebView font rendering and the window's fit at the featured row's new height are not. Worth a local look before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a redesigned meeting picker with selectable meeting cards.
  * Highlighted live meetings and the next upcoming meeting.
  * Added badges, title fallbacks, formatted start times, and disabled states.
  * Added responsive hover, focus, reduced-motion, and live-status styling.
  * Added scroll-edge fade effects for expanded meeting lists.

* **Bug Fixes**
  * Preserved access to selected past meetings from the Library when expanding the full meeting list.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->