### PR TITLE
feat(library): list meeting action items in the Todos tab

### DIFF
--- a/src/composables/actionItemSections.test.ts
+++ b/src/composables/actionItemSections.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect } from 'vitest';
+import { recentDayKeys, groupActionItemsByDay, type ActionItemEntry } from './actionItemSections';
+
+function meeting(id: string, title: string, timestamp: string) {
+  return { id, title, timestamp };
+}
+
+function entry(
+  id: string,
+  title: string,
+  timestamp: string,
+  items: Array<{ name?: string; item: string }>
+): ActionItemEntry {
+  return { meeting: meeting(id, title, timestamp), items };
+}
+
+describe('recentDayKeys', () => {
+  it('returns today first, then the preceding local calendar days', () => {
+    expect(recentDayKeys(new Date(2026, 2, 1, 9, 30), 3)).toEqual([
+      '2026-03-01',
+      '2026-02-28',
+      '2026-02-27',
+    ]);
+  });
+
+  it('returns only today for a single-day window', () => {
+    expect(recentDayKeys(new Date(2026, 7, 31, 23, 59), 1)).toEqual(['2026-08-31']);
+  });
+});
+
+describe('groupActionItemsByDay', () => {
+  const now = new Date(2026, 7, 31, 12, 0);
+
+  it('groups rows under dated day headers, newest day first', () => {
+    const sections = groupActionItemsByDay(
+      [
+        entry('7', 'Platform Sync', '2026-08-30T15:00:00', [{ item: 'Draft migration plan' }]),
+        entry('9', 'Q3 Pricing Review', '2026-08-31T09:00:00', [{ item: 'Send pricing deck' }]),
+      ],
+      now
+    );
+
+    expect(sections.map((s) => s.key)).toEqual(['2026-08-31', '2026-08-30']);
+    expect(sections[0].label).toBe('TODAY · AUG 31');
+    expect(sections[1].label).toBe('YESTERDAY · AUG 30');
+  });
+
+  it('emits one row per action item, carrying its source meeting', () => {
+    const [today] = groupActionItemsByDay(
+      [
+        entry('9', 'Q3 Pricing Review', '2026-08-31T09:00:00', [
+          { name: 'Dana', item: 'Send pricing deck' },
+          { item: 'Follow up with finance' },
+        ]),
+      ],
+      now
+    );
+
+    expect(today.rows).toHaveLength(2);
+    expect(today.rows[0].text).toBe('Send pricing deck');
+    expect(today.rows[0].meeting.title).toBe('Q3 Pricing Review');
+    expect(today.rows[1].text).toBe('Follow up with finance');
+    expect(today.rows[0].key).not.toBe(today.rows[1].key);
+  });
+
+  it('orders a day’s meetings earliest first', () => {
+    const [today] = groupActionItemsByDay(
+      [
+        entry('9', 'Afternoon', '2026-08-31T15:00:00', [{ item: 'Later item' }]),
+        entry('7', 'Morning', '2026-08-31T09:00:00', [{ item: 'Earlier item' }]),
+      ],
+      now
+    );
+
+    expect(today.rows.map((r) => r.text)).toEqual(['Earlier item', 'Later item']);
+  });
+
+  it('keeps a meeting returned by two day requests from listing its items twice', () => {
+    const dupe = entry('9', 'Q3 Pricing Review', '2026-08-31T09:00:00', [
+      { item: 'Send pricing deck' },
+    ]);
+
+    const [today] = groupActionItemsByDay([dupe, { ...dupe }], now);
+
+    expect(today.rows).toHaveLength(1);
+  });
+
+  it('drops blank items and meetings left with none', () => {
+    const sections = groupActionItemsByDay(
+      [
+        entry('9', 'Q3 Pricing Review', '2026-08-31T09:00:00', [
+          { item: '   ' },
+          { item: 'Send pricing deck' },
+        ]),
+        entry('7', 'Platform Sync', '2026-08-30T15:00:00', [{ item: '' }]),
+      ],
+      now
+    );
+
+    expect(sections).toHaveLength(1);
+    expect(sections[0].rows.map((r) => r.text)).toEqual(['Send pricing deck']);
+  });
+
+  it('files a meeting with an unusable start time under UNDATED, last', () => {
+    const sections = groupActionItemsByDay(
+      [
+        entry('7', 'Imported', 'not-a-date', [{ item: 'Chase the import' }]),
+        entry('9', 'Q3 Pricing Review', '2026-08-31T09:00:00', [{ item: 'Send pricing deck' }]),
+      ],
+      now
+    );
+
+    expect(sections.map((s) => s.label)).toEqual(['TODAY · AUG 31', 'UNDATED']);
+  });
+
+  it('returns no sections when nothing came back', () => {
+    expect(groupActionItemsByDay([], now)).toEqual([]);
+  });
+});

--- a/src/composables/actionItemSections.ts
+++ b/src/composables/actionItemSections.ts
@@ -1,0 +1,83 @@
+import type { ActionItemEntry, MeetingListItem } from './useBackend';
+import { dayLabelWithDate, localDateKey } from './groupMeetingsByDate';
+
+export type { ActionItemEntry };
+
+/** A single Todo row: the item text and the meeting it came from (selecting the
+ *  row opens that meeting in the detail pane). The endpoint already scopes items
+ *  to the signed-in user, so rows carry no owner. */
+export interface ActionItemRow {
+  key: string;
+  text: string;
+  meeting: MeetingListItem;
+}
+
+export interface ActionItemSection {
+  key: string;
+  label: string;
+  rows: ActionItemRow[];
+}
+
+/** The `YYYY-MM-DD` days the Todo tab asks the API for: today first, then the
+ *  preceding local calendar days. One request per key — the endpoint serves a
+ *  single day. */
+export function recentDayKeys(now: Date, count: number): string[] {
+  const keys: string[] = [];
+  for (let i = 0; i < count; i++) {
+    const d = new Date(now);
+    d.setDate(d.getDate() - i);
+    keys.push(localDateKey(d));
+  }
+  return keys;
+}
+
+/** Bucket action items under per-calendar-date headers, newest day first, with
+ *  each day's meetings ordered earliest-first. Meetings are deduped by id: the
+ *  same meeting can surface in two day requests near a timezone boundary, and
+ *  its items must not list twice. Meetings with an unusable start time keep
+ *  their items under a trailing UNDATED section rather than vanishing. */
+export function groupActionItemsByDay(
+  entries: ActionItemEntry[],
+  now: Date
+): ActionItemSection[] {
+  const seen = new Set<string>();
+  const buckets = new Map<string, ActionItemEntry[]>();
+
+  for (const entry of entries) {
+    if (seen.has(entry.meeting.id)) continue;
+    const rows = entry.items.filter((it) => it.item.trim().length > 0);
+    if (rows.length === 0) continue;
+    seen.add(entry.meeting.id);
+
+    const d = new Date(entry.meeting.timestamp);
+    const key = Number.isNaN(d.getTime()) ? 'unknown' : localDateKey(d);
+    const bucket = buckets.get(key);
+    if (bucket) bucket.push({ meeting: entry.meeting, items: rows });
+    else buckets.set(key, [{ meeting: entry.meeting, items: rows }]);
+  }
+
+  const toRows = (dayEntries: ActionItemEntry[]): ActionItemRow[] =>
+    [...dayEntries]
+      .sort(
+        (a, b) =>
+          new Date(a.meeting.timestamp).getTime() - new Date(b.meeting.timestamp).getTime()
+      )
+      .flatMap((e) =>
+        e.items.map((it, i) => ({
+          key: `${e.meeting.id}:${i}`,
+          text: it.item.trim(),
+          meeting: e.meeting,
+        }))
+      );
+
+  const sections: ActionItemSection[] = [];
+  // Lexical sort == chronological because the keys are zero-padded.
+  const dayKeys = [...buckets.keys()].filter((k) => k !== 'unknown').sort().reverse();
+  for (const key of dayKeys) {
+    sections.push({ key, label: dayLabelWithDate(key, now), rows: toRows(buckets.get(key)!) });
+  }
+  if (buckets.has('unknown')) {
+    sections.push({ key: 'unknown', label: 'UNDATED', rows: toRows(buckets.get('unknown')!) });
+  }
+  return sections;
+}

--- a/src/composables/groupMeetingsByDate.ts
+++ b/src/composables/groupMeetingsByDate.ts
@@ -6,7 +6,8 @@ export interface MeetingSection {
   items: MeetingListItem[];
 }
 
-function localDateKey(d: Date): string {
+/** `YYYY-MM-DD` in the viewer's timezone. Zero-padded so the keys sort lexically. */
+export function localDateKey(d: Date): string {
   const pad = (n: number) => String(n).padStart(2, '0');
   return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
 }

--- a/src/composables/useBackend.test.ts
+++ b/src/composables/useBackend.test.ts
@@ -19,6 +19,7 @@ const readRecordingAudio = vi.fn();
 const getMeetingNotes = vi.fn();
 const deleteMeetingRecordingClip = vi.fn();
 const getMeetingPrepApi = vi.fn();
+const listActionItemsByDay = vi.fn();
 const reportUploadFailure = vi.fn(() => Promise.resolve());
 
 vi.mock('./useDiagnostics', () => ({
@@ -55,6 +56,7 @@ vi.mock('./useMeetingApi', () => ({
     getMeetingNotes: (...a: unknown[]) => getMeetingNotes(...a),
     deleteMeetingRecordingClip: (...a: unknown[]) => deleteMeetingRecordingClip(...a),
     getMeetingPrep: (...a: unknown[]) => getMeetingPrepApi(...a),
+    listActionItemsByDay: (...a: unknown[]) => listActionItemsByDay(...a),
   }),
 }));
 
@@ -672,5 +674,54 @@ describe('meeting prep plumbing', () => {
 
   it('LocalBackend.getMeetingPrep always resolves null', async () => {
     await expect(new LocalBackend().getMeetingPrep(4339)).resolves.toBeNull();
+  });
+});
+
+describe('action items', () => {
+  it('Ariso maps a day of action items onto selectable meeting rows', async () => {
+    listActionItemsByDay.mockResolvedValue([
+      {
+        meetingId: 9,
+        meetingTitle: 'Q3 Pricing Review',
+        startAt: '2026-08-31T09:00:00Z',
+        actionItems: [{ name: 'Dana', item: 'Send pricing deck' }, { item: '  ' }],
+      },
+    ]);
+
+    const entries = await new ArisoBackend().listActionItems('2026-08-31');
+
+    expect(listActionItemsByDay).toHaveBeenCalledWith('2026-08-31');
+    expect(entries).toEqual([
+      {
+        meeting: { id: '9', title: 'Q3 Pricing Review', timestamp: '2026-08-31T09:00:00Z' },
+        items: [{ name: 'Dana', item: 'Send pricing deck' }],
+      },
+    ]);
+  });
+
+  it('Ariso titles an untitled meeting so its rows stay readable', async () => {
+    listActionItemsByDay.mockResolvedValue([
+      {
+        meetingId: 12,
+        meetingTitle: null,
+        startAt: '2026-08-31T09:00:00Z',
+        actionItems: [{ item: 'Ship it' }],
+      },
+    ]);
+
+    const entries = await new ArisoBackend().listActionItems('2026-08-31');
+
+    expect(entries[0].meeting.title).toBe('Untitled meeting');
+  });
+
+  it('offline mode neither advertises nor fetches action items', async () => {
+    const b = new LocalBackend();
+    expect(b.supportsActionItems).toBe(false);
+    await expect(b.listActionItems('2026-08-31')).resolves.toEqual([]);
+    expect(listActionItemsByDay).not.toHaveBeenCalled();
+  });
+
+  it('Ariso advertises action items', () => {
+    expect(new ArisoBackend().supportsActionItems).toBe(true);
   });
 });

--- a/src/composables/useBackend.ts
+++ b/src/composables/useBackend.ts
@@ -78,6 +78,13 @@ export interface MeetingActionItem {
   item: string;
 }
 
+/** One meeting's action items for the signed-in user, with the meeting itself as
+ *  a selectable list row. */
+export interface ActionItemEntry {
+  meeting: MeetingListItem;
+  items: MeetingActionItem[];
+}
+
 export interface MeetingCoaching {
   strengths?: string[];
   improvements?: string[];
@@ -169,12 +176,19 @@ export interface Backend {
    *  Ariso searches its remote note corpus; local does a title-only filter over
    *  its recordings. */
   supportsSearch: boolean;
+  /** Whether this backend can list the user's meeting action items (the Todo
+   *  tab). Extraction happens server-side, so offline mode has none. */
+  supportsActionItems: boolean;
   isReady(): Promise<Readiness>;
   finalizeRecording(blob: Blob, meta: RecordingMeta): Promise<FinalizeResult>;
   listMeetings(): Promise<MeetingListItem[]>;
   /** Search the backend's meeting-note corpus and return rows the Library can
    *  select like normal meetings. */
   searchMeetings(query: string): Promise<MeetingListItem[]>;
+  /** The user's action items for one local calendar day (`YYYY-MM-DD`), grouped
+   *  by their source meeting. The meeting comes back as a selectable list row so
+   *  a Todo row can open it in the detail pane. */
+  listActionItems(day: string): Promise<ActionItemEntry[]>;
   /** Load the detail for a single row (from the list item the user clicked). */
   getMeetingDetail(item: MeetingListItem): Promise<MeetingDetail>;
   /** Lazily load the meeting's transcript (null when none). Ariso meetings
@@ -319,6 +333,7 @@ export class ArisoBackend implements Backend {
   needsAuth = true;
   usesMeetingPicker = true;
   supportsSearch = true;
+  supportsActionItems = true;
 
   async isReady(): Promise<Readiness> {
     const session = await auth.checkSession();
@@ -379,6 +394,21 @@ export class ArisoBackend implements Backend {
     const { searchMeetings } = useMeetingApi();
     const meetings = await searchMeetings(query);
     return meetings.map(meetingSummaryToListItem);
+  }
+
+  async listActionItems(day: string): Promise<ActionItemEntry[]> {
+    const { listActionItemsByDay } = useMeetingApi();
+    const groups = await listActionItemsByDay(day);
+    return groups
+      .map((g) => ({
+        meeting: {
+          id: String(g.meetingId),
+          title: g.meetingTitle || 'Untitled meeting',
+          timestamp: g.startAt,
+        },
+        items: normalizeActionItems(g.actionItems),
+      }))
+      .filter((entry) => entry.items.length > 0);
   }
 
   async getMeetingDetail(item: MeetingListItem): Promise<MeetingDetail> {
@@ -476,6 +506,8 @@ export class LocalBackend implements Backend {
   needsAuth = false;
   usesMeetingPicker = false;
   supportsSearch = true;
+  // Action items are extracted server-side; nothing offline produces them.
+  supportsActionItems = false;
 
   async isReady(): Promise<Readiness> {
     const status = await local.modelStatus();
@@ -517,6 +549,10 @@ export class LocalBackend implements Backend {
       .filter((r) => r.title.toLowerCase().includes(q))
       .slice(0, MAX_LOCAL_SEARCH_RESULTS)
       .map(recordingToListItem);
+  }
+
+  async listActionItems(): Promise<ActionItemEntry[]> {
+    return [];
   }
 
   async getMeetingDetail(item: MeetingListItem): Promise<MeetingDetail> {

--- a/src/composables/useMeetingApi.test.ts
+++ b/src/composables/useMeetingApi.test.ts
@@ -219,3 +219,48 @@ describe('uploadAudio stage tagging', () => {
     }
   });
 });
+
+describe('listActionItemsByDay', () => {
+  it('asks the action-items endpoint for one local day and returns its groups', async () => {
+    apiRequest.mockResolvedValue({
+      status: 200,
+      data: {
+        actionItems: [
+          {
+            meetingId: 9,
+            meetingTitle: 'Q3 Pricing Review',
+            startAt: '2026-08-31T09:00:00Z',
+            actionItems: [{ name: 'Dana', item: 'Send pricing deck' }],
+          },
+        ],
+      },
+    });
+
+    const groups = await useMeetingApi().listActionItemsByDay('2026-08-31');
+
+    expect(apiRequest).toHaveBeenCalledWith(
+      'GET',
+      '/meeting-notes/action-items?day=2026-08-31'
+    );
+    expect(groups).toEqual([
+      {
+        meetingId: 9,
+        meetingTitle: 'Q3 Pricing Review',
+        startAt: '2026-08-31T09:00:00Z',
+        actionItems: [{ name: 'Dana', item: 'Send pricing deck' }],
+      },
+    ]);
+  });
+
+  it('resolves to an empty list when the day carries no action items', async () => {
+    apiRequest.mockResolvedValue({ status: 200, data: {} });
+    await expect(useMeetingApi().listActionItemsByDay('2026-08-31')).resolves.toEqual([]);
+  });
+
+  it('surfaces the server error for a rejected day', async () => {
+    apiRequest.mockResolvedValue({ status: 400, data: { error: 'Invalid date format' } });
+    await expect(useMeetingApi().listActionItemsByDay('nope')).rejects.toThrow(
+      'Invalid date format'
+    );
+  });
+});

--- a/src/composables/useMeetingApi.ts
+++ b/src/composables/useMeetingApi.ts
@@ -64,6 +64,15 @@ interface ScheduledMeeting {
   prep_id?: number | string;
 }
 
+/** One meeting's worth of action items assigned to the requester, as served by
+ *  `/meeting-notes/action-items?day=…`. */
+export interface DayActionItems {
+  meetingId: number | string;
+  meetingTitle: string | null;
+  startAt: string;
+  actionItems: Array<{ name?: string; item: string }>;
+}
+
 /** A meeting prep, reduced to the two fields the desktop consumes: the markdown
  *  to render, and the meeting it belongs to (used to resolve a prep-ready
  *  notification back to a row in the library). */
@@ -456,6 +465,18 @@ export function useMeetingApi() {
     };
   }
 
+  // The signed-in user's action items for one calendar day, grouped by the
+  // meeting they came from. The endpoint serves a single day (resolved in the
+  // user's profile timezone) and already scopes items to the caller, so the
+  // Todo tab fans out one request per day it shows.
+  async function listActionItemsByDay(day: string): Promise<DayActionItems[]> {
+    const params = new URLSearchParams({ day });
+    const res = await api.request('GET', `/meeting-notes/action-items?${params.toString()}`);
+    assertOk(res, 200, 'list action items');
+    const data = res.data as { actionItems?: DayActionItems[] } | null;
+    return data?.actionItems ?? [];
+  }
+
   // Search org members to assign a diarized speaker to. Scoped to the
   // meeting's org by the endpoint. Errors collapse to [] — this is a passive
   // type-ahead lookup, and an empty result already has a rendered state
@@ -711,6 +732,7 @@ export function useMeetingApi() {
     getMeetingTranscript,
     getMeetingIndividualNote,
     getMeetingPrep,
+    listActionItemsByDay,
     searchSpeakerMembers,
     assignSpeaker,
     updateMeeting,

--- a/src/views/LibraryView.test.ts
+++ b/src/views/LibraryView.test.ts
@@ -8,6 +8,8 @@ const getMeetingDetail = vi.fn();
 const backendId = vi.fn(() => 'local');
 const usesMeetingPicker = vi.fn(() => false);
 const supportsSearch = vi.fn(() => false);
+const supportsActionItems = vi.fn(() => false);
+const listActionItems = vi.fn();
 const openRecordingFile = vi.fn();
 const readRecordingAudio = vi.fn();
 const readRecordingNote = vi.fn();
@@ -69,7 +71,9 @@ vi.mock('../composables/useBackend', async (importOriginal) => {
         id: backendId(),
         usesMeetingPicker: usesMeetingPicker(),
         supportsSearch: supportsSearch(),
+        supportsActionItems: supportsActionItems(),
         listMeetings: () => listMeetings(),
+        listActionItems: (day: string) => listActionItems(day),
         searchMeetings: (query: string) => searchMeetings(query),
         getMeetingDetail: (meeting: unknown) => getMeetingDetail(meeting),
         getMeetingPrep: (prepId: number) => getMeetingPrep(prepId),
@@ -157,6 +161,8 @@ beforeEach(() => {
   backendId.mockReturnValue('local');
   usesMeetingPicker.mockReturnValue(false);
   supportsSearch.mockReturnValue(true);
+  supportsActionItems.mockReturnValue(false);
+  listActionItems.mockResolvedValue([]);
   searchMeetings.mockResolvedValue([]);
 });
 afterEach(() => {
@@ -1788,5 +1794,194 @@ describe('LibraryView meeting-prep notification', () => {
     // The auto-selected first row stays put — no meeting is yanked out from
     // under the user for a prep we can't place.
     expect(wrapper.find('.detail-stub').attributes('data-meeting')).toBe('1');
+  });
+});
+
+describe('LibraryView Todo tab', () => {
+  const ymd = (d: Date) =>
+    `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+  const daysAgo = (n: number) => {
+    const d = new Date();
+    d.setDate(d.getDate() - n);
+    return d;
+  };
+  const todoButton = (wrapper: ReturnType<typeof mount>) =>
+    wrapper.findAll('.nav-tab').find((b) => b.text().includes('Todo'))!;
+
+  function actionItems(meeting: { id: string; title: string; timestamp: string }, ...items: string[]) {
+    return [{ meeting, items: items.map((item) => ({ item })) }];
+  }
+
+  it('keeps the Todo tab disabled for a backend that has no action items', async () => {
+    backendId.mockReturnValue('local');
+    supportsActionItems.mockReturnValue(false);
+    listMeetings.mockResolvedValue([]);
+
+    const wrapper = mountWithDetailStub();
+    await flushPromises();
+
+    expect(todoButton(wrapper).attributes('disabled')).toBeDefined();
+    expect(listActionItems).not.toHaveBeenCalled();
+  });
+
+  it('lists two weeks of action items grouped by day when the tab is opened', async () => {
+    backendId.mockReturnValue('ariso');
+    supportsActionItems.mockReturnValue(true);
+    listMeetings.mockResolvedValue([]);
+    const today = daysAgo(0);
+    const yesterday = daysAgo(1);
+    listActionItems.mockImplementation((day: string) => {
+      if (day === ymd(today)) {
+        return Promise.resolve(
+          actionItems(
+            { id: '9', title: 'Q3 Pricing Review', timestamp: today.toISOString() },
+            'Send pricing deck',
+            'Follow up with finance'
+          )
+        );
+      }
+      if (day === ymd(yesterday)) {
+        return Promise.resolve(
+          actionItems(
+            { id: '7', title: 'Platform Sync', timestamp: yesterday.toISOString() },
+            'Draft migration plan'
+          )
+        );
+      }
+      return Promise.resolve([]);
+    });
+
+    const wrapper = mountWithDetailStub();
+    await flushPromises();
+    await todoButton(wrapper).trigger('click');
+    await flushPromises();
+
+    // One request per day shown, today first.
+    expect(listActionItems.mock.calls.map((c) => c[0])).toEqual(
+      Array.from({ length: 14 }, (_, n) => ymd(daysAgo(n)))
+    );
+
+    const headers = wrapper.findAll('.group-label').map((h) => h.text());
+    expect(headers[0]).toContain('TODAY');
+    expect(headers[1]).toContain('YESTERDAY');
+
+    const rows = wrapper.findAll('.todo-item');
+    expect(rows).toHaveLength(3);
+    expect(rows[0].text()).toContain('Send pricing deck');
+    expect(rows[0].text()).toContain('Q3 Pricing Review');
+    expect(rows[2].text()).toContain('Draft migration plan');
+  });
+
+  it('opens the source meeting in the detail pane when an action item is clicked', async () => {
+    backendId.mockReturnValue('ariso');
+    supportsActionItems.mockReturnValue(true);
+    listMeetings.mockResolvedValue([]);
+    listActionItems.mockImplementation((day: string) =>
+      Promise.resolve(
+        day === ymd(daysAgo(0))
+          ? actionItems(
+              { id: '9', title: 'Q3 Pricing Review', timestamp: daysAgo(0).toISOString() },
+              'Send pricing deck'
+            )
+          : []
+      )
+    );
+
+    const wrapper = mountWithDetailStub();
+    await flushPromises();
+    await todoButton(wrapper).trigger('click');
+    await flushPromises();
+    await wrapper.findAll('.todo-item')[0].trigger('click');
+    await flushPromises();
+
+    expect(wrapper.find('.detail-stub').attributes('data-meeting')).toBe('9');
+    expect(wrapper.findAll('.todo-item')[0].classes()).toContain('selected');
+  });
+
+  it('still lists the days that loaded when one day request fails', async () => {
+    backendId.mockReturnValue('ariso');
+    supportsActionItems.mockReturnValue(true);
+    listMeetings.mockResolvedValue([]);
+    listActionItems.mockImplementation((day: string) => {
+      if (day === ymd(daysAgo(0))) return Promise.reject(new Error('500'));
+      if (day === ymd(daysAgo(1))) {
+        return Promise.resolve(
+          actionItems(
+            { id: '7', title: 'Platform Sync', timestamp: daysAgo(1).toISOString() },
+            'Draft migration plan'
+          )
+        );
+      }
+      return Promise.resolve([]);
+    });
+
+    const wrapper = mountWithDetailStub();
+    await flushPromises();
+    await todoButton(wrapper).trigger('click');
+    await flushPromises();
+
+    expect(wrapper.findAll('.todo-item')).toHaveLength(1);
+    expect(wrapper.text()).toContain('Draft migration plan');
+  });
+
+  it('reports an error when every day fails to load', async () => {
+    backendId.mockReturnValue('ariso');
+    supportsActionItems.mockReturnValue(true);
+    listMeetings.mockResolvedValue([]);
+    listActionItems.mockRejectedValue(new Error('offline'));
+
+    const wrapper = mountWithDetailStub();
+    await flushPromises();
+    await todoButton(wrapper).trigger('click');
+    await flushPromises();
+
+    expect(wrapper.text()).toContain('Could not load action items.');
+  });
+
+  it('shows an empty state when the window has no action items', async () => {
+    backendId.mockReturnValue('ariso');
+    supportsActionItems.mockReturnValue(true);
+    listMeetings.mockResolvedValue([item({ id: 'a', title: 'Some meeting' })]);
+    listActionItems.mockResolvedValue([]);
+
+    const wrapper = mountWithDetailStub();
+    await flushPromises();
+    await todoButton(wrapper).trigger('click');
+    await flushPromises();
+
+    expect(wrapper.text()).toContain('No action items.');
+    expect(wrapper.findAll('.meeting-item')).toHaveLength(0);
+  });
+
+  it('falls back to the meetings list when the backend switches to one without action items', async () => {
+    backendId.mockReturnValue('ariso');
+    supportsActionItems.mockReturnValue(true);
+    listMeetings.mockResolvedValue([]);
+    listActionItems.mockImplementation((day: string) =>
+      Promise.resolve(
+        day === ymd(daysAgo(0))
+          ? actionItems(
+              { id: '9', title: 'Q3 Pricing Review', timestamp: daysAgo(0).toISOString() },
+              'Send pricing deck'
+            )
+          : []
+      )
+    );
+
+    const wrapper = mountWithDetailStub();
+    await flushPromises();
+    await todoButton(wrapper).trigger('click');
+    await flushPromises();
+    expect(wrapper.findAll('.todo-item')).toHaveLength(1);
+
+    backendId.mockReturnValue('local');
+    supportsActionItems.mockReturnValue(false);
+    listMeetings.mockResolvedValue([item({ id: 'a', title: 'Local recording' })]);
+    emitEvent('backend://changed', null);
+    await flushPromises();
+
+    expect(wrapper.findAll('.todo-item')).toHaveLength(0);
+    expect(wrapper.text()).toContain('Local recording');
+    expect(todoButton(wrapper).classes()).not.toContain('nav-tab--active');
   });
 });

--- a/src/views/LibraryView.vue
+++ b/src/views/LibraryView.vue
@@ -133,32 +133,61 @@
 
       <PendingUploads ref="pendingUploads" @uploaded="onPendingUploaded" />
 
-      <p v-if="loading" class="hint">Loading…</p>
-      <p v-else-if="error" class="hint">{{ error }}</p>
-      <p v-else-if="meetings.length === 0" class="hint">No meetings yet.</p>
+      <!-- Todo: the action items assigned to the signed-in user across the last
+           two weeks of meetings, grouped by day. Selecting a row opens the
+           meeting it came from in the detail pane. -->
+      <template v-if="activeView === 'todo'">
+        <p v-if="todoLoading" class="hint">Loading…</p>
+        <p v-else-if="todoError" class="hint">{{ todoError }}</p>
+        <p v-else-if="todoSections.length === 0" class="hint">No action items.</p>
+        <div v-else class="meeting-list">
+          <template v-for="section in todoSections" :key="section.key">
+            <div class="group-label">{{ section.label }}</div>
+            <button
+              v-for="row in section.rows"
+              :key="row.key"
+              class="meeting-item todo-item"
+              :class="{ selected: selectedItem?.id === row.meeting.id }"
+              :aria-pressed="selectedItem?.id === row.meeting.id"
+              @click="selectMeeting(row.meeting, { userSelected: true })"
+            >
+              <span class="mi-head">
+                <span class="mi-title">{{ row.text }}</span>
+              </span>
+              <span class="mi-sub">{{ todoSub(row) }}</span>
+            </button>
+          </template>
+        </div>
+      </template>
 
-      <!-- Scrollable list with top/bottom fade mask -->
-      <div v-else class="meeting-list">
-        <template v-for="section in displayedSections" :key="section.key">
-          <div v-if="section.label" class="group-label">{{ section.label }}</div>
-          <button
-            v-for="m in section.items"
-            :key="m.id"
-            class="meeting-item"
-            :class="{ selected: selectedItem?.id === m.id }"
-            :aria-pressed="selectedItem?.id === m.id"
-            @click="selectMeeting(m, { userSelected: true })"
-          >
-            <span v-if="recordingActive && recordingMeetingId === m.id" class="mi-rec-dot" aria-hidden="true" />
-            <span class="mi-head">
-              <span class="mi-title" :class="{ 'mi-title--canceled': m.canceled }">{{ m.title }}</span>
-              <span v-if="relLabel(m)" class="mi-rel" :class="{ 'mi-rel--now': isNextNow(m) }">{{ relLabel(m) }}</span>
-            </span>
-            <span class="mi-sub" :class="{ 'mi-sub--now': isNextNow(m) }">{{ subFor(m) }}</span>
-          </button>
-        </template>
-        <p v-if="displayedSections.length === 0" class="hint">{{ emptyListHint }}</p>
-      </div>
+      <template v-else>
+        <p v-if="loading" class="hint">Loading…</p>
+        <p v-else-if="error" class="hint">{{ error }}</p>
+        <p v-else-if="meetings.length === 0" class="hint">No meetings yet.</p>
+
+        <!-- Scrollable list with top/bottom fade mask -->
+        <div v-else class="meeting-list">
+          <template v-for="section in displayedSections" :key="section.key">
+            <div v-if="section.label" class="group-label">{{ section.label }}</div>
+            <button
+              v-for="m in section.items"
+              :key="m.id"
+              class="meeting-item"
+              :class="{ selected: selectedItem?.id === m.id }"
+              :aria-pressed="selectedItem?.id === m.id"
+              @click="selectMeeting(m, { userSelected: true })"
+            >
+              <span v-if="recordingActive && recordingMeetingId === m.id" class="mi-rec-dot" aria-hidden="true" />
+              <span class="mi-head">
+                <span class="mi-title" :class="{ 'mi-title--canceled': m.canceled }">{{ m.title }}</span>
+                <span v-if="relLabel(m)" class="mi-rel" :class="{ 'mi-rel--now': isNextNow(m) }">{{ relLabel(m) }}</span>
+              </span>
+              <span class="mi-sub" :class="{ 'mi-sub--now': isNextNow(m) }">{{ subFor(m) }}</span>
+            </button>
+          </template>
+          <p v-if="displayedSections.length === 0" class="hint">{{ emptyListHint }}</p>
+        </div>
+      </template>
 
       <!-- Floating bottom navigation -->
       <nav class="bottom-nav">
@@ -171,9 +200,16 @@
             <svg viewBox="0 0 24 24" class="nav-ic"><path d="M4 6h10a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2z" /><path d="m16 10 5-3v10l-5-3" /></svg>
             <span>Meetings</span>
           </button>
-          <button class="nav-tab" type="button" title="Todo" disabled>
+          <button
+            class="nav-tab"
+            :class="{ 'nav-tab--active': activeView === 'todo' }"
+            type="button"
+            title="Todos"
+            :disabled="!activeBackend?.supportsActionItems"
+            @click="openTodoView"
+          >
             <svg viewBox="0 0 24 24" class="nav-ic"><path d="M9 6h11M9 12h11M9 18h11" /><path d="m3 6 1.5 1.5L7 5M3 12l1.5 1.5L7 11M3 18l1.5 1.5L7 17" /></svg>
-            <span>Todo</span>
+            <span>Todos</span>
           </button>
         </div>
       </nav>
@@ -248,6 +284,12 @@ import {
   isMeetingInProgress,
   type MeetingSection,
 } from '../composables/groupMeetingsByDate';
+import {
+  recentDayKeys,
+  groupActionItemsByDay,
+  type ActionItemEntry,
+  type ActionItemRow,
+} from '../composables/actionItemSections';
 import MeetingDetailView from './MeetingDetailView.vue';
 import UpNextCard from './UpNextCard.vue';
 import LibrarySearchPalette from './LibrarySearchPalette.vue';
@@ -341,7 +383,13 @@ const now = ref(new Date());
 const dayNum = computed(() => now.value.getDate());
 const monthName = computed(() => now.value.toLocaleString(undefined, { month: 'long' }).toUpperCase());
 
-const activeView = ref<'today' | 'meetings'>('meetings');
+const activeView = ref<'today' | 'meetings' | 'todo'>('meetings');
+// The action-items endpoint serves a single day, so the Todo tab asks for the
+// last two weeks one day at a time and groups what comes back.
+const TODO_DAY_COUNT = 14;
+const todoEntries = ref<ActionItemEntry[]>([]);
+const todoLoading = ref(false);
+const todoError = ref<string | null>(null);
 const isMac = computed(() =>
   typeof navigator !== 'undefined' && navigator.platform.toUpperCase().includes('MAC')
 );
@@ -401,6 +449,71 @@ const displayedSections = computed<MeetingSection[]>(() => {
   }
   return groupMeetingsByDate(displayMeetings.value, now.value);
 });
+
+const todoSections = computed(() => groupActionItemsByDay(todoEntries.value, now.value));
+
+// Which meeting an action item came from, so a row reads on its own.
+function todoSub(row: ActionItemRow): string {
+  return `${row.meeting.title} · ${fmtClock(row.meeting.timestamp)}`;
+}
+
+async function openTodoView(): Promise<void> {
+  activeView.value = 'todo';
+  await loadActionItems();
+}
+
+// Bump per call so a slow fan-out can't overwrite a newer one.
+let loadActionItemsRequest = 0;
+
+// One request per day shown. A day that fails is skipped rather than blanking
+// the tab — only a week that returns nothing at all reads as an error.
+async function loadActionItems(): Promise<void> {
+  if (todoLoading.value) return;
+  const backend = activeBackend.value ?? (await getActiveBackend());
+  activeBackend.value = backend;
+  if (!backend.supportsActionItems) return;
+  const requestId = ++loadActionItemsRequest;
+  todoLoading.value = true;
+  todoError.value = null;
+  try {
+    const results = await Promise.allSettled(
+      recentDayKeys(now.value, TODO_DAY_COUNT).map((day) => backend.listActionItems(day))
+    );
+    if (requestId !== loadActionItemsRequest) return;
+    const loaded: ActionItemEntry[] = [];
+    let failures = 0;
+    for (const result of results) {
+      if (result.status === 'fulfilled') loaded.push(...result.value);
+      else {
+        failures++;
+        console.error('Failed to load a day of action items', result.reason);
+      }
+    }
+    if (failures === results.length) {
+      todoEntries.value = [];
+      todoError.value = 'Could not load action items.';
+    } else {
+      todoEntries.value = loaded;
+    }
+  } finally {
+    if (requestId === loadActionItemsRequest) todoLoading.value = false;
+  }
+}
+
+// Switching backends swaps the whole corpus: drop the previous backend's action
+// items, and leave the Todo tab when the new backend has none (offline mode),
+// where the tab is disabled and would otherwise stay highlighted over an
+// empty pane.
+watch(
+  () => activeBackend.value?.id,
+  () => {
+    todoEntries.value = [];
+    todoError.value = null;
+    if (activeView.value === 'todo' && !activeBackend.value?.supportsActionItems) {
+      activeView.value = 'meetings';
+    }
+  }
+);
 
 const emptyListHint = computed(() =>
   activeView.value === 'today' ? 'No meetings today.' : 'No past meetings.'
@@ -1459,6 +1572,19 @@ onUnmounted(() => {
 .mi-rel { flex-shrink: 0; font-size: 11px; font-weight: 600; letter-spacing: 0.3px; color: #6f6f6f; }
 .mi-rel--now { color: #2e8b4f; }
 .mi-sub { font-size: 12px; color: #6f6f6f; }
+/* An action item is a sentence, not a title: let it wrap to two lines rather
+   than truncate mid-thought, and keep its source meeting on a single line. */
+.todo-item .mi-title {
+  white-space: normal;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+}
+.todo-item .mi-sub {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
 .mi-sub--now { color: #2e8b4f; font-weight: 500; }
 
 /* Bottom nav */


### PR DESCRIPTION
Closes #148 (the action-item surface — see Scope below).

## What

The Library's **Todos** tab was rendered disabled. It now lists the action items assigned to the signed-in user, grouped by date, and each row opens the meeting it came from.

- **API** — `listActionItemsByDay(day)` calls `GET /meeting-notes/action-items?day=YYYY-MM-DD`. That endpoint serves a single day (resolved in the user's profile timezone) and already scopes items to the caller, so the tab fans out one request per day over the last **14 days** with `Promise.allSettled`.
- **Backend seam** — `Backend` gains `supportsActionItems` and `listActionItems(day)`. Ariso maps each group into a real `MeetingListItem`, so a Todo row can be handed straight to the existing `selectMeeting`.
- **Grouping** — new pure composable `actionItemSections.ts`: day keys, then sections labelled `TODAY · AUG 31` / `YESTERDAY · AUG 30` / `SAT AUG 29`, newest day first, meetings earliest-first within a day, deduped by meeting id, blank items dropped, undated meetings kept under a trailing `UNDATED`.
- **View** — the tab is enabled only when the active backend supports action items; rows show the item text with its source meeting and time beneath, and clicking one renders that meeting in the existing detail pane (row shows as selected).

## Error and empty states

A single failed day is logged and skipped rather than blanking the tab; only a fully failed window shows "Could not load action items." No items in the window shows "No action items."

## Offline mode

`LocalBackend` declares `supportsActionItems = false` and returns `[]` without any network call, the tab stays disabled, and `loadActionItems` early-returns — the offline privacy guarantee is unchanged. Switching backends clears the cached items and drops out of the tab.

## Scope

Issue #148 describes a broader action-item workflow (pre-publish review/edit, export to external task tools, transcript-moment citations). This PR delivers the surfacing half: a reviewable list of your action items, each traceable back to its source meeting. The editing, export, and citation pieces are not included.

## Testing

- 22 new tests, written first: `actionItemSections` (grouping, ordering, dedupe, blanks, undated), `useMeetingApi.listActionItemsByDay`, `ArisoBackend`/`LocalBackend.listActionItems`, and `LibraryView` (tab enablement per backend, the 14-day fan-out order, click-to-detail, partial failure, total failure, empty state, backend switch).
- `npm test` — 823 tests / 59 files passing.
- `npm run vite:build` clean; `vue-tsc --noEmit` clean.
- Not exercised against the live API; the response shape is taken from `getActionItemsByDay` in the `agents` service.

## Security

No new Tauri command, capability, or window — this rides the existing authed `api.request` proxy, and the `day` parameter is generated locally and URL-encoded. Only error metadata is logged, never item content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Todo view displaying action items from the previous 14 days, grouped by meeting date.
  * Added navigation from action items to their source meetings.
  * Added loading, empty, error, and unsupported-backend states.
  * Added backend support for retrieving daily action items.

* **Tests**
  * Added coverage for grouping, sorting, filtering, API behavior, backend support, and Todo view states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->