### PR TITLE
docs: document how to run the Rust test suite

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,7 +69,20 @@ npm run tauri:build -- -- --features prod-api
 
 # Run the frontend test suite
 npm test
+
+# Run the Rust (backend) test suite — always serially, see below
+cargo test --manifest-path src-tauri/Cargo.toml -- --test-threads=1
 ```
+
+### Running the Rust tests
+
+**`--test-threads=1` is not optional.** Parts of the suite drive the code through process-wide state — `ARISO_ROOT`, the vault-directory override — so tests running concurrently overwrite each other's fixtures. A parallel `cargo test` currently fails around 40 tests for that reason alone, with unrelated-looking errors ("No such file or directory", `unwrap()` on a `None`).
+
+Run it locally even for a Rust-only change: the `Desktop App` workflow runs the host test suite (with the same flag) on its **Windows** leg only — the macOS leg builds the host but doesn't test it — so a macOS-side regression is yours to catch before the PR.
+
+`cargo test` also builds the Tauri host, and `tauri.conf.json` declares the `ariso-stt` sidecar as an `externalBin`, so the sidecar binary must exist before the suite will build on a fresh checkout — see [Local backend](#local-backend-on-device-transcription).
+
+If the test binary aborts before running anything, see [`cargo test` aborts with a missing Swift runtime library](#cargo-test-aborts-with-a-missing-swift-runtime-library).
 
 ## API build targets vs. transcription backend
 
@@ -173,7 +186,7 @@ Both directories are git-ignored.
 
 1. Fork the repo and create a feature branch.
 2. Make your change, with a focused scope.
-3. Run `npm test` and make sure the app builds (`npm run tauri:build`).
+3. Run both test suites — `npm test` and `cargo test --manifest-path src-tauri/Cargo.toml -- --test-threads=1` ([why serial](#running-the-rust-tests)) — and make sure the app builds (`npm run tauri:build`).
 4. Commit using [conventional commit](#commit-conventions) messages.
 5. Open a pull request against `main`. CI (`Desktop App`) will validate it.
 
@@ -357,6 +370,21 @@ Releases are automated by [release-please](https://github.com/googleapis/release
 No PAT is required: the `Release` workflow uses the default `GITHUB_TOKEN` (with `contents: write` + `pull-requests: write` granted at the job level). This works because the macOS signing pipeline runs as downstream jobs in the same run rather than relying on the published Release to trigger a separate workflow — the one thing the default token can't do. The Windows workflow is reached by `workflow_dispatch` (with `actions: write`), which is explicitly exempt from that restriction.
 
 ## Troubleshooting
+
+### `cargo test` aborts with a missing Swift runtime library
+
+On macOS the test binary links the Swift runtime (through the audio and sidecar code). If your toolchain can't resolve Swift's concurrency library, the binary aborts at load time — before any test runs — with a dyld error naming `libswift_Concurrency.dylib`, which reads like a build failure rather than a missing back-deployment library.
+
+Point the loader at Xcode's copy for the run:
+
+```bash
+DYLD_LIBRARY_PATH="/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift-5.5/macosx" \
+  cargo test --manifest-path src-tauri/Cargo.toml -- --test-threads=1
+```
+
+That loads a second copy of the Swift runtime, so the run then prints an `objc[…]: Class SwiftNativeNSObject is implemented in both …` warning. It is benign — expect it whenever you use the override.
+
+Only reach for this if you actually hit the abort: on a current toolchain the suite runs green without it (verified on macOS 26.6 with Xcode's default toolchain), and the override is what introduces the warning above.
 
 ### `tauri:build` fails with `Cannot find module '.../node_modules/dist/node/cli.js'`
 


### PR DESCRIPTION
## What does this PR do?

Closes #307. CONTRIBUTING.md pointed contributors at `npm test` and mentioned `cargo test` only in passing (as a thing that needs the sidecar built), so a contributor's first Rust test run was a coin flip: run it the obvious way and ~40 tests fail with errors that look nothing like their real cause.

Adds to CONTRIBUTING.md:

- the working invocation in **Development scripts**, next to `npm test`;
- a **Running the Rust tests** subsection — why `--test-threads=1` is required (parts of the suite mutate process-wide state: `ARISO_ROOT`, the vault-directory override), the `externalBin` sidecar prerequisite, and the fact that the `Desktop App` workflow runs this suite on its **Windows** leg only, so a macOS-side regression has to be caught locally;
- a **Troubleshooting** entry for the `libswift_Concurrency.dylib` load abort and its `DYLD_LIBRARY_PATH` fix;
- both suites named in the submitting-changes checklist.

## One deviation from the issue

The issue asks to copy the `AGENTS.md` invocation across as-is. I checked both halves of it first:

| | verdict |
|---|---|
| `-- --test-threads=1` | **Required**, and worse than advertised — a parallel `cargo test` fails **39** tests, with errors ("No such file or directory", `unwrap()` on a `None`) that give no hint of the real cause. |
| `DYLD_LIBRARY_PATH=.../swift-5.5/macosx` | **Not needed on a current toolchain.** Full suite green without it on macOS 26.6, even though `/usr/lib/swift/libswift_Concurrency.dylib` is absent. Setting it is what produces the `objc[…] Class SwiftNativeNSObject is implemented in both …` warning. |

So the override is documented as a Troubleshooting entry keyed to its symptom rather than as the headline command — presenting it as the default would hand every contributor a warning to explain, to work around a load failure they may never hit.

Follow-up worth doing separately: `AGENTS.md` / `CLAUDE.md` and the `oats-tauri` skill still present the override as required, and are now stale in the same way.

## Type of change

- [ ] `fix:` — bug fix
- [ ] `feat:` — new feature
- [ ] `feat!:` / `BREAKING CHANGE:` — breaking change
- [x] `docs:` / `chore:` / `refactor:` — no user-facing release

## How was this tested?

Docs only — no code changes. The claims in it were verified on this machine (macOS 26.6, Apple Silicon, Xcode default toolchain) rather than copied:

- `cargo test --manifest-path src-tauri/Cargo.toml -- --test-threads=1` → 297 passed, 3 ignored (the ignored three are the network-gated model downloads).
- same command without `--test-threads=1` → 258 passed, **39 failed**.
- same command without `DYLD_LIBRARY_PATH` → green, which is what demoted that half to Troubleshooting.

Anchor links (`#running-the-rust-tests`, `#cargo-test-aborts-with-a-missing-swift-runtime-library`, `#local-backend-on-device-transcription`) match their headings.

## Screenshots / recordings

No UI change.

## Checklist

- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I ran `npm test` and the suite passes
- [ ] I tested the change in the app — n/a, documentation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for running Rust tests serially.
  * Documented fixture-state constraints, CI coverage gaps, sidecar prerequisites, and Swift runtime troubleshooting.
  * Updated contribution instructions to require frontend and serial Rust test suites before building.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->