### PR TITLE
fix: report which recording blocks a new one, and in what state

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1203,6 +1203,22 @@ const YIELD_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(3);
 const YIELD_REOPEN_POLLS: u32 = 20;
 const YIELD_REOPEN_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(25);
 
+/// Payload for the `recording://start-failed` event emitted when a queued
+/// recording's yield request expires (#320).
+///
+/// The incumbent pill refuses to stand down in two states the user must not
+/// have confused: `capture_active()` is set while audio is actually being
+/// recorded and cleared on stop, before the upload runs — so telling someone
+/// mid-recording to "wait for the upload to finish" describes a wait that never
+/// ends. The frontend turns `reason` into user-facing copy and names the meeting
+/// when it can resolve `meeting_id`; only it has meeting titles.
+fn yield_expired_payload(capturing: bool, meeting_id: Option<i64>) -> serde_json::Value {
+    serde_json::json!({
+        "reason": if capturing { "capturing" } else { "uploading" },
+        "meetingId": meeting_id,
+    })
+}
+
 /// Shared helper to open the waveform recording window. Used by the
 /// `start_recording_window` command, the tray (Local backend path), and the
 /// auto mic monitor. `auto` adds `auto=1` to the URL and tags the shared
@@ -1237,23 +1253,22 @@ pub(crate) fn open_waveform_window(
         // down and re-open once it's actually gone (see the Destroyed handler
         // below). It refuses while still capturing or uploading — then the
         // queued request expires and the focus above is all that happens. Tell
-        // the frontend so the user sees why the new recording never started
-        // (#320) instead of a launch spinner that hangs forever.
+        // the frontend which recording is in the way, and in which state, so the
+        // user gets an accurate explanation (#320) instead of a launch spinner
+        // that hangs forever.
         let token = state.queue_reopen(meeting_id, local_append_id, force_new, auto);
         let _ = app.emit("recorder://yield", ());
         let app_for_expiry = app.clone();
         tauri::async_runtime::spawn(async move {
             tokio::time::sleep(YIELD_TIMEOUT).await;
-            let expired = app_for_expiry
-                .state::<crate::recording_state::RecordingState>()
-                .expire_reopen(token);
-            if expired {
-                let _ = app_for_expiry.emit(
-                    "recording://start-failed",
-                    serde_json::json!({
-                        "message": "Can't start a new recording yet: the previous recording is still uploading. Try again once it finishes.",
-                    }),
-                );
+            let state = app_for_expiry.state::<crate::recording_state::RecordingState>();
+            if state.expire_reopen(token) {
+                // Read the blocking state only after the request is confirmed
+                // dropped, so the reason describes the pill that outlasted the
+                // handshake rather than whatever it was doing 3s ago.
+                let payload =
+                    yield_expired_payload(state.capture_active(), state.active_meeting_id());
+                let _ = app_for_expiry.emit("recording://start-failed", payload);
             }
         });
         return Ok(());
@@ -2236,6 +2251,27 @@ pub fn share_text_native(_text: String, _anchor: ShareAnchor) -> Result<(), Stri
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // A recording requested while the pill still holds the window slot is
+    // dropped after the yield timeout. What the user is told about it must match
+    // the state the pill is actually in (#320).
+    #[test]
+    fn yield_expiry_distinguishes_a_recording_pill_from_an_uploading_one() {
+        assert_eq!(yield_expired_payload(true, Some(42))["reason"], "capturing");
+        assert_eq!(yield_expired_payload(false, Some(42))["reason"], "uploading");
+    }
+
+    #[test]
+    fn yield_expiry_names_the_meeting_holding_the_recorder() {
+        assert_eq!(yield_expired_payload(false, Some(42))["meetingId"], 42);
+    }
+
+    #[test]
+    fn yield_expiry_reports_an_ad_hoc_recording_with_no_meeting() {
+        // Local ad-hoc recordings carry no meeting id; the frontend falls back
+        // to unnamed copy rather than inventing one.
+        assert!(yield_expired_payload(true, None)["meetingId"].is_null());
+    }
 
     #[test]
     fn desktop_auth_redirect_encodes_port_and_nonce() {

--- a/src/composables/recordingStartError.test.ts
+++ b/src/composables/recordingStartError.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { recordingStartErrorMessage } from './recordingStartError';
+import {
+  recordingBlockedMessage,
+  recordingBlockedPayload,
+  recordingStartErrorMessage,
+} from './recordingStartError';
 
 describe('recordingStartErrorMessage', () => {
   it('explains how to recover from a blocked microphone', () => {
@@ -24,5 +28,54 @@ describe('recordingStartErrorMessage', () => {
     expect(recordingStartErrorMessage(new Error('driver path C:\\secret'))).not.toContain(
       'C:\\secret',
     );
+  });
+});
+
+describe('recordingBlockedPayload', () => {
+  it('reads the reason and stringifies the numeric meeting id', () => {
+    expect(recordingBlockedPayload({ reason: 'uploading', meetingId: 42 })).toEqual({
+      reason: 'uploading',
+      meetingId: '42',
+    });
+  });
+
+  it('accepts a blocked start with no identifiable meeting', () => {
+    expect(recordingBlockedPayload({ reason: 'capturing', meetingId: null })).toEqual({
+      reason: 'capturing',
+      meetingId: null,
+    });
+  });
+
+  it('ignores payloads from every other start failure', () => {
+    expect(recordingBlockedPayload({ message: 'No microphone was found.' })).toBeNull();
+    expect(recordingBlockedPayload({ reason: 'something-else' })).toBeNull();
+    expect(recordingBlockedPayload(null)).toBeNull();
+  });
+});
+
+describe('recordingBlockedMessage', () => {
+  it('names the meeting still recording and says how to unblock it', () => {
+    const message = recordingBlockedMessage('capturing', 'Standup');
+    expect(message).toContain('Standup');
+    expect(message).toContain('still recording');
+  });
+
+  it('names the meeting still uploading', () => {
+    const message = recordingBlockedMessage('uploading', 'Standup');
+    expect(message).toContain('Standup');
+    expect(message).toContain('still uploading');
+  });
+
+  // The two states are not interchangeable: a pill that is mid-capture is not
+  // uploading, and telling the user to wait for an upload that never runs is
+  // worse than saying nothing (#320).
+  it('does not describe an in-progress recording as an upload', () => {
+    expect(recordingBlockedMessage('capturing', 'Standup')).not.toContain('uploading');
+    expect(recordingBlockedMessage('capturing', null)).not.toContain('uploading');
+  });
+
+  it('stays accurate when the blocking meeting cannot be named', () => {
+    expect(recordingBlockedMessage('uploading', null)).toContain('previous recording');
+    expect(recordingBlockedMessage('capturing', '  ')).toContain('Another recording');
   });
 });

--- a/src/composables/recordingStartError.ts
+++ b/src/composables/recordingStartError.ts
@@ -36,3 +36,51 @@ export function recordingStartErrorMessage(error: unknown): string {
   }
   return 'Oats could not start recording. Check that your audio devices are connected and available, then try again.';
 }
+
+/** Why a queued recording never started: the recorder pill already up refused to
+ * give up the one window slot. Mirrors the `reason` values the backend emits
+ * from `open_waveform_window`'s yield-expiry branch. */
+export type RecordingBlockedReason = 'capturing' | 'uploading';
+
+export interface RecordingBlocked {
+  reason: RecordingBlockedReason;
+  /** The meeting holding the recorder, as a `MeetingListItem` id. Null when the
+   * incumbent has no meeting attached (an ad-hoc local recording). */
+  meetingId: string | null;
+}
+
+/** Read a `recording://start-failed` payload emitted by the yield-expiry branch.
+ * Returns null for every other start failure — those carry a ready-made
+ * `message` and are handled by `recordingStartErrorMessage`. */
+export function recordingBlockedPayload(payload: unknown): RecordingBlocked | null {
+  if (typeof payload !== 'object' || payload === null || !('reason' in payload)) return null;
+  const { reason } = payload as { reason: unknown };
+  if (reason !== 'capturing' && reason !== 'uploading') return null;
+  const raw = 'meetingId' in payload ? (payload as { meetingId: unknown }).meetingId : null;
+  const meetingId =
+    typeof raw === 'number' && Number.isFinite(raw)
+      ? String(raw)
+      : typeof raw === 'string' && raw.length > 0
+        ? raw
+        : null;
+  return { reason, meetingId };
+}
+
+/** Explain which recording is holding the recorder and what clears it, naming
+ * the meeting when the caller could resolve a title. The two states are not
+ * interchangeable — a pill mid-capture is not uploading, and telling the user to
+ * wait for an upload that never runs leaves them stuck (#320). */
+export function recordingBlockedMessage(
+  reason: RecordingBlockedReason,
+  title: string | null,
+): string {
+  const named = title !== null && title.trim().length > 0;
+  if (reason === 'capturing') {
+    return named
+      ? `“${title!.trim()}” is still recording. Stop it before starting a new one.`
+      : 'Another recording is still in progress. Stop it before starting a new one.';
+  }
+  return named
+    ? `“${title!.trim()}” is still uploading. Try again once it finishes.`
+    : 'The previous recording is still uploading. Try again once it finishes.';
+}

--- a/src/views/LibraryView.test.ts
+++ b/src/views/LibraryView.test.ts
@@ -1365,6 +1365,52 @@ describe('LibraryView', () => {
     expect(wrapper.get('.add-btn').attributes('disabled')).toBeUndefined();
   });
 
+  // Starting a second recording while the first still holds the recorder pill:
+  // the backend drops the queued request and reports which recording blocked it
+  // and in what state, rather than leaving Start stuck forever (#320).
+  it('names the meeting still uploading when a second recording is blocked', async () => {
+    listMeetings.mockResolvedValue([item({ id: '42', title: 'Weekly Standup' })]);
+    const wrapper = mount(LibraryView);
+    await flushPromises();
+
+    emitEvent('recording://state', true);
+    emitEvent('recording://start-failed', { reason: 'uploading', meetingId: 42 });
+    await flushPromises();
+
+    const error = wrapper.get('.recording-start-error').text();
+    expect(error).toContain('Weekly Standup');
+    expect(error).toContain('still uploading');
+    expect(wrapper.get('.add-btn').attributes('disabled')).toBeUndefined();
+  });
+
+  it('says the blocking meeting is still recording rather than uploading', async () => {
+    listMeetings.mockResolvedValue([item({ id: '42', title: 'Weekly Standup' })]);
+    const wrapper = mount(LibraryView);
+    await flushPromises();
+
+    emitEvent('recording://state', true);
+    emitEvent('recording://start-failed', { reason: 'capturing', meetingId: 42 });
+    await flushPromises();
+
+    const error = wrapper.get('.recording-start-error').text();
+    expect(error).toContain('Weekly Standup');
+    expect(error).toContain('still recording');
+    expect(error).not.toContain('uploading');
+  });
+
+  it('still explains a blocked start when the meeting is not in the list', async () => {
+    listMeetings.mockResolvedValue([]);
+    const wrapper = mount(LibraryView);
+    await flushPromises();
+
+    emitEvent('recording://state', true);
+    emitEvent('recording://start-failed', { reason: 'uploading', meetingId: null });
+    await flushPromises();
+
+    expect(wrapper.get('.recording-start-error').text()).toContain('previous recording');
+    expect(wrapper.get('.add-btn').attributes('disabled')).toBeUndefined();
+  });
+
   it('renders the PendingUploads section inside the sidebar', async () => {
     listMeetings.mockResolvedValue([]);
     const wrapper = mount(LibraryView, {

--- a/src/views/LibraryView.vue
+++ b/src/views/LibraryView.vue
@@ -254,7 +254,11 @@ import AriJoinConfirmDialog from './AriJoinConfirmDialog.vue';
 import { decideStartRecording } from '../composables/decideStartRecording';
 import { useRecordingStartChoice } from '../composables/useRecordingStartChoice';
 import RecordingStartChoiceDialog from './RecordingStartChoiceDialog.vue';
-import { recordingStartErrorMessage } from '../composables/recordingStartError';
+import {
+  recordingBlockedMessage,
+  recordingBlockedPayload,
+  recordingStartErrorMessage,
+} from '../composables/recordingStartError';
 import oatsLogo from '../assets/oats-dark.svg';
 
 const meetings = ref<MeetingListItem[]>([]);
@@ -773,16 +777,37 @@ function onNativeRecordingState(event: { payload: unknown }): void {
   }
 }
 
+// The title of the meeting holding the recorder, for a blocked start. Only this
+// window can resolve it: the backend knows the id but has no meeting titles.
+function blockingMeetingTitle(id: string | null): string | null {
+  if (id === null) return null;
+  // displayMeetings already layers pinned ad-hoc meetings over the loaded list,
+  // so a meeting recorded moments ago is findable here.
+  const title = displayMeetings.value.find((m) => m.id === id)?.title?.trim();
+  return title ? title : null;
+}
+
 function onRecordingStartFailed(event: { payload: unknown }): void {
   const payload = event.payload;
-  recordingStartError.value =
-    typeof payload === 'object'
-    && payload !== null
-    && 'message' in payload
-    && typeof payload.message === 'string'
-    && payload.message.length <= 300
-      ? payload.message
-      : recordingStartErrorMessage(payload);
+  // A start blocked by the incumbent recorder pill names which recording is in
+  // the way and what clears it (#320); every other failure arrives with a
+  // ready-made message.
+  const blocked = recordingBlockedPayload(payload);
+  if (blocked) {
+    recordingStartError.value = recordingBlockedMessage(
+      blocked.reason,
+      blockingMeetingTitle(blocked.meetingId),
+    );
+  } else {
+    recordingStartError.value =
+      typeof payload === 'object'
+      && payload !== null
+      && 'message' in payload
+      && typeof payload.message === 'string'
+      && payload.message.length <= 300
+        ? payload.message
+        : recordingStartErrorMessage(payload);
+  }
   clearRecordingLaunch();
 }
 


### PR DESCRIPTION
Follow-up to #324. Refs #320 — deliberately not `Fixes`, see *Remaining* below.

## What #324 left wrong

#324 made the dropped-request case visible instead of silent, which fixed the stuck launch spinner. But it described every case with one hardcoded string:

> Can't start a new recording yet: the previous recording is still uploading. Try again once it finishes.

That is wrong in the more common case. The pill refuses `recorder://yield` in `handleYield` (`src/views/WaveformView.vue`) whenever `uploadResult === null` — i.e. **still capturing** — or an upload is genuinely in flight. Someone who hits record on a second meeting while the first is still running was told to wait for an upload that had not started, so the advice never came true. (CodeRabbit flagged the same on #324 as a "bounded user-facing correctness issue".)

## The change

**Backend reports state instead of guessing it.** `capture_active()` is set by `set_tray_recording` while audio is recording and cleared on stop, *before* the upload runs — exactly the distinction needed. The expiry branch now emits `{ reason, meetingId }` rather than prose:

```rust
fn yield_expired_payload(capturing: bool, meeting_id: Option<i64>) -> serde_json::Value
```

**Copy moves to the frontend**, the only side that can turn a meeting id into a title (Rust has `active_meeting_id()` but no titles; `FeaturedMeetingState` tracks the *upcoming* tray meeting, not the recording one). `LibraryView` resolves it against `displayMeetings`, which already layers pinned ad-hoc meetings over the loaded list, so a meeting recorded moments ago is findable.

| state | message |
|---|---|
| capturing, named | `“Weekly Standup” is still recording. Stop it before starting a new one.` |
| uploading, named | `“Weekly Standup” is still uploading. Try again once it finishes.` |
| capturing, unnamed | `Another recording is still in progress. Stop it before starting a new one.` |
| uploading, unnamed | `The previous recording is still uploading. Try again once it finishes.` |

Unnamed fallbacks cover ad-hoc local recordings, which carry no meeting id. This also removes the copy duplication #324 would otherwise have created across two languages. `onRecordingStartFailed` still honors plain `message` payloads, which is what `WaveformView` emits for device failures.

## Against #320's acceptance criteria

| Criterion | Before | Now |
|---|---|---|
| Don't silently disable a new recording | ✅ (#324) | ✅ |
| Errors identify which meeting/recording is affected | ❌ | ✅ named, with the blocking state |
| Regression coverage for a second start while the first is pending | ❌ | ✅ see below |
| Reproduce the blocked-start scenario | ❌ | ⚠️ covered by tests, not manually — see below |

## Tests

`#324` added none; this adds coverage for the path it changed.

- **Rust** (`commands.rs`) — 3 tests over `yield_expired_payload`: capturing vs uploading, meeting id passthrough, and the ad-hoc no-meeting case. Extracting the pure payload builder is what makes the branch testable without an `AppHandle`.
- **`LibraryView.test.ts`** — 3 tests driving `recording://start-failed` end to end: names the uploading meeting, says "recording" (and *not* "uploading") for a capturing pill, and stays accurate with an unresolvable meeting. **All three fail on `main`** (verified by stashing the handler change: they get the generic "Oats could not start recording" string).
- **`recordingStartError.test.ts`** — 7 tests for the payload reader and message builder, including an explicit assertion that a capturing pill is never described as uploading.

Verification:
- `npm test` — **775 passed** (57 files), up from 775 baseline plus the 10 new
- `cargo test ... --test-threads=1` — **297 passed**, 3 ignored
- `npm run vite:build` — passes

## Risk

Contained. No change to `RecordingState`, the yield handshake, or the window lifecycle — the pill still holds its slot exactly as before. The event payload shape changes for this one emitter, and the sole listener is updated with it; the legacy `message` form still works for `WaveformView`'s emissions.

## Remaining (not this PR)

Per the scope call on this follow-up, no escape hatch. If a finalize is genuinely hung, the block persists — the user now gets an accurate description of what is holding the recorder, but no way to force past it short of quitting. That's a real reliability gap worth its own issue, and it needs a decision about force-closing a pill whose audio may not be persisted. Leaving #320 open for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recording-start errors when another recording is active.
  * Messages now distinguish between an active recording and an upload in progress.
  * Identifies the blocking meeting when available, with a fallback for unnamed meetings.
  * Ensures the Start button is restored after a blocked recording attempt.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->