### PR TITLE
fix: send recording audio over the raw IPC body instead of a JSON number[]

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1571,13 +1571,22 @@ pub fn local_recording_status(
     })
 }
 
+/// Non-binary arguments of [`buffer_pending_audio`], carried in the
+/// `x-oats-meta` header because the audio itself occupies the request body.
+#[derive(serde::Deserialize)]
+pub struct BufferPendingAudioArgs {
+    pub meta: crate::storage::PendingUploadMeta,
+}
+
 /// Buffer a stopped Ariso recording's mp3 + metadata on disk before the upload
 /// attempt, keyed by its ISO `created_at`. Returns the sanitized id.
+///
+/// Takes the mp3 as a raw IPC body for the same reason as
+/// `local_finalize_recording` — see `raw_ipc` for the measurements.
 #[tauri::command]
-pub fn buffer_pending_audio(
-    audio: Vec<u8>,
-    meta: crate::storage::PendingUploadMeta,
-) -> Result<String, String> {
+pub fn buffer_pending_audio(request: tauri::ipc::Request<'_>) -> Result<String, String> {
+    let audio = crate::raw_ipc::body_bytes(&request)?;
+    let BufferPendingAudioArgs { meta } = crate::raw_ipc::meta(&request)?;
     let root = crate::storage::ariso_root()?;
     crate::storage::write_pending_audio(&root, &meta, &audio)
 }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1588,7 +1588,8 @@ pub fn buffer_pending_audio(request: tauri::ipc::Request<'_>) -> Result<String, 
     let audio = crate::raw_ipc::body_bytes(&request)?;
     let BufferPendingAudioArgs { meta } = crate::raw_ipc::meta(&request)?;
     let root = crate::storage::ariso_root()?;
-    crate::storage::write_pending_audio(&root, &meta, &audio)
+    // Borrowed straight through to the write — no copy of the mp3.
+    crate::storage::write_pending_audio(&root, &meta, audio)
 }
 
 /// Remove the buffered mp3 for `created_at` (idempotent). Called after a

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -9,6 +9,7 @@ mod commands;
 mod meeting_notifications;
 mod mic_monitor;
 mod platform;
+mod raw_ipc;
 mod recorder_pill;
 mod storage;
 mod transcribe;

--- a/src-tauri/src/raw_ipc.rs
+++ b/src-tauri/src/raw_ipc.rs
@@ -1,0 +1,119 @@
+//! Helpers for commands that receive a large binary payload over the IPC bridge.
+//!
+//! Tauri only takes the raw-body fast path when the byte array *is* the entire
+//! args payload. Measured in-app against a 48 MB recording (50 min @ 128 kbps),
+//! sending the same bytes four ways:
+//!
+//! | payload shape                        | invoke |
+//! |--------------------------------------|--------|
+//! | raw `Uint8Array` as the whole args   |  44 ms |
+//! | nested `{ audio: Uint8Array }`       |  15.0 s |
+//! | nested `{ audio: ArrayBuffer }`      |  14.8 s |
+//! | `number[]`                           |  29.7 s |
+//!
+//! So the audio travels as the body and every other argument rides along in a
+//! header. Encoding the header as hex-of-JSON (rather than plain JSON) keeps it
+//! within the visible-ASCII range HTTP header values require, which matters
+//! because a recording title can contain arbitrary Unicode.
+
+use tauri::ipc::{InvokeBody, Request};
+
+/// Header carrying the hex-encoded JSON arguments of a raw-body command.
+pub const META_HEADER: &str = "x-oats-meta";
+
+/// Upper bound on a raw body, matching the `MAX_AUDIO_BYTES` bound the audio
+/// *read* paths already enforce — a recording too large to read back is not
+/// worth writing. ~17 hours of 128 kbps mp3. Commands are only reachable from
+/// our own webviews, but the raw path is fast enough (48 MB in ~44 ms) that it
+/// no longer throttles a runaway caller the way JSON serialization did.
+pub const MAX_BODY_BYTES: usize = 1024 * 1024 * 1024;
+
+/// The raw payload bytes. Rejects a JSON body so a frontend that regresses to
+/// `number[]` fails loudly here instead of silently costing 30 seconds.
+pub fn body_bytes(request: &Request<'_>) -> Result<Vec<u8>, String> {
+    match request.body() {
+        InvokeBody::Raw(bytes) if bytes.len() > MAX_BODY_BYTES => Err(format!(
+            "payload of {} bytes exceeds the {MAX_BODY_BYTES}-byte limit",
+            bytes.len()
+        )),
+        InvokeBody::Raw(bytes) => Ok(bytes.clone()),
+        InvokeBody::Json(_) => {
+            Err("expected a raw binary body; got JSON (see raw_ipc)".to_string())
+        }
+    }
+}
+
+/// The command's non-binary arguments, decoded from [`META_HEADER`].
+pub fn meta<T: serde::de::DeserializeOwned>(request: &Request<'_>) -> Result<T, String> {
+    let header = request
+        .headers()
+        .get(META_HEADER)
+        .ok_or_else(|| format!("missing {META_HEADER} header"))?
+        .to_str()
+        .map_err(|e| format!("non-ASCII {META_HEADER} header: {e}"))?;
+    let json = hex::decode(header).map_err(|e| format!("malformed {META_HEADER} hex: {e}"))?;
+    serde_json::from_slice(&json).map_err(|e| format!("malformed {META_HEADER} JSON: {e}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde::Deserialize;
+
+    #[derive(Debug, Deserialize, PartialEq)]
+    #[serde(rename_all = "camelCase")]
+    struct Args {
+        title: String,
+        duration_seconds: u64,
+        append_to: Option<String>,
+    }
+
+    /// `Request` cannot be constructed outside Tauri, so the header contract is
+    /// tested through the same decode chain `meta` uses.
+    fn decode(header: &str) -> Result<Args, String> {
+        let json = hex::decode(header).map_err(|e| format!("malformed {META_HEADER} hex: {e}"))?;
+        serde_json::from_slice(&json).map_err(|e| format!("malformed {META_HEADER} JSON: {e}"))
+    }
+
+    fn encode(json: &str) -> String {
+        hex::encode(json.as_bytes())
+    }
+
+    #[test]
+    fn decodes_hex_encoded_json_args() {
+        let header = encode(r#"{"title":"Mon Jun 2 @ 2PM","durationSeconds":2400}"#);
+        assert_eq!(
+            decode(&header).unwrap(),
+            Args {
+                title: "Mon Jun 2 @ 2PM".to_string(),
+                duration_seconds: 2400,
+                append_to: None,
+            }
+        );
+    }
+
+    /// The reason the header is hex rather than raw JSON: titles are user- and
+    /// locale-derived, and a non-ASCII byte is not a legal header value.
+    #[test]
+    fn survives_non_ascii_titles() {
+        let header = encode(r#"{"title":"打ち合わせ ☕","durationSeconds":60}"#);
+        assert_eq!(decode(&header).unwrap().title, "打ち合わせ ☕");
+    }
+
+    #[test]
+    fn optional_args_may_be_absent_or_null() {
+        let header = encode(r#"{"title":"T","durationSeconds":1,"appendTo":null}"#);
+        assert_eq!(decode(&header).unwrap().append_to, None);
+        let header = encode(r#"{"title":"T","durationSeconds":1,"appendTo":"2026-06-02T10-00-00Z"}"#);
+        assert_eq!(
+            decode(&header).unwrap().append_to.as_deref(),
+            Some("2026-06-02T10-00-00Z")
+        );
+    }
+
+    #[test]
+    fn rejects_malformed_headers() {
+        assert!(decode("not hex").unwrap_err().contains("hex"));
+        assert!(decode(&encode("{not json")).unwrap_err().contains("JSON"));
+    }
+}

--- a/src-tauri/src/raw_ipc.rs
+++ b/src-tauri/src/raw_ipc.rs
@@ -28,15 +28,20 @@ pub const META_HEADER: &str = "x-oats-meta";
 /// no longer throttles a runaway caller the way JSON serialization did.
 pub const MAX_BODY_BYTES: usize = 1024 * 1024 * 1024;
 
-/// The raw payload bytes. Rejects a JSON body so a frontend that regresses to
-/// `number[]` fails loudly here instead of silently costing 30 seconds.
-pub fn body_bytes(request: &Request<'_>) -> Result<Vec<u8>, String> {
+/// The raw payload bytes, borrowed from the request. Rejects a JSON body so a
+/// frontend that regresses to `number[]` fails loudly here instead of silently
+/// costing 30 seconds.
+///
+/// Returns a slice rather than a `Vec` so that copying a 48 MB payload is an
+/// explicit `.to_vec()` at the call site that needs ownership, not a hidden
+/// cost paid by every caller.
+pub fn body_bytes<'a>(request: &'a Request<'_>) -> Result<&'a [u8], String> {
     match request.body() {
         InvokeBody::Raw(bytes) if bytes.len() > MAX_BODY_BYTES => Err(format!(
             "payload of {} bytes exceeds the {MAX_BODY_BYTES}-byte limit",
             bytes.len()
         )),
-        InvokeBody::Raw(bytes) => Ok(bytes.clone()),
+        InvokeBody::Raw(bytes) => Ok(bytes),
         InvokeBody::Json(_) => {
             Err("expected a raw binary body; got JSON (see raw_ipc)".to_string())
         }

--- a/src-tauri/src/transcribe.rs
+++ b/src-tauri/src/transcribe.rs
@@ -704,15 +704,34 @@ pub async fn local_recording_id_for_start(
     storage::resolve_local_recording_id(&root, &created_at)
 }
 
+/// Non-binary arguments of [`local_finalize_recording`], carried in the
+/// `x-oats-meta` header because the audio itself occupies the request body.
+#[derive(serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FinalizeArgs {
+    pub title: String,
+    pub created_at: String,
+    pub duration_seconds: u64,
+    pub append_to: Option<String>,
+    pub force_new: Option<bool>,
+}
+
+/// Takes the mp3 as a raw IPC body rather than a JSON `number[]`: a 50-minute
+/// recording is ~48 MB, which costs ~30 s to serialize as numbers versus ~44 ms
+/// as a raw body (see `raw_ipc`). That serialization ran on the webview's main
+/// thread, freezing the recorder pill while it worked.
 #[tauri::command]
 pub async fn local_finalize_recording(
-    audio: Vec<u8>,
-    title: String,
-    created_at: String,
-    duration_seconds: u64,
-    append_to: Option<String>,
-    force_new: Option<bool>,
+    request: tauri::ipc::Request<'_>,
 ) -> Result<FinalizeResult, String> {
+    let audio = crate::raw_ipc::body_bytes(&request)?;
+    let FinalizeArgs {
+        title,
+        created_at,
+        duration_seconds,
+        append_to,
+        force_new,
+    } = crate::raw_ipc::meta(&request)?;
     let root = crate::vault::meta_root()?;
     // Drop the notes JoinHandle: notes are best-effort and continue running
     // in the background, writing their outcome to meta.json directly.

--- a/src-tauri/src/transcribe.rs
+++ b/src-tauri/src/transcribe.rs
@@ -724,7 +724,8 @@ pub struct FinalizeArgs {
 pub async fn local_finalize_recording(
     request: tauri::ipc::Request<'_>,
 ) -> Result<FinalizeResult, String> {
-    let audio = crate::raw_ipc::body_bytes(&request)?;
+    // Owned: the finalize chain persists the audio and outlives the request.
+    let audio = crate::raw_ipc::body_bytes(&request)?.to_vec();
     let FinalizeArgs {
         title,
         created_at,

--- a/src/composables/useBackend.test.ts
+++ b/src/composables/useBackend.test.ts
@@ -99,7 +99,10 @@ describe('LocalBackend', () => {
     });
     expect(res.backend).toBe('local');
     const [audioArg, titleArg, createdAtArg, durationArg] = localFinalize.mock.calls[0];
-    expect(audioArg).toEqual([1, 2, 3]);
+    // A Uint8Array, not a number[]: the raw-body IPC path is what keeps a long
+    // recording's finalize from freezing the recorder pill for ~30 s.
+    expect(audioArg).toEqual(new Uint8Array([1, 2, 3]));
+    expect(ArrayBuffer.isView(audioArg)).toBe(true);
     expect(createdAtArg).toBe('2026-06-02T14:30:05.000Z');
     expect(durationArg).toBe(2400);
     // Title is a friendly local "Ddd Mmm D @ h[:mm]A" label (assert format, not
@@ -235,7 +238,7 @@ describe('ArisoBackend', () => {
       endAt: '2026-06-02T15:10:00.000Z',
       durationSeconds: 2400,
     });
-    expect(bufferPendingAudio).toHaveBeenCalledWith([9], {
+    expect(bufferPendingAudio).toHaveBeenCalledWith(new Uint8Array([9]), {
       createdAt: '2026-06-02T14:30:05.000Z',
       startAt: '2026-06-02T14:30:05.000Z',
       endAt: '2026-06-02T15:10:00.000Z',

--- a/src/composables/useBackend.ts
+++ b/src/composables/useBackend.ts
@@ -223,8 +223,12 @@ function normalizeActionItems(
     .filter((it) => it.item.trim().length > 0);
 }
 
-async function blobToBytes(blob: Blob): Promise<number[]> {
-  return [...new Uint8Array(await blob.arrayBuffer())];
+// Stays a Uint8Array all the way to `invoke`. Materializing the bytes as a
+// `number[]` cost ~2 s of main-thread conversion plus ~30 s of IPC
+// serialization for a 50-minute recording; as a raw body the same 48 MB crosses
+// in ~44 ms. See `rawMetaOptions` in tauri.ts and `raw_ipc.rs`.
+async function blobToBytes(blob: Blob): Promise<Uint8Array> {
+  return new Uint8Array(await blob.arrayBuffer());
 }
 
 // The remote list/search endpoints return nearly the same meeting shape. Keep

--- a/src/tauri.finalize.test.ts
+++ b/src/tauri.finalize.test.ts
@@ -3,15 +3,39 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 const invoke = vi.fn(() => Promise.resolve({ backend: 'local', id: 'x', title: 't', status: 'done' }));
 vi.mock('@tauri-apps/api/core', () => ({ invoke: (...a: unknown[]) => invoke(...a) }));
 
-import { local } from './tauri';
+import { local, pending } from './tauri';
 
 beforeEach(() => vi.clearAllMocks());
 
+/** Mirror of `raw_ipc::meta` in Rust: hex header -> the command's arguments. */
+function decodeMetaHeader(options: unknown): Record<string, unknown> {
+  const header = (options as { headers: Record<string, string> }).headers['x-oats-meta'];
+  const bytes = new Uint8Array(header.match(/../g)!.map((h) => parseInt(h, 16)));
+  return JSON.parse(new TextDecoder().decode(bytes));
+}
+
 describe('local.finalizeRecording', () => {
+  // The whole point of the raw-body shape: Tauri only skips JSON serialization
+  // when the bytes ARE the args payload. Nesting them in an object costs ~15 s
+  // for a 48 MB recording and freezes the recorder pill while it serializes.
+  it('sends the audio as the raw args payload, not a JSON-serializable value', async () => {
+    const audio = new Uint8Array([1, 2]);
+    await local.finalizeRecording(audio, 'Title', '2026-06-02T10:00:00Z', 12);
+    const [cmd, payload] = invoke.mock.calls[0];
+    expect(cmd).toBe('local_finalize_recording');
+    expect(payload).toBe(audio);
+    expect(ArrayBuffer.isView(payload)).toBe(true);
+  });
+
   it('forwards appendTo to the local_finalize_recording command', async () => {
-    await local.finalizeRecording([1, 2], 'Title', '2026-06-02T10:00:00Z', 12, '2026-06-01T09-00-00Z');
-    expect(invoke).toHaveBeenCalledWith('local_finalize_recording', {
-      audio: [1, 2],
+    await local.finalizeRecording(
+      new Uint8Array([1, 2]),
+      'Title',
+      '2026-06-02T10:00:00Z',
+      12,
+      '2026-06-01T09-00-00Z'
+    );
+    expect(decodeMetaHeader(invoke.mock.calls[0][2])).toEqual({
       title: 'Title',
       createdAt: '2026-06-02T10:00:00Z',
       durationSeconds: 12,
@@ -20,9 +44,36 @@ describe('local.finalizeRecording', () => {
   });
 
   it('omits appendTo (undefined) for a normal new recording', async () => {
-    await local.finalizeRecording([1], 'T', '2026-06-02T10:00:00Z', 5);
-    expect(invoke).toHaveBeenCalledWith('local_finalize_recording', {
-      audio: [1], title: 'T', createdAt: '2026-06-02T10:00:00Z', durationSeconds: 5, appendTo: undefined,
-    });
+    await local.finalizeRecording(new Uint8Array([1]), 'T', '2026-06-02T10:00:00Z', 5);
+    const meta = decodeMetaHeader(invoke.mock.calls[0][2]);
+    expect(meta).toEqual({ title: 'T', createdAt: '2026-06-02T10:00:00Z', durationSeconds: 5 });
+    expect('appendTo' in meta).toBe(false);
+  });
+
+  // Header values must be visible ASCII, and titles are locale-derived — hence
+  // the hex encoding rather than raw JSON.
+  it('carries a non-ASCII title through the header intact', async () => {
+    await local.finalizeRecording(new Uint8Array([1]), '打ち合わせ ☕', '2026-06-02T10:00:00Z', 5);
+    const header = (invoke.mock.calls[0][2] as { headers: Record<string, string> })
+      .headers['x-oats-meta'];
+    expect(header).toMatch(/^[0-9a-f]+$/);
+    expect(decodeMetaHeader(invoke.mock.calls[0][2]).title).toBe('打ち合わせ ☕');
+  });
+});
+
+describe('pending.bufferAudio', () => {
+  it('sends the audio as the raw args payload with meta in the header', async () => {
+    const audio = new Uint8Array([9]);
+    const meta = {
+      createdAt: '2026-06-02T14:30:05.000Z',
+      startAt: '2026-06-02T14:30:05.000Z',
+      endAt: '2026-06-02T15:10:00.000Z',
+      durationSeconds: 2400,
+    };
+    await pending.bufferAudio(audio, meta);
+    const [cmd, payload, options] = invoke.mock.calls[0];
+    expect(cmd).toBe('buffer_pending_audio');
+    expect(payload).toBe(audio);
+    expect(decodeMetaHeader(options)).toEqual({ meta });
   });
 });

--- a/src/tauri.ts
+++ b/src/tauri.ts
@@ -7,6 +7,22 @@ import { open as openDialog } from '@tauri-apps/plugin-dialog';
 // can mount before onboarding signs in, so it needs a cross-window refresh cue.
 export const AUTH_SIGNED_IN_EVENT = 'auth://signed-in';
 
+/** Header carrying the non-binary arguments of a raw-body command. */
+const RAW_META_HEADER = 'x-oats-meta';
+
+// Tauri only takes the raw-body fast path when the bytes ARE the whole args
+// payload — nesting a Uint8Array inside an object drops back to JSON, which for
+// a 48 MB recording costs ~15 s (and `number[]` costs ~30 s) of main-thread
+// serialization versus ~44 ms raw. So audio commands send the bytes alone and
+// pass everything else through this header, hex-encoded so that a title with
+// non-ASCII characters stays a legal header value. Mirrors `raw_ipc.rs`.
+function rawMetaOptions(meta: unknown): { headers: Record<string, string> } {
+  const json = new TextEncoder().encode(JSON.stringify(meta));
+  let hex = '';
+  for (const byte of json) hex += byte.toString(16).padStart(2, '0');
+  return { headers: { [RAW_META_HEADER]: hex } };
+}
+
 interface SignInResult {
   success?: boolean;
   sessionToken?: string;
@@ -333,21 +349,18 @@ export interface ModelStatus {
 
 export const local = {
   finalizeRecording(
-    audio: number[],
+    audio: Uint8Array,
     title: string,
     createdAt: string,
     durationSeconds: number,
     appendTo?: string,
     forceNew?: boolean
   ): Promise<LocalFinalizeResult> {
-    return invoke<LocalFinalizeResult>('local_finalize_recording', {
+    return invoke<LocalFinalizeResult>(
+      'local_finalize_recording',
       audio,
-      title,
-      createdAt,
-      durationSeconds,
-      appendTo,
-      forceNew,
-    });
+      rawMetaOptions({ title, createdAt, durationSeconds, appendTo, forceNew })
+    );
   },
   listRecordings(): Promise<RecordingSummary[]> {
     return invoke<RecordingSummary[]>('list_local_recordings');
@@ -428,8 +441,8 @@ export interface PendingUploadMeta {
  *  upload attempt and removed once the server confirms (or the user
  *  dismisses). Keyed by the recording's ISO `createdAt`; Rust derives the id. */
 export const pending = {
-  bufferAudio(audio: number[], meta: PendingUploadMeta): Promise<string> {
-    return invoke<string>('buffer_pending_audio', { audio, meta });
+  bufferAudio(audio: Uint8Array, meta: PendingUploadMeta): Promise<string> {
+    return invoke<string>('buffer_pending_audio', audio, rawMetaOptions({ meta }));
   },
   /** Idempotent — missing buffer files are not an error. */
   discardAudio(createdAt: string): Promise<void> {


### PR DESCRIPTION
## What does this PR do?

Refs #304. Stops finalize from freezing the webview's main thread for ~30 seconds
after a long recording.

`blobToBytes` materialized the recorded mp3 as a `number[]`, which Tauri then
JSON-encoded element by element to cross the IPC bridge. A 50-minute recording is
~48 MB at 128 kbps — a 50-million-element array. Both the conversion and the
serialization run synchronously on the recorder window's main thread, so the pill
cannot repaint or fire a timer for the duration.

Measured in the running app (dev build, `--features mcp`) sending the same 48 MB
four ways:

| payload shape | invoke |
|---|---|
| raw `Uint8Array` as the whole args payload | **44 ms** |
| nested `{ audio: Uint8Array }` | 14,976 ms |
| nested `{ audio: ArrayBuffer }` | 14,836 ms |
| `number[]` (before this PR) | 29,653 ms |

Tauri only takes the raw-body fast path when the byte array **is** the entire args
payload — nesting it in an object drops back to JSON. So `local_finalize_recording`
and `buffer_pending_audio` now take `tauri::ipc::Request`: audio from the body,
everything else from a hex-encoded JSON header (hex because header values must be
visible ASCII, and a recording title can contain arbitrary Unicode).

The Rust side rejects a JSON body outright, so a future regression back to
`number[]` fails loudly instead of silently costing 30 seconds, and bounds the body
at the same 1 GB limit the audio *read* paths already enforce.

## Scope: what this does and doesn't prove about #304

I could not reproduce #304's indefinite spinner directly — that needs a real
50-minute recording. What is measured is the mechanism underneath it:

- **Proven**: the `number[]` path blocks the main thread ~32 s (2 s conversion +
  ~30 s serialization) and holds ~600 MB of peak webview memory (the `number[]`
  plus its JSON string) that this PR removes.
- **Not proven**: that this alone makes the pill settle. On-device transcription of
  a 50-minute file runs inside the same 120 s `Promise.race` in `runFinalize`, and
  I have not measured how long that takes. If it exceeds 120 s, #304 needs a
  second fix to the timeout/progress handling.

Linked as `Refs` rather than `Closes` for that reason — worth confirming against a
real long recording before closing the issue.

This supersedes #310, which attributed the freeze to spread-vs-`Array.from` in
`blobToBytes`. Measured, those are ~2669 ms and ~2169 ms at 48 MB — a ~1.2x
difference on a path that spends ~30 s in IPC. Details in
https://github.com/ariso-ai/oats/pull/310#issuecomment-5382678834.

## Type of change

- [x] `fix:` — bug fix

## How was this tested?

- `npm test` — 691 pass (54 files).
- `cargo test` — 292 pass, including 4 new `raw_ipc` tests covering the header
  contract: hex-JSON decode, non-ASCII titles, absent/null optional args, and
  malformed input.
- **In the app, Local backend, macOS 15 / Apple Silicon.** Drove
  `buffer_pending_audio` through the new path with a 48 MB payload: **78 ms**
  including the disk write, main thread blocked **28 ms**. Confirmed the bytes
  landed (`list_pending_uploads` showed the entry), then discarded it and confirmed
  it was gone. Also confirmed the old `number[]` shape is now rejected:
  `expected a raw binary body; got JSON (see raw_ipc)`.

New regression tests assert the audio reaches `invoke` as a `Uint8Array` and as the
whole args payload — the property the fast path depends on.

## Screenshots / recordings

No UI change.

## Checklist

- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I ran `npm test` and the suite passes
- [x] I tested the change in the app (Local backend, macOS 15 / Apple Silicon)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Audio recording finalization and pending-audio buffering now transfer binary audio more efficiently.
  * Supports large audio payloads up to 1 GiB.
  * Recording metadata, including Unicode titles, is preserved more reliably.
  * Optional recording settings such as append targets and force-new behavior continue to work correctly.

* **Bug Fixes**
  * Improved validation of audio data and recording metadata.
  * Added safeguards for missing, malformed, or invalid metadata.
  * Improved handling of binary audio payloads during recording workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->