### PR TITLE
fix: never dock a recording that belongs to no meeting

### DIFF
--- a/src/views/LibraryView.test.ts
+++ b/src/views/LibraryView.test.ts
@@ -1201,11 +1201,16 @@ describe('LibraryView', () => {
     expect(badge.element.tagName).toBe('SPAN');
 
     // Once the recording resolves its id it has a meeting to return to, so the
-    // indicator becomes a clickable button again.
+    // indicator becomes a clickable button again. The resolved id synthesizes a
+    // recording row and selects it, so step off it deliberately (by id, not by
+    // row order) — on the recording's own row the strip docks and there is no
+    // indicator to assert on.
     emitEvent('recorder://state', localRecorderState());
     await flushPromises();
-    await wrapper.findAll('.meeting-item')[0].trigger('click');
+    const standup = wrapper.findAll('.meeting-item').find((row) => row.text().includes('Standup'));
+    await standup?.trigger('click');
     await flushPromises();
+    expect(wrapper.find('.detail-stub').attributes('data-meeting')).toBe('a');
     expect(wrapper.find('.add-btn--recording').element.tagName).toBe('BUTTON');
   });
 

--- a/src/views/LibraryView.test.ts
+++ b/src/views/LibraryView.test.ts
@@ -1163,33 +1163,65 @@ describe('LibraryView', () => {
     expect(wrapper.find('.add-btn').attributes('disabled')).toBeDefined();
   });
 
-  // Regression (#318): a recording that hasn't attached to a meeting id yet
-  // (both meetingId and localRecordingId null) used to dock in the detail
-  // pane for whatever meeting happened to be selected, rather than only the
-  // meeting shown when the recording began.
-  it('floats a homeless recording away from an unrelated meeting and re-docks on the one it started on', async () => {
+  // Regression (#318): a recording attached to no meeting at all (an Ariso
+  // auto-recording that matched no calendar event stays that way for the whole
+  // session) must never dock — the pill above a meeting reads as "this meeting
+  // is being recorded", whichever meeting happens to be on screen.
+  it('never docks an unattached recording, whichever meeting is on screen', async () => {
     listMeetings.mockResolvedValue([item({ id: 'a', title: 'Standup' }), item({ id: 'b', title: 'Planning' })]);
     const wrapper = mountWithDetailStub();
     await flushPromises();
-    // Auto-select lands on Standup (the earliest row) — that's the recording's home.
     expect(wrapper.find('.detail-stub').attributes('data-meeting')).toBe('a');
 
     emitEvent('recorder://state', localRecorderState({ localRecordingId: null }));
     await flushPromises();
-    expect(wrapper.find('.strip').exists()).toBe(true);
+    expect(wrapper.find('.strip').exists()).toBe(false);
+    expect(wrapper.find('.add-btn--recording').exists()).toBe(true);
 
-    // Navigate to the unrelated meeting — the strip must not follow it there.
     await wrapper.findAll('.meeting-item')[1].trigger('click');
     await flushPromises();
     expect(wrapper.find('.detail-stub').attributes('data-meeting')).toBe('b');
     expect(wrapper.find('.strip').exists()).toBe(false);
     expect(wrapper.find('.add-btn--recording').exists()).toBe(true);
+  });
 
-    // The floating indicator brings the user back to the recording's home meeting.
-    await wrapper.find('.add-btn--recording').trigger('click');
+  // An unattached recording has no meeting to navigate back to, so the titlebar
+  // indicator is a plain badge there — a button that silently does nothing on
+  // click is worse than one that never invites the click.
+  it('renders the "In recording" indicator as a badge when there is no meeting to return to', async () => {
+    listMeetings.mockResolvedValue([item({ id: 'a', title: 'Standup' })]);
+    const wrapper = mountWithDetailStub();
     await flushPromises();
-    expect(wrapper.find('.detail-stub').attributes('data-meeting')).toBe('a');
-    expect(wrapper.find('.strip').exists()).toBe(true);
+
+    emitEvent('recorder://state', localRecorderState({ localRecordingId: null }));
+    await flushPromises();
+    const badge = wrapper.find('.add-btn--recording');
+    expect(badge.exists()).toBe(true);
+    expect(badge.text()).toContain('In recording');
+    expect(badge.element.tagName).toBe('SPAN');
+
+    // Once the recording resolves its id it has a meeting to return to, so the
+    // indicator becomes a clickable button again.
+    emitEvent('recorder://state', localRecorderState());
+    await flushPromises();
+    await wrapper.findAll('.meeting-item')[0].trigger('click');
+    await flushPromises();
+    expect(wrapper.find('.add-btn--recording').element.tagName).toBe('BUTTON');
+  });
+
+  // The docked strip and the titlebar indicator are two renderings of one rule
+  // (LibraryView mirrors RecorderStrip's own visibility) — they must never both
+  // show. An empty detail pane is where the two used to disagree.
+  it('never shows the docked strip and the titlebar indicator at the same time', async () => {
+    listMeetings.mockResolvedValue([]);
+    const wrapper = mountWithDetailStub();
+    await flushPromises();
+    expect(wrapper.find('.detail-stub').exists()).toBe(false);
+
+    emitEvent('recorder://state', localRecorderState({ localRecordingId: null }));
+    await flushPromises();
+    expect(wrapper.find('.strip').exists()).toBe(false);
+    expect(wrapper.find('.add-btn--recording').exists()).toBe(true);
   });
 
   // Clicking the floating recorder pill emits `recording://reveal`; the open

--- a/src/views/LibraryView.vue
+++ b/src/views/LibraryView.vue
@@ -31,14 +31,20 @@
       </button>
       <!-- While a recording runs off-screen (its meeting isn't shown), the
            Start button becomes a "Recording" indicator that re-docks the strip
-           when clicked. Otherwise it starts a recording, disabled while the
-           strip is already on-screen so a second recording can't begin. -->
-      <button
+           when clicked. A recording attached to no meeting has nowhere to
+           re-dock, so it renders as a plain badge rather than a button whose
+           click would silently do nothing. Otherwise it starts a recording,
+           disabled while the strip is already on-screen so a second recording
+           can't begin. -->
+      <component
+        :is="recordingMeetingId ? 'button' : 'span'"
         v-if="recordingOffscreen"
         class="add-btn add-btn--recording"
-        type="button"
-        aria-label="Show current recording"
-        title="Show current recording"
+        :class="{ 'add-btn--static': !recordingMeetingId }"
+        :type="recordingMeetingId ? 'button' : undefined"
+        :role="recordingMeetingId ? undefined : 'status'"
+        :aria-label="recordingMeetingId ? 'Show current recording' : undefined"
+        :title="recordingMeetingId ? 'Show current recording' : 'Recording in progress'"
         @click="showRecordingMeeting"
       >
         <span class="rec-wave" aria-hidden="true">
@@ -48,7 +54,7 @@
           <span class="rec-wave-bar" />
         </span>
         <span class="add-btn-label">In recording</span>
-      </button>
+      </component>
       <button
         v-else
         class="add-btn"
@@ -291,12 +297,6 @@ const pendingUploads = ref<{ refresh: () => Promise<void> } | null>(null);
 // Meeting the recording session belongs to (reported by the strip). Persists
 // through the upload/failed phases so the row stays selected/pinned.
 const recordingMeetingId = ref<string | null>(null);
-// The meeting shown when the current session's first heartbeat arrived. A
-// fresh session reports no meeting id for a beat (local: resolving its id) or
-// indefinitely (Ariso: auto-recording awaiting confirmation) — this session's
-// docking home for that gap, so navigating to some other meeting during it
-// doesn't wrongly keep the strip docked there. Set below alongside recordingPhase.
-const recordingHomeMeetingId = ref<string | null>(null);
 // True only while audio is actively being captured — gates the red dot so it
 // stops pulsing the moment recording ends (e.g. a lingering failed-upload pill).
 const recordingActive = ref(false);
@@ -308,26 +308,22 @@ const recordingStarting = computed(
 );
 
 // The recorder strip is docked in the detail pane when an active recording's
-// meeting is the one on-screen; while the session has no meeting id yet, its
-// docking home takes over instead. Mirrors RecorderStrip's own visibility rule.
+// meeting is the one on-screen. A recording attached to no meeting (an Ariso
+// auto-recording that matched no calendar event; a local one still resolving
+// its id) belongs to no row, so it never docks — a pill above a meeting reads
+// as "this meeting is being recorded" (#318). Mirrors RecorderStrip's own
+// visibility rule; the two must agree, or the docked strip and the titlebar
+// indicator both show (or neither does).
 const recorderStripVisible = computed(
   () =>
     recordingActive.value &&
-    (recordingMeetingId.value != null
-      ? recordingMeetingId.value === selectedItem.value?.id
-      : recordingHomeMeetingId.value === selectedItem.value?.id)
+    recordingMeetingId.value != null &&
+    recordingMeetingId.value === selectedItem.value?.id
 );
 // A recording is running but its meeting isn't on-screen (the user closed the
 // detail or navigated to another meeting). The titlebar then shows a
 // "Recording" indicator instead of the Start button.
 const recordingOffscreen = computed(() => recordingActive.value && !recorderStripVisible.value);
-// Capture the on-screen meeting the instant a new session's first heartbeat
-// arrives (recordingPhase flips from null), and release it once the session
-// ends (recordingPhase returns to null) — see recordingHomeMeetingId above.
-watch(recordingPhase, (phase, prevPhase) => {
-  if (phase != null && prevPhase == null) recordingHomeMeetingId.value = selectedItem.value?.id ?? null;
-  else if (phase == null) recordingHomeMeetingId.value = null;
-});
 // A single waveform window owns capture, upload, and failed-upload recovery.
 // Keep every launcher disabled for that window's full lifetime so a second
 // click cannot race native creation or replace a recoverable failed session.
@@ -477,7 +473,7 @@ async function clearSelection(): Promise<void> {
 // Re-dock the recorder strip: pull the in-progress recording's meeting back
 // into the detail pane (the titlebar "Recording" indicator's action).
 async function showRecordingMeeting(): Promise<void> {
-  const id = recordingMeetingId.value ?? recordingHomeMeetingId.value;
+  const id = recordingMeetingId.value;
   if (!id) return;
   const m = displayMeetings.value.find((x) => x.id === id);
   if (m) await selectMeeting(m, { userSelected: false });
@@ -1315,6 +1311,10 @@ onUnmounted(() => {
   background: #fdf3f2;
 }
 .add-btn--recording .add-btn-label { color: #c5352f; }
+/* Same pill as a non-interactive badge (an unattached recording has no meeting
+   to re-dock on), so it must not invite a click it can't honor. */
+.add-btn--static { cursor: default; }
+.add-btn--static:hover { box-shadow: 1px 1px 0 #e7e5e2; transform: none; }
 /* Mini live waveform: four bars pulsing on a staggered cycle. */
 .rec-wave {
   display: inline-flex;

--- a/src/views/RecorderStrip.test.ts
+++ b/src/views/RecorderStrip.test.ts
@@ -43,37 +43,40 @@ describe('RecorderStrip', () => {
   });
 
   it('shows 3 bars and the timer while recording', async () => {
-    const wrapper = mount(RecorderStrip);
+    const wrapper = mount(RecorderStrip, { props: { meetingId: '42' } });
     await flushPromises();
-    sendState(recording());
+    sendState(recording({ meetingId: 42 }));
     await flushPromises();
     expect(wrapper.findAll('.bar')).toHaveLength(3);
     expect(wrapper.find('.timer').text()).toBe('01:05');
   });
 
   it('pause button emits the tray pause event; resume when paused', async () => {
-    const wrapper = mount(RecorderStrip);
+    const wrapper = mount(RecorderStrip, { props: { meetingId: '42' } });
     await flushPromises();
-    sendState(recording());
+    sendState(recording({ meetingId: 42 }));
     await flushPromises();
     await wrapper.find('.pause-btn').trigger('click');
     expect(emitEvent).toHaveBeenCalledWith('tray://pause-recording');
 
-    sendState(recording({ isPaused: true }));
+    sendState(recording({ meetingId: 42, isPaused: true }));
     await flushPromises();
     await wrapper.find('.pause-btn').trigger('click');
     expect(emitEvent).toHaveBeenCalledWith('tray://resume-recording');
   });
 
   it('stop button emits the tray stop event', async () => {
-    const wrapper = mount(RecorderStrip);
+    const wrapper = mount(RecorderStrip, { props: { meetingId: '42' } });
     await flushPromises();
-    sendState(recording());
+    sendState(recording({ meetingId: 42 }));
     await flushPromises();
     await wrapper.find('.stop-btn').trigger('click');
     expect(emitEvent).toHaveBeenCalledWith('tray://stop-recording');
   });
 
+  // An unattached session's upload outcome has no row to dock on and no other
+  // place in the library to surface, so it shows wherever the user is — unlike
+  // its live phases, which never dock (see the #318 tests below).
   it('shows the uploading spinner, then the success check', async () => {
     const wrapper = mount(RecorderStrip);
     await flushPromises();
@@ -87,10 +90,10 @@ describe('RecorderStrip', () => {
   });
 
   it('shows an initializing state before capture becomes active', async () => {
-    const wrapper = mount(RecorderStrip);
+    const wrapper = mount(RecorderStrip, { props: { meetingId: '42' } });
     await flushPromises();
 
-    sendState(recording({ phase: 'starting', bars: [], durationSeconds: 0 }));
+    sendState(recording({ meetingId: 42, phase: 'starting', bars: [], durationSeconds: 0 }));
     await flushPromises();
 
     expect(wrapper.find('.spinner').exists()).toBe(true);
@@ -100,13 +103,13 @@ describe('RecorderStrip', () => {
   });
 
   it('hides after a closed phase', async () => {
-    const wrapper = mount(RecorderStrip);
+    const wrapper = mount(RecorderStrip, { props: { meetingId: '42' } });
     await flushPromises();
-    sendState(recording());
+    sendState(recording({ meetingId: 42 }));
     await flushPromises();
     expect(wrapper.find('.strip').exists()).toBe(true);
 
-    sendState(recording({ phase: 'closed' }));
+    sendState(recording({ meetingId: 42, phase: 'closed' }));
     await flushPromises();
     expect(wrapper.find('.strip').exists()).toBe(false);
   });
@@ -125,19 +128,36 @@ describe('RecorderStrip', () => {
     expect(wrapper.find('.strip').exists()).toBe(false);
   });
 
-  it('docks on the meeting shown when a homeless recording started, not wherever the user later navigates', async () => {
+  // #318: a recording that belongs to no meeting (an Ariso auto-recording that
+  // matched no calendar event) must never dock — docking it above whichever
+  // meeting is on screen reads as "this meeting is being recorded".
+  it('never docks a recording with no meeting id at all', async () => {
     const wrapper = mount(RecorderStrip, { props: { meetingId: '7' } });
     await flushPromises();
     sendState(recording({ meetingId: null, localRecordingId: null }));
     await flushPromises();
-    expect(wrapper.find('.strip').exists()).toBe(true);
+    expect(wrapper.find('.strip').exists()).toBe(false);
 
-    // Navigating to a different, non-recording meeting floats it away.
+    // Not on any other meeting either, nor on the empty detail pane.
     await wrapper.setProps({ meetingId: '9' });
     expect(wrapper.find('.strip').exists()).toBe(false);
 
-    // Navigating back to the recorded meeting re-docks it.
-    await wrapper.setProps({ meetingId: '7' });
+    await wrapper.setProps({ meetingId: null });
+    expect(wrapper.find('.strip').exists()).toBe(false);
+  });
+
+  // The same unattached state resolves into a real id mid-session (a local
+  // recording finishing its append/new decision) — the strip must dock then.
+  it('docks as soon as an unattached recording resolves its id', async () => {
+    const id = '2026-06-02T14-30-05Z';
+    const wrapper = mount(RecorderStrip, { props: { meetingId: id } });
+    await flushPromises();
+    sendState(recording({ meetingId: null, localRecordingId: null }));
+    await flushPromises();
+    expect(wrapper.find('.strip').exists()).toBe(false);
+
+    sendState(recording({ meetingId: null, localRecordingId: id }));
+    await flushPromises();
     expect(wrapper.find('.strip').exists()).toBe(true);
   });
 
@@ -199,14 +219,14 @@ describe('RecorderStrip', () => {
 
   it('clears itself when state broadcasts stop (recorder died without closing)', async () => {
     vi.useFakeTimers();
-    const wrapper = mount(RecorderStrip, { props: { meetingId: null } });
+    const wrapper = mount(RecorderStrip, { props: { meetingId: '42' } });
     await flushPromises();
-    sendState(recording({ meetingId: null }));
+    sendState(recording({ meetingId: 42 }));
     await vi.advanceTimersByTimeAsync(2000);
     expect(wrapper.find('.strip').exists()).toBe(true);
 
     // Heartbeats keep it alive…
-    sendState(recording({ meetingId: null }));
+    sendState(recording({ meetingId: 42 }));
     await vi.advanceTimersByTimeAsync(2000);
     expect(wrapper.find('.strip').exists()).toBe(true);
 

--- a/src/views/RecorderStrip.vue
+++ b/src/views/RecorderStrip.vue
@@ -98,26 +98,22 @@ function recordedMeetingId(s: RecorderState): string | null {
   return s.localRecordingId ?? null;
 }
 
-// The meeting shown when this recording session's first heartbeat arrived.
-// Recordings with no id at all yet (e.g. an Ariso auto-recording awaiting
-// confirmation, or a local recording still resolving its id) have no home
-// row to compare against, so this stands in as their home until a real id
-// shows up — otherwise the strip would dock onto whatever meeting the user
-// has since navigated to instead of the one it actually belongs to.
-const homeMeetingId = ref<string | null>(null);
-
 // The strip belongs to the recorded meeting: render it only while the detail
-// panel shows that meeting (or, before an id exists, its docking home).
+// panel shows that meeting. A recording with no id at all belongs to no row —
+// an Ariso auto-recording that matched no calendar event stays that way for
+// the whole session, a local one only until it resolves its id — so while it
+// is capturing it never docks (#318): a live strip above a meeting reads as
+// "this meeting is being recorded". The library shows its titlebar "In
+// recording" badge instead. Its upload outcome still shows wherever the user
+// is, because a homeless "Upload failed" has nowhere else to surface.
 const visible = computed(() => {
   if (!state.value) return false;
   const id = recordedMeetingId(state.value);
-  if (id == null) return homeMeetingId.value === props.meetingId;
-  return id === props.meetingId;
+  if (id != null) return id === props.meetingId;
+  return state.value.phase !== 'starting' && state.value.phase !== 'recording';
 });
 
-watch(state, (s, prev) => {
-  if (s && !prev) homeMeetingId.value = props.meetingId;
-  else if (!s) homeMeetingId.value = null;
+watch(state, (s) => {
   emitToParent('recording-change', s ? recordedMeetingId(s) : null);
   emitToParent('recording-active', s?.phase === 'recording');
   emitToParent('recording-phase', s?.phase ?? null);


### PR DESCRIPTION
## What does this PR do?

Follow-up to #329 (merged), which fixed the reported symptom in #318 — the recorder pill following the user to unrelated meetings — but left three things.

**1. An unattached recording still docked on a meeting that isn't being recorded.**
#329 docks such a recording on whichever meeting was on screen when it started. Where that state persists — an Ariso auto-recording, which `mic_monitor.rs:344` starts with `meeting_id: None`, that then matches no calendar event in `WaveformView.vue`'s association lookup, and broadcasts `localRecordingId: null` because the backend isn't local — the meeting it lands on is never the one being recorded. #318's AC 1 asks for the pill "only for the meeting currently shown in the detail section when that meeting is under recording".

Now a session with no id at all never docks **while it is capturing**; the library shows its titlebar "In recording" indicator instead. Its upload outcome (`Saving…`, `Recording saved`, `Upload failed`) still shows wherever the user is — a homeless failed upload has no row to dock on and nowhere else to surface, and losing it would cost the user the retry signal.

**2. The docked strip and the titlebar indicator could both show at once.**
`LibraryView` compared its captured home (`null` when nothing is selected) against `selectedItem?.id` (`undefined`), while `RecorderStrip` compared `null` against `null`. Starting a recording with an empty detail pane — the local "record a new meeting" flow — rendered both. Verified before the fix with a probe test:

```
this branch's parent: strip=true floating=true
before #329:          strip=true floating=false
```

**3. The two "mirrored" rules captured their home off different signals.**
`LibraryView` on `recordingPhase` flipping non-null (which happens in `markRecordingStarting()`, before the recorder window exists and before `selectRecordingMeeting()` moves the detail pane); `RecorderStrip` on its first heartbeat, ~a second later. Any selection change in between left them with different homes for the whole unattached window.

Both are gone: with no captured state, the two rules are the same pure comparison over the same values.

Also: the titlebar indicator becomes a non-interactive badge (`<span role="status">`) when there is no meeting to return to, instead of a button whose click silently does nothing.

## Type of change

- [x] `fix:` — bug fix

## How was this tested?

- `npm test` — 779 pass (57 files), including four new/rewritten tests: an unattached recording never docks on any meeting; it docks the moment its id resolves; the strip and the titlebar indicator are never both shown (the empty-pane case); the indicator is a badge, not a button, when there's nowhere to return to. Each was watched failing against the merged #329 first.
- `npm run vite:build` — passes.
- Frontend only; no Rust, invoke-contract or event-payload changes.
- **Not** verified in the running app — the persistent case needs an Ariso auto-record that matches no calendar event, which I can't stage here. Reviewers with an Ariso account are the right check.

## Risk

Two `computed`s, one lookup, and the titlebar element's tag. The behavior change reviewers should weigh is the deliberate one: an unattached recording now has **no** pause/stop controls inside an open library window (the tray menu and the floating pill — which appears when the library is minimized or closed — remain). That already matches what happens for an attached recording whose meeting isn't on screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Unattached recordings now display a clear, non-clickable “In recording” status.
  * Recorder controls dock only when an identified recording matches the selected meeting.
  * Unidentified recordings no longer appear in the recorder strip while starting or recording.
  * Prevented simultaneous display of recording indicators and the docked recorder strip.
  * Recording upload results remain visible even when no meeting is attached.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->