### PR TITLE
add status when transcribing audio

### DIFF
--- a/src/composables/useMeetingApi.test.ts
+++ b/src/composables/useMeetingApi.test.ts
@@ -9,7 +9,7 @@ vi.mock('../tauri', () => ({
   },
 }));
 
-import { useMeetingApi } from './useMeetingApi';
+import { useMeetingApi, isMeetingNotesReady } from './useMeetingApi';
 
 beforeEach(() => {
   apiRequest.mockReset();
@@ -262,5 +262,21 @@ describe('listActionItemsByDay', () => {
     await expect(useMeetingApi().listActionItemsByDay('nope')).rejects.toThrow(
       'Invalid date format'
     );
+  });
+});
+
+describe('isMeetingNotesReady', () => {
+  it('is ready once a transcript exists', () => {
+    expect(isMeetingNotesReady({ hasTranscript: true })).toBe(true);
+  });
+
+  it('is ready once a summary exists, even without a transcript', () => {
+    expect(isMeetingNotesReady({ hasTranscript: false, summary: '{"digest":"x"}' })).toBe(true);
+  });
+
+  it('is not ready when neither is present', () => {
+    expect(isMeetingNotesReady({})).toBe(false);
+    expect(isMeetingNotesReady({ hasTranscript: false, summary: null })).toBe(false);
+    expect(isMeetingNotesReady({ summary: '' })).toBe(false);
   });
 });

--- a/src/composables/useMeetingApi.ts
+++ b/src/composables/useMeetingApi.ts
@@ -169,6 +169,17 @@ interface MeetingNotes {
   audio_clips?: MeetingAudioClip[];
 }
 
+/** Whether the server has produced *anything* for a meeting yet. These are the
+ *  same two fields `ArisoBackend.getMeetingDetail` reads off `/meeting-notes/:id`
+ *  to decide whether the Transcript/AI-Notes tabs exist, so one truthy value is
+ *  enough to call the meeting "no longer processing" — the later assessment and
+ *  coaching fields lag and must not hold the indicator up. */
+export function isMeetingNotesReady(
+  n: Pick<MeetingNotes, 'hasTranscript' | 'summary'>
+): boolean {
+  return !!n.hasTranscript || !!n.summary;
+}
+
 interface ScheduledMeetingsResponse {
   meetings: ScheduledMeeting[];
 }

--- a/src/composables/useMeetingProcessing.test.ts
+++ b/src/composables/useMeetingProcessing.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const getMeetingNotes = vi.fn();
+
+vi.mock('./useMeetingApi', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./useMeetingApi')>();
+  return {
+    ...actual,
+    useMeetingApi: () => ({ getMeetingNotes: (id: unknown) => getMeetingNotes(id) }),
+  };
+});
+
+import { useMeetingProcessing } from './useMeetingProcessing';
+
+const processing = useMeetingProcessing();
+
+// Advance past one 5s poll interval and let the in-flight requests settle.
+async function tick(): Promise<void> {
+  await vi.advanceTimersByTimeAsync(5000);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.useFakeTimers();
+  processing.reset();
+  processing.version.value = 0;
+});
+afterEach(() => {
+  processing.reset();
+  vi.useRealTimers();
+});
+
+describe('useMeetingProcessing', () => {
+  it('tracks a meeting once marked uploaded', () => {
+    expect(processing.isProcessing('42')).toBe(false);
+    processing.markUploaded('42');
+    expect(processing.isProcessing('42')).toBe(true);
+  });
+
+  it('accepts a numeric id and matches it as a string', () => {
+    processing.markUploaded(42);
+    expect(processing.isProcessing('42')).toBe(true);
+  });
+
+  it('does not poll before the interval elapses', async () => {
+    processing.markUploaded('42');
+    await vi.advanceTimersByTimeAsync(4000);
+    expect(getMeetingNotes).not.toHaveBeenCalled();
+  });
+
+  it('stops tracking and bumps version once the meeting has a transcript', async () => {
+    getMeetingNotes.mockResolvedValue({ hasTranscript: true });
+    processing.markUploaded('42');
+
+    await tick();
+
+    expect(getMeetingNotes).toHaveBeenCalledWith('42');
+    expect(processing.isProcessing('42')).toBe(false);
+    expect(processing.version.value).toBe(1);
+  });
+
+  it('stops tracking once the meeting has a summary but no transcript', async () => {
+    getMeetingNotes.mockResolvedValue({ summary: '{"digest":"x"}' });
+    processing.markUploaded('42');
+    await tick();
+    expect(processing.isProcessing('42')).toBe(false);
+  });
+
+  it('keeps polling while the meeting has no content yet', async () => {
+    getMeetingNotes.mockResolvedValue({ hasTranscript: false, summary: null });
+    processing.markUploaded('42');
+
+    await tick();
+    expect(processing.isProcessing('42')).toBe(true);
+    expect(processing.version.value).toBe(0);
+
+    await tick();
+    expect(getMeetingNotes).toHaveBeenCalledTimes(2);
+    expect(processing.isProcessing('42')).toBe(true);
+  });
+
+  it('keeps the meeting tracked when the poll request fails', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    getMeetingNotes.mockRejectedValue(new Error('offline'));
+    processing.markUploaded('42');
+
+    await tick();
+
+    expect(processing.isProcessing('42')).toBe(true);
+    expect(processing.version.value).toBe(0);
+  });
+
+  it('resolves tracked meetings independently', async () => {
+    getMeetingNotes.mockImplementation((id: string) =>
+      id === '1' ? Promise.resolve({ hasTranscript: true }) : Promise.reject(new Error('offline'))
+    );
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    processing.markUploaded('1');
+    processing.markUploaded('2');
+
+    await tick();
+
+    expect(processing.isProcessing('1')).toBe(false);
+    expect(processing.isProcessing('2')).toBe(true);
+    expect(processing.version.value).toBe(1);
+  });
+
+  it('stops polling once every tracked meeting is ready', async () => {
+    getMeetingNotes.mockResolvedValue({ hasTranscript: true });
+    processing.markUploaded('42');
+    await tick();
+    expect(getMeetingNotes).toHaveBeenCalledTimes(1);
+
+    await tick();
+    expect(getMeetingNotes).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores a duplicate mark for an already-tracked meeting', async () => {
+    getMeetingNotes.mockResolvedValue({ hasTranscript: false });
+    processing.markUploaded('42');
+    processing.markUploaded('42');
+
+    await tick();
+
+    expect(getMeetingNotes).toHaveBeenCalledTimes(1);
+  });
+
+  it('reset drops tracking and stops polling', async () => {
+    getMeetingNotes.mockResolvedValue({ hasTranscript: false });
+    processing.markUploaded('42');
+    processing.reset();
+
+    expect(processing.isProcessing('42')).toBe(false);
+    await tick();
+    expect(getMeetingNotes).not.toHaveBeenCalled();
+  });
+});

--- a/src/composables/useMeetingProcessing.ts
+++ b/src/composables/useMeetingProcessing.ts
@@ -1,0 +1,107 @@
+import { ref, type Ref } from 'vue';
+import { useMeetingApi, isMeetingNotesReady } from './useMeetingApi';
+
+/** How often to re-ask the server whether an uploaded meeting has content yet.
+ *  Heavier than the local pipeline's on-disk 2s check and far less
+ *  latency-sensitive: this is a background confirmation, not a progress bar. */
+const POLL_MS = 5000;
+
+export interface MeetingProcessing {
+  /** Start treating `meetingId` as "uploaded, still processing". */
+  markUploaded: (meetingId: string | number) => void;
+  /** Reactive membership check — read it inside a computed/template. */
+  isProcessing: (meetingId: string | number) => boolean;
+  /** Bumps every time a meeting leaves the tracked set (its content landed),
+   *  so callers can reload their list without re-deriving membership per tick. */
+  version: Ref<number>;
+  /** Drop all tracking. Used when the active backend changes (the ids belong to
+   *  Ariso) and by tests, which share this module-scoped state. */
+  reset: () => void;
+}
+
+// Module-scoped on purpose: the Library row and the detail panel must agree on
+// which meetings are processing, and the poll should run once for both. State
+// is session-only — nothing is persisted, so an app restart forgets everything
+// (see the spec's Non-goals).
+const tracked = ref<Set<string>>(new Set());
+const version = ref(0);
+let timer: ReturnType<typeof setTimeout> | null = null;
+// Invalidates in-flight polls across a reset so a late response can't resurrect
+// or drop an id that belongs to a newer generation of the tracked set.
+let token = 0;
+
+function clearTimer(): void {
+  if (timer) {
+    clearTimeout(timer);
+    timer = null;
+  }
+}
+
+function schedule(my: number): void {
+  clearTimer();
+  timer = setTimeout(() => void poll(my), POLL_MS);
+}
+
+async function poll(my: number): Promise<void> {
+  if (my !== token || tracked.value.size === 0) return;
+  const api = useMeetingApi();
+  const ids = [...tracked.value];
+  // Each id resolves independently: one meeting's failed request must not stop
+  // the others from being confirmed on this tick.
+  const results = await Promise.all(
+    ids.map(async (id) => {
+      try {
+        return isMeetingNotesReady(await api.getMeetingNotes(id));
+      } catch (e) {
+        // A transient network blip keeps the meeting tracked — better to show
+        // "Processing…" a little longer than to flip back to the ambiguous
+        // empty state. Mirrors useLocalRecordingProgress's retry behavior.
+        console.error('meeting processing poll failed', e);
+        return false;
+      }
+    })
+  );
+  if (my !== token) return;
+  const done = ids.filter((_, i) => results[i]);
+  if (done.length) {
+    const next = new Set(tracked.value);
+    for (const id of done) next.delete(id);
+    tracked.value = next;
+    version.value++;
+  }
+  if (tracked.value.size > 0) schedule(my);
+  else clearTimer();
+}
+
+function markUploaded(meetingId: string | number): void {
+  const id = String(meetingId);
+  if (!id || tracked.value.has(id)) return;
+  const next = new Set(tracked.value);
+  next.add(id);
+  tracked.value = next;
+  if (!timer) schedule(token);
+}
+
+function isProcessing(meetingId: string | number): boolean {
+  return tracked.value.has(String(meetingId));
+}
+
+function reset(): void {
+  token++;
+  clearTimer();
+  tracked.value = new Set();
+}
+
+/**
+ * Tracks Ariso meetings this session just uploaded and polls until the server
+ * has produced a transcript or notes for them.
+ *
+ * Ariso exposes no "processing" status for audio-uploaded meetings — its
+ * `status` field only carries the calendar-call lifecycle — so "processing" is
+ * inferred client-side from content absence for meetings we know we uploaded.
+ * Local recordings need no equivalent: their state already lives on disk
+ * (`useLocalRecordingProgress`).
+ */
+export function useMeetingProcessing(): MeetingProcessing {
+  return { markUploaded, isProcessing, version, reset };
+}

--- a/src/composables/usePendingUploads.test.ts
+++ b/src/composables/usePendingUploads.test.ts
@@ -163,9 +163,23 @@ describe('combineAndUpload', () => {
   });
 
   it('is a no-op for an empty list', async () => {
-    await combineAndUpload([]);
+    await expect(combineAndUpload([])).resolves.toEqual([]);
     expect(combine).not.toHaveBeenCalled();
     expect(uploadAudio).not.toHaveBeenCalled();
+  });
+
+  // The caller shows each uploaded meeting as "processing" until the server has
+  // a transcript for it, so the ids have to survive the upload.
+  it('returns the meeting id each group uploaded to', async () => {
+    const a = { ...items[0], createdAt: 'a', meetingId: 5 };
+    const d = { ...items[0], createdAt: 'd', meetingId: 9 };
+    combine.mockResolvedValue(new ArrayBuffer(4));
+    uploadAudio.mockImplementation((_blob: unknown, meta: { meetingId?: number }) =>
+      Promise.resolve({ meetingId: meta.meetingId ?? 77 })
+    );
+    discardAudio.mockResolvedValue(undefined);
+
+    await expect(combineAndUpload([a, d, items[0]])).resolves.toEqual([5, 9, 77]);
   });
 });
 

--- a/src/composables/usePendingUploads.test.ts
+++ b/src/composables/usePendingUploads.test.ts
@@ -20,7 +20,13 @@ vi.mock('./useMeetingApi', () => ({
   useMeetingApi: () => ({ uploadAudio: (...a: unknown[]) => uploadAudio(...a) }),
 }));
 
-import { mergedMeta, groupByMeetingId, combineAndUpload, discardAll } from './usePendingUploads';
+import {
+  mergedMeta,
+  groupByMeetingId,
+  combineAndUpload,
+  discardAll,
+  PartialUploadError,
+} from './usePendingUploads';
 
 const items = [
   { createdAt: '2026-06-12T09:00:00Z', startAt: '2026-06-12T09:00:00Z', endAt: '2026-06-12T09:05:00Z', durationSeconds: 300 },
@@ -133,6 +139,24 @@ describe('combineAndUpload', () => {
     // The succeeded group is discarded; the failed group is left in place.
     expect(discardAudio).toHaveBeenCalledWith('a');
     expect(discardAudio).not.toHaveBeenCalledWith('d');
+  });
+
+  // The caller only learns about the failed group via the throw, so the
+  // succeeded group's meeting id must ride along on the error or it's lost.
+  it('carries the succeeded meeting ids on a PartialUploadError when one group fails', async () => {
+    const a = { ...items[0], createdAt: 'a', durationSeconds: 300, meetingId: 5 };
+    const d = { ...items[0], createdAt: 'd', durationSeconds: 90, meetingId: 9 };
+
+    combine.mockResolvedValue(new ArrayBuffer(4));
+    uploadAudio.mockImplementation((_blob: unknown, meta: { meetingId?: number }) =>
+      meta.meetingId === 9 ? Promise.reject(new Error('offline')) : Promise.resolve({ meetingId: 5 })
+    );
+    discardAudio.mockResolvedValue(undefined);
+
+    const error = await combineAndUpload([a, d]).catch((e) => e);
+    expect(error).toBeInstanceOf(PartialUploadError);
+    expect((error as PartialUploadError).uploadedMeetingIds).toEqual([5]);
+    expect((error as PartialUploadError).message).toBe('offline');
   });
 
   it('does not discard when the upload fails', async () => {

--- a/src/composables/usePendingUploads.ts
+++ b/src/composables/usePendingUploads.ts
@@ -39,8 +39,10 @@ export function groupByMeetingId(items: PendingUploadMeta[]): PendingUploadMeta[
 }
 
 /** Concatenate one meetingId group server-side, upload it (to its existing
- *  meeting when it has an id, else a fresh one), then discard its buffers. */
-async function uploadGroup(group: PendingUploadMeta[]): Promise<void> {
+ *  meeting when it has an id, else a fresh one), then discard its buffers.
+ *  Resolves to the meeting the audio landed on, so the caller can show it as
+ *  "processing" until the server produces a transcript/notes. */
+async function uploadGroup(group: PendingUploadMeta[]): Promise<number> {
   const keys = group.map((i) => i.createdAt);
   const meta = mergedMeta(group);
 
@@ -62,8 +64,9 @@ async function uploadGroup(group: PendingUploadMeta[]): Promise<void> {
   }
 
   const blob = new Blob([buf], { type: 'audio/mpeg' });
+  let meetingId: number;
   try {
-    await useMeetingApi().uploadAudio(blob, meta);
+    ({ meetingId } = await useMeetingApi().uploadAudio(blob, meta));
   } catch (e) {
     await reportUploadFailure(e, {
       attempt: 'retry',
@@ -82,18 +85,24 @@ async function uploadGroup(group: PendingUploadMeta[]): Promise<void> {
   if (failed > 0) {
     console.error(`Uploaded combined audio, but failed to discard ${failed} buffered item(s)`);
   }
+  return meetingId;
 }
 
 /** Resume pending uploads: group by meeting so each meeting's audio re-attaches
  *  to that meeting (preserving its id), then upload each group. A group that
  *  fails is left buffered for a later retry while the others still upload and
  *  discard; the first failure is re-thrown so the caller surfaces an error.
- *  `items` must be chronological (as `pending.list()` returns). */
-export async function combineAndUpload(items: PendingUploadMeta[]): Promise<void> {
-  if (items.length === 0) return;
+ *  `items` must be chronological (as `pending.list()` returns).
+ *
+ *  Resolves to the ids of the meetings that did upload. They are only useful on
+ *  the success path — a throw carries no ids — which is exactly when the caller
+ *  wants to start tracking them as processing. */
+export async function combineAndUpload(items: PendingUploadMeta[]): Promise<number[]> {
+  if (items.length === 0) return [];
   const results = await Promise.allSettled(groupByMeetingId(items).map(uploadGroup));
   const firstFailure = results.find((r) => r.status === 'rejected');
   if (firstFailure) throw (firstFailure as PromiseRejectedResult).reason;
+  return results.map((r) => (r as PromiseFulfilledResult<number>).value);
 }
 
 /** Discard every pending upload (the "Discard all" action). */

--- a/src/composables/usePendingUploads.ts
+++ b/src/composables/usePendingUploads.ts
@@ -88,20 +88,37 @@ async function uploadGroup(group: PendingUploadMeta[]): Promise<number> {
   return meetingId;
 }
 
+/** Thrown by {@link combineAndUpload} when at least one group fails but
+ *  others succeeded. Carries the succeeded groups' meeting ids so the caller
+ *  can still track them as processing instead of losing them to the throw. */
+export class PartialUploadError extends Error {
+  constructor(public readonly uploadedMeetingIds: number[], cause: unknown) {
+    super(cause instanceof Error ? cause.message : String(cause));
+    this.name = 'PartialUploadError';
+    this.cause = cause;
+  }
+}
+
 /** Resume pending uploads: group by meeting so each meeting's audio re-attaches
  *  to that meeting (preserving its id), then upload each group. A group that
  *  fails is left buffered for a later retry while the others still upload and
  *  discard; the first failure is re-thrown so the caller surfaces an error.
  *  `items` must be chronological (as `pending.list()` returns).
  *
- *  Resolves to the ids of the meetings that did upload. They are only useful on
- *  the success path — a throw carries no ids — which is exactly when the caller
- *  wants to start tracking them as processing. */
+ *  Resolves to the ids of the meetings that did upload. On a full failure the
+ *  throw carries no ids; on a partial failure (some groups succeeded, one
+ *  failed) it throws a {@link PartialUploadError} carrying the succeeded
+ *  groups' ids so the caller can still track them as processing. */
 export async function combineAndUpload(items: PendingUploadMeta[]): Promise<number[]> {
   if (items.length === 0) return [];
   const results = await Promise.allSettled(groupByMeetingId(items).map(uploadGroup));
   const firstFailure = results.find((r) => r.status === 'rejected');
-  if (firstFailure) throw (firstFailure as PromiseRejectedResult).reason;
+  if (firstFailure) {
+    const uploadedMeetingIds = results
+      .filter((r): r is PromiseFulfilledResult<number> => r.status === 'fulfilled')
+      .map((r) => r.value);
+    throw new PartialUploadError(uploadedMeetingIds, (firstFailure as PromiseRejectedResult).reason);
+  }
   return results.map((r) => (r as PromiseFulfilledResult<number>).value);
 }
 

--- a/src/views/LibraryView.test.ts
+++ b/src/views/LibraryView.test.ts
@@ -83,6 +83,45 @@ vi.mock('../composables/useBackend', async (importOriginal) => {
 vi.mock('../composables/useMeetingNotifications', () => ({
   emitNotificationsSync: () => emitNotificationsSync(),
 }));
+// A miniature stand-in for the session-scoped cloud tracker: `markUploaded`
+// records the id the way the real one does, and `resolveProcessing` is the
+// test's hand on "the poll found content for this meeting".
+// Hoisted so the (also hoisted) mock factory can reach it — the refs themselves
+// are created inside the factory, which is the first place `vue` is loadable.
+const processingMock = vi.hoisted(() => ({
+  markUploaded: vi.fn(),
+  tracked: null as null | import('vue').Ref<Set<string>>,
+  version: null as null | import('vue').Ref<number>,
+}));
+const markUploaded = processingMock.markUploaded;
+vi.mock('../composables/useMeetingProcessing', async () => {
+  const { ref } = await import('vue');
+  const tracked = ref(new Set<string>());
+  const version = ref(0);
+  processingMock.tracked = tracked;
+  processingMock.version = version;
+  return {
+    useMeetingProcessing: () => ({
+      markUploaded: (id: string | number) => {
+        processingMock.markUploaded(id);
+        tracked.value = new Set(tracked.value).add(String(id));
+      },
+      isProcessing: (id: string | number) => tracked.value.has(String(id)),
+      version,
+      reset: () => {
+        tracked.value = new Set();
+      },
+    }),
+  };
+});
+// The test's hand on "the poll found content for this meeting".
+function resolveProcessing(id: string): void {
+  const tracked = processingMock.tracked!;
+  const next = new Set(tracked.value);
+  next.delete(id);
+  tracked.value = next;
+  processingMock.version!.value++;
+}
 // RecordingAudioPlayer (rendered for local rows) and openNote/openTranscript go
 // through ../tauri; keep those mocked so jsdom never touches real IPC.
 // pending.list() is also mocked so the PendingUploads child never calls Tauri IPC.
@@ -118,7 +157,7 @@ function item(over: Record<string, unknown>) {
 // chrome (selection, the recorder strip, the titlebar button).
 const detailStub = {
   name: 'MeetingDetailView',
-  emits: ['close', 'title-updated'],
+  emits: ['close', 'title-updated', 'content-ready'],
   props: ['item'],
   methods: {
     openPrepTab: (meetingId?: string) => openPrepTab(meetingId),
@@ -164,6 +203,8 @@ beforeEach(() => {
   supportsActionItems.mockReturnValue(false);
   listActionItems.mockResolvedValue([]);
   searchMeetings.mockResolvedValue([]);
+  processingMock.tracked!.value = new Set();
+  processingMock.version!.value = 0;
 });
 afterEach(() => {
   // Restore real timers even if a fake-timer test failed before its own
@@ -630,6 +671,163 @@ describe('LibraryView', () => {
     const row = wrapper.find('.meeting-item');
     expect(row.find('.mi-title').text()).toBe('Morning Sync');
     expect(row.find('.mi-sub').text()).toContain('min');
+  });
+
+  // Between the recorder pill's checkmark and the notes actually landing, the
+  // row is the only place the sidebar can say a meeting is still being worked
+  // on rather than permanently empty (#315).
+  describe('processing rows', () => {
+    async function mountWithRows(rows: Record<string, unknown>[]) {
+      listMeetings.mockResolvedValue(rows);
+      const wrapper = mountWithDetailStub();
+      await flushPromises();
+      return wrapper;
+    }
+
+    it('shows a spinner and "Processing…" while a local recording transcribes', async () => {
+      const wrapper = await mountWithRows([item({ id: 'a', status: 'transcribing' })]);
+      const row = wrapper.get('.meeting-item');
+      expect(row.find('.mi-sub--processing').text()).toContain('Processing');
+      expect(row.find('.mi-spinner').exists()).toBe(true);
+    });
+
+    it('keeps showing "Processing…" while a transcribed local recording awaits its notes', async () => {
+      const wrapper = await mountWithRows([
+        item({
+          id: 'a',
+          timestamp: new Date(Date.now() - 60_000).toISOString(),
+          status: 'done',
+          files: { hasAudio: true, hasTranscript: true, hasNote: false },
+        }),
+      ]);
+      expect(wrapper.get('.meeting-item').find('.mi-sub--processing').exists()).toBe(true);
+    });
+
+    // Notes generation runs for minutes. A recording that ended long ago and
+    // still has no note is stuck, not busy — a real vault had 18 such rows from
+    // three months back, every one of them spinning forever.
+    it('stops inferring "Processing…" for a recording that ended long ago', async () => {
+      const wrapper = await mountWithRows([
+        item({
+          id: 'a',
+          timestamp: new Date(Date.now() - 3 * 60 * 60 * 1000).toISOString(),
+          status: 'done',
+          files: { hasAudio: true, hasTranscript: true, hasNote: false },
+        }),
+      ]);
+      expect(wrapper.get('.meeting-item').find('.mi-sub--processing').exists()).toBe(false);
+    });
+
+    // The window is measured from the end, so a long recording isn't already
+    // stale the moment it stops.
+    it('measures the window from the end of a long recording, not its start', async () => {
+      const wrapper = await mountWithRows([
+        item({
+          id: 'a',
+          timestamp: new Date(Date.now() - 3 * 60 * 60 * 1000).toISOString(),
+          durationSeconds: 3 * 60 * 60 - 60,
+          status: 'done',
+          files: { hasAudio: true, hasTranscript: true, hasNote: false },
+        }),
+      ]);
+      expect(wrapper.get('.meeting-item').find('.mi-sub--processing').exists()).toBe(true);
+    });
+
+    // An age bound must never suppress a live state the backend reports directly.
+    it('still shows "Processing…" for an old recording that is actively transcribing', async () => {
+      const wrapper = await mountWithRows([
+        item({
+          id: 'a',
+          timestamp: new Date(Date.now() - 3 * 60 * 60 * 1000).toISOString(),
+          status: 'transcribing',
+        }),
+      ]);
+      expect(wrapper.get('.meeting-item').find('.mi-sub--processing').exists()).toBe(true);
+    });
+
+    it('shows the normal sub-line once a local recording has its notes', async () => {
+      const wrapper = await mountWithRows([
+        item({ id: 'a', status: 'done', files: { hasAudio: true, hasTranscript: true, hasNote: true } }),
+      ]);
+      const row = wrapper.get('.meeting-item');
+      expect(row.find('.mi-sub--processing').exists()).toBe(false);
+      expect(row.find('.mi-sub').text()).toContain('min');
+    });
+
+    // A failed transcription is reported by the detail panel's chip with a Retry;
+    // a row that kept spinning forever would be a lie.
+    it('shows the normal sub-line for a failed local recording', async () => {
+      const wrapper = await mountWithRows([
+        item({ id: 'a', status: 'failed', files: { hasAudio: true, hasTranscript: false, hasNote: false } }),
+      ]);
+      expect(wrapper.get('.meeting-item').find('.mi-sub--processing').exists()).toBe(false);
+    });
+
+    it('marks the recorded cloud meeting as processing when the upload succeeds', async () => {
+      backendId.mockReturnValue('ariso');
+      const wrapper = await mountWithRows([item({ id: '42', status: undefined, files: undefined })]);
+
+      const strip = wrapper.findComponent({ name: 'RecorderStrip' });
+      strip.vm.$emit('recording-change', '42');
+      strip.vm.$emit('recording-phase', 'success');
+      await flushPromises();
+
+      expect(markUploaded).toHaveBeenCalledWith('42');
+      expect(wrapper.get('.meeting-item').find('.mi-sub--processing').text()).toContain('Processing');
+    });
+
+    it('does not track a local recording as a cloud upload', async () => {
+      const wrapper = await mountWithRows([item({ id: 'a' })]);
+
+      const strip = wrapper.findComponent({ name: 'RecorderStrip' });
+      strip.vm.$emit('recording-change', 'a');
+      strip.vm.$emit('recording-phase', 'success');
+      await flushPromises();
+
+      expect(markUploaded).not.toHaveBeenCalled();
+    });
+
+    it('reloads the list and drops the indicator once the cloud meeting has content', async () => {
+      backendId.mockReturnValue('ariso');
+      const wrapper = await mountWithRows([item({ id: '42', status: undefined, files: undefined })]);
+      const strip = wrapper.findComponent({ name: 'RecorderStrip' });
+      strip.vm.$emit('recording-change', '42');
+      strip.vm.$emit('recording-phase', 'success');
+      await flushPromises();
+      listMeetings.mockClear();
+
+      resolveProcessing('42');
+      await flushPromises();
+
+      expect(listMeetings).toHaveBeenCalled();
+      expect(wrapper.get('.meeting-item').find('.mi-sub--processing').exists()).toBe(false);
+    });
+
+    // The detail panel owns the only live poll of a local recording's pipeline,
+    // so it is what tells the list its row went stale.
+    it('reloads the list when the open local recording reports its content is ready', async () => {
+      const wrapper = await mountWithRows([item({ id: 'a', status: 'transcribing' })]);
+      await wrapper.get('.meeting-item').trigger('click');
+      await flushPromises();
+      listMeetings.mockClear();
+
+      wrapper.findComponent({ name: 'MeetingDetailView' }).vm.$emit('content-ready', { id: 'a' });
+      await flushPromises();
+
+      expect(listMeetings).toHaveBeenCalled();
+    });
+
+    it('does not reload when a row that was never processing reports content ready', async () => {
+      const wrapper = await mountWithRows([item({ id: 'a', status: 'done' })]);
+      await wrapper.get('.meeting-item').trigger('click');
+      await flushPromises();
+      listMeetings.mockClear();
+
+      wrapper.findComponent({ name: 'MeetingDetailView' }).vm.$emit('content-ready', { id: 'a' });
+      await flushPromises();
+
+      expect(listMeetings).not.toHaveBeenCalled();
+    });
   });
 
   it('strikes through the title of a canceled meeting only', async () => {

--- a/src/views/LibraryView.vue
+++ b/src/views/LibraryView.vue
@@ -182,7 +182,15 @@
                 <span class="mi-title" :class="{ 'mi-title--canceled': m.canceled }">{{ m.title }}</span>
                 <span v-if="relLabel(m)" class="mi-rel" :class="{ 'mi-rel--now': isNextNow(m) }">{{ relLabel(m) }}</span>
               </span>
-              <span class="mi-sub" :class="{ 'mi-sub--now': isNextNow(m) }">{{ subFor(m) }}</span>
+              <!-- While a recording is still being turned into a transcript/notes,
+                   the row says so instead of showing its time/duration — that
+                   line is the only place the sidebar can tell "still working" and
+                   "this meeting will never have notes" apart. -->
+              <span v-if="rowProcessingLabel(m)" class="mi-sub mi-sub--processing">
+                <span class="mi-spinner" aria-hidden="true" />
+                {{ rowProcessingLabel(m) }}
+              </span>
+              <span v-else class="mi-sub" :class="{ 'mi-sub--now': isNextNow(m) }">{{ subFor(m) }}</span>
             </button>
           </template>
           <p v-if="displayedSections.length === 0" class="hint">{{ emptyListHint }}</p>
@@ -226,6 +234,7 @@
           :now="now"
           @close="clearSelection"
           @title-updated="onTitleUpdated"
+          @content-ready="onContentReady"
         />
         <UpNextCard
           v-else
@@ -296,6 +305,7 @@ import LibrarySearchPalette from './LibrarySearchPalette.vue';
 import RecorderStrip from './RecorderStrip.vue';
 import PendingUploads from './PendingUploads.vue';
 import { emitNotificationsSync } from '../composables/useMeetingNotifications';
+import { useMeetingProcessing } from '../composables/useMeetingProcessing';
 import { shouldConfirmAriJoin } from '../composables/autoJoin';
 import { useAriJoinConfirm } from '../composables/useAriJoinConfirm';
 import AriJoinConfirmDialog from './AriJoinConfirmDialog.vue';
@@ -330,6 +340,11 @@ const ariConfirm = useAriJoinConfirm();
 const recordingStartChoice = useRecordingStartChoice();
 const activeBackend = ref<Backend | null>(null);
 const searchPaletteOpen = ref(false);
+// Cloud meetings uploaded in this session that the server hasn't produced a
+// transcript or notes for yet. Local recordings carry their own on-disk state on
+// the list row instead, so they never enter this set.
+const processingMeetings = useMeetingProcessing();
+const PROCESSING_LABEL = 'Processing…';
 type MeetingDetailViewExposed = InstanceType<typeof MeetingDetailView> & {
   saveNotesNow?: () => Promise<void>;
   openPrepTab?: () => void;
@@ -552,6 +567,43 @@ function subFor(m: MeetingListItem): string {
   return itemSub(m);
 }
 
+// A recording whose transcript/notes are still being produced. Local reads the
+// on-disk pipeline state the list row already carries; cloud has no such signal,
+// so it falls back to this session's upload tracking (see useMeetingProcessing).
+// Returns the label to show, or null when the row's normal sub-line applies.
+function rowProcessingLabel(m: MeetingListItem): string | null {
+  if (activeBackend.value?.id === 'local') {
+    // `recording`/`transcribing` are authoritative live states from disk.
+    // `failed` is deliberately excluded — the failure is reported by the detail
+    // panel's chip with a Retry, and a row that kept spinning forever would be
+    // a lie.
+    if (m.status === 'recording' || m.status === 'transcribing') return PROCESSING_LABEL;
+    // "Has a transcript but no note" is an *inference* that notes are still
+    // generating, and it can't tell a running pipeline from one that never
+    // finished (telling notes-pending from notes-failed needs the per-recording
+    // status view, which the list payload doesn't carry). Generation runs for
+    // minutes, so bound it: an old recording with no note is stuck, not busy.
+    if (m.status === 'done' && m.files?.hasTranscript && !m.files?.hasNote) {
+      return finishedRecently(m) ? PROCESSING_LABEL : null;
+    }
+    return null;
+  }
+  return processingMeetings.isProcessing(m.id) ? PROCESSING_LABEL : null;
+}
+
+// How long after a recording ends its missing note still reads as "generating".
+const NOTES_PENDING_WINDOW_MS = 60 * 60 * 1000;
+
+// Measured from the recording's end (start + duration), so a long recording
+// isn't already "old" the moment it stops. Reads the ticking `now`, so a row
+// that crosses the line drops the indicator on its own.
+function finishedRecently(m: MeetingListItem): boolean {
+  const start = new Date(m.timestamp).getTime();
+  if (Number.isNaN(start)) return false;
+  const end = start + (m.durationSeconds ?? 0) * 1000;
+  return now.value.getTime() - end < NOTES_PENDING_WINDOW_MS;
+}
+
 function itemSub(m: MeetingListItem): string {
   const d = new Date(m.timestamp);
   const time = Number.isNaN(d.getTime())
@@ -627,6 +679,22 @@ function onTitleUpdated(payload: { id: string; title: string }): void {
     selectedItem.value = { ...selectedItem.value, title: payload.title };
   }
 }
+
+// The open local recording finished generating. Its row still shows the stale
+// "Processing…" sub-line the list payload described, so pull fresh list data —
+// but only when the row actually claims to be processing, so simply opening an
+// already-finished recording doesn't cost a list round trip.
+async function onContentReady(payload: { id: string }): Promise<void> {
+  const row = displayMeetings.value.find((m) => m.id === payload.id);
+  if (row && rowProcessingLabel(row)) await loadMeetings();
+}
+
+// A tracked cloud meeting's transcript/notes just landed. Reload so its row
+// swaps "Processing…" back for its normal sub-line and the detail panel picks up
+// the content. The tracked set is normally 0-1 items, so this is cheap.
+watch(processingMeetings.version, () => {
+  void loadMeetings();
+});
 
 function toggleLeftPanel(): void {
   leftPanelVisible.value = !leftPanelVisible.value;
@@ -882,6 +950,13 @@ async function onRecorderPhase(phase: RecorderPhase | null): Promise<void> {
   if (phase === 'failed') {
     if (pendingWasMounted) await pendingUploads.value?.refresh();
   } else if (phase === 'success') {
+    // The upload landed but the server still has to transcribe it. RecorderStrip
+    // clears recordingMeetingId only *after* this callback (see the comment on
+    // the 'closed' branch), so the id is still readable here — track it so the
+    // row and detail panel say "processing" once the pill's checkmark closes.
+    if (activeBackend.value?.id === 'ariso' && recordingMeetingId.value) {
+      processingMeetings.markUploaded(recordingMeetingId.value);
+    }
     await Promise.all([
       loadMeetings(),
       pendingWasMounted ? pendingUploads.value?.refresh() : Promise.resolve(),
@@ -1173,6 +1248,9 @@ onMounted(() => {
     selectedItem.value = null;
     userSelectedMeetingId.value = null;
     pinnedMeetings.value = new Map();
+    // The tracked ids are Ariso's; keeping them alive would keep polling its
+    // API from offline mode and re-show "Processing…" on a later switch back.
+    processingMeetings.reset();
     void loadMeetings();
   }).then((un) => {
     unlistenBackendChanged = un;
@@ -1586,6 +1664,23 @@ onUnmounted(() => {
   white-space: nowrap;
 }
 .mi-sub--now { color: #2e8b4f; font-weight: 500; }
+/* Sits where the time/duration sub-line normally does, so a processing row is
+   the same height as every other one. */
+.mi-sub--processing {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.mi-spinner {
+  flex: 0 0 10px;
+  width: 10px;
+  height: 10px;
+  border: 1.5px solid #dedbd6;
+  border-bottom-color: #6f6f6f;
+  border-radius: 50%;
+  animation: mi-spin 0.7s linear infinite;
+}
+@keyframes mi-spin { to { transform: rotate(360deg); } }
 
 /* Bottom nav */
 .bottom-nav {

--- a/src/views/MeetingDetailView.test.ts
+++ b/src/views/MeetingDetailView.test.ts
@@ -40,6 +40,41 @@ vi.mock('../composables/useMeetingNotesPersistence', () => ({
 vi.mock('../composables/usePlatformCapabilities', () => ({
   loadPlatformCapabilities: () => loadPlatformCapabilities(),
 }));
+// Stand-in for the session-scoped cloud upload tracker. `trackProcessing` /
+// `resolveProcessing` play the part of "we just uploaded this" and "the poll
+// found content"; the refs live inside the factory, which is hoisted.
+const processingMock = vi.hoisted(() => ({
+  tracked: null as null | import('vue').Ref<Set<string>>,
+  version: null as null | import('vue').Ref<number>,
+}));
+vi.mock('../composables/useMeetingProcessing', async () => {
+  const { ref } = await import('vue');
+  const tracked = ref(new Set<string>());
+  const version = ref(0);
+  processingMock.tracked = tracked;
+  processingMock.version = version;
+  return {
+    useMeetingProcessing: () => ({
+      markUploaded: (id: string | number) => {
+        tracked.value = new Set(tracked.value).add(String(id));
+      },
+      isProcessing: (id: string | number) => tracked.value.has(String(id)),
+      version,
+      reset: () => {
+        tracked.value = new Set();
+      },
+    }),
+  };
+});
+function trackProcessing(id: string): void {
+  processingMock.tracked!.value = new Set(processingMock.tracked!.value).add(id);
+}
+function resolveProcessing(id: string): void {
+  const next = new Set(processingMock.tracked!.value);
+  next.delete(id);
+  processingMock.tracked!.value = next;
+  processingMock.version!.value++;
+}
 vi.mock('../tauri', () => ({
   api: {
     request: (...a: unknown[]) => apiRequest(...a),
@@ -91,6 +126,8 @@ beforeEach(() => {
   // clearAllMocks keeps queued `mockResolvedValueOnce` implementations, so an
   // unconsumed one would answer the next test's first detail load.
   getMeetingDetail.mockReset();
+  processingMock.tracked!.value = new Set();
+  processingMock.version!.value = 0;
   renameMeeting.mockResolvedValue(undefined);
   getMeetingTranscript.mockResolvedValue(null);
   getMeetingAudio.mockResolvedValue(null);
@@ -996,6 +1033,126 @@ describe('MeetingDetailView local generation progress', () => {
     // A note exists (old body) but notes are generating -> chip owns the row.
     expect(wrapper.find('.tab-status-label').text()).toBe('Generating AI Notes');
     expect(wrapper.find('.tab-regen').exists()).toBe(false);
+  });
+
+  // The Library row reads the pipeline state from the list payload, which only
+  // refreshes on a reload — this panel owns the live poll, so it has to say when
+  // the recording settles.
+  // The poll is on a 2s timer, so these mount under fake timers rather than
+  // starting them mid-flight — a timer scheduled for real never fires once the
+  // fakes take over.
+  async function mountLocalFaked(d: MeetingDetail) {
+    vi.useFakeTimers();
+    getMeetingDetail.mockResolvedValue(d);
+    const wrapper = mount(MeetingDetailView, { props: { item: localItem } });
+    await vi.advanceTimersByTimeAsync(0);
+    return wrapper;
+  }
+
+  it('tells the parent when a local recording finishes generating', async () => {
+    recordingStatus.mockResolvedValue({
+      status: 'transcribing', hasTranscript: false, hasNote: false, notesStatus: 'pending',
+    });
+    const wrapper = await mountLocalFaked(detail({ isLocal: true }));
+    expect(wrapper.emitted('contentReady')).toBeUndefined();
+
+    recordingStatus.mockResolvedValue({
+      status: 'done', hasTranscript: true, hasNote: true, notesStatus: 'ready',
+    });
+    await vi.advanceTimersByTimeAsync(2000);
+
+    expect(wrapper.emitted('contentReady')).toEqual([[{ id: '7' }]]);
+  });
+
+  it('also reports a terminal failure, so the row stops claiming to be processing', async () => {
+    recordingStatus.mockResolvedValue({
+      status: 'transcribing', hasTranscript: false, hasNote: false, notesStatus: 'pending',
+    });
+    const wrapper = await mountLocalFaked(detail({ isLocal: true }));
+
+    recordingStatus.mockResolvedValue({
+      status: 'failed', hasTranscript: false, hasNote: false, notesStatus: 'pending',
+    });
+    await vi.advanceTimersByTimeAsync(2000);
+
+    expect(wrapper.emitted('contentReady')).toEqual([[{ id: '7' }]]);
+  });
+
+  // Also fires on the very first poll: a row that was listed while the recording
+  // was still transcribing is stale the moment it is opened and found finished.
+  // The Library ignores the report when its row wasn't claiming to be processing.
+  it('reports a recording found already finished on the first poll', async () => {
+    recordingStatus.mockResolvedValue({
+      status: 'done', hasTranscript: true, hasNote: true, notesStatus: 'ready',
+    });
+    readRecordingFile.mockResolvedValue('AI body');
+    const wrapper = await mountLocal(detail({ isLocal: true, note: 'AI body', hasTranscript: true }));
+    await flushPromises();
+
+    expect(wrapper.emitted('contentReady')).toEqual([[{ id: '7' }]]);
+  });
+
+  it('says nothing for an Ariso meeting, which has no local pipeline', async () => {
+    const wrapper = await mountLocal(detail({ isLocal: false, digest: 'A digest' }));
+    await flushPromises();
+    expect(wrapper.emitted('contentReady')).toBeUndefined();
+  });
+});
+
+// Ariso exposes no processing status for an uploaded recording, so the chip is
+// driven by this session's own upload tracking (#315).
+describe('MeetingDetailView cloud processing chip', () => {
+  it('shows a spinner chip with no Retry while an uploaded meeting is processing', async () => {
+    trackProcessing('7');
+    const wrapper = await mountWith(detail({ isLocal: false }));
+
+    expect(wrapper.find('.tab-status-label').text()).toBe(
+      'Uploaded — processing transcript & notes…'
+    );
+    expect(wrapper.find('.tab-status .spinner').exists()).toBe(true);
+    expect(wrapper.find('.tab-retry').exists()).toBe(false);
+  });
+
+  // A meeting nobody uploaded this session is indistinguishable from one that
+  // will never have notes; it keeps the plain empty state it has always had.
+  it('leaves an untracked empty meeting unchanged', async () => {
+    const wrapper = await mountWith(detail({ isLocal: false }));
+
+    expect(wrapper.find('.tab-status').exists()).toBe(false);
+    expect(wrapper.find('.content-empty').text()).toBe('No notes available for this meeting yet.');
+  });
+
+  it('drops the chip and refetches the meeting once its content lands', async () => {
+    trackProcessing('7');
+    const wrapper = await mountWith(detail({ isLocal: false }));
+    getMeetingDetail.mockResolvedValue(detail({ isLocal: false, hasTranscript: true }));
+
+    resolveProcessing('7');
+    await flushPromises();
+
+    expect(wrapper.find('.tab-status').exists()).toBe(false);
+    expect(wrapper.findAll('.seg-btn').map((b) => b.text())).toContain('Transcript');
+  });
+
+  // Selecting another meeting also clears the tracked-and-open condition; that
+  // must not fire a second fetch on top of the selection's own load.
+  it('does not refetch when the tracked meeting is simply closed', async () => {
+    // Its own meeting id: wrappers mounted by earlier tests in this file stay
+    // alive and would react to tracking changes for the shared id.
+    const openItem: MeetingListItem = { id: '99', title: 'Rec', timestamp: '2026-06-02T10:00:00Z' };
+    trackProcessing('99');
+    getMeetingDetail.mockResolvedValue(detail({ id: '99', isLocal: false }));
+    const wrapper = mount(MeetingDetailView, { props: { item: openItem } });
+    await flushPromises();
+    getMeetingDetail.mockClear();
+
+    await wrapper.setProps({ item: null });
+    await flushPromises();
+    resolveProcessing('99');
+    await flushPromises();
+
+    expect(getMeetingDetail).not.toHaveBeenCalled();
+    wrapper.unmount();
   });
 });
 

--- a/src/views/MeetingDetailView.vue
+++ b/src/views/MeetingDetailView.vue
@@ -160,8 +160,11 @@
         @close="closeSpeakers"
       />
 
-      <!-- Tabs + generation status -->
-      <div v-if="availableTabs.length" class="card-tabs">
+      <!-- Tabs + generation status. The row also carries the status chip on its
+           own: a cloud meeting still being processed has no tabs yet, and the
+           chip is the only thing that tells it apart from one that will never
+           have notes. -->
+      <div v-if="availableTabs.length || showStatusChip" class="card-tabs">
         <div class="segment">
           <button
             v-for="t in availableTabs"
@@ -429,7 +432,11 @@ import { composeLocalShareText } from './meetingShareText';
 import { transcriptFilename } from './transcriptDownloadName';
 import { shareTextNative, local, pickMarkdownSavePath } from '../tauri';
 import { ariJoinChip } from '../composables/meetingStatus';
-import { useLocalRecordingProgress } from '../composables/useLocalRecordingProgress';
+import {
+  useLocalRecordingProgress,
+  type LocalProgressStage,
+} from '../composables/useLocalRecordingProgress';
+import { useMeetingProcessing } from '../composables/useMeetingProcessing';
 import { loadPlatformCapabilities } from '../composables/usePlatformCapabilities';
 
 // `now` is the parent's ticking clock — it lets the Ari chip retire itself when
@@ -438,6 +445,10 @@ const props = defineProps<{ item: MeetingListItem | null; now?: Date }>();
 const emit = defineEmits<{
   close: [];
   titleUpdated: [payload: { id: string; title: string }];
+  /** A local recording's generation pipeline reached a terminal state while this
+   *  panel was open. The Library reloads its list so the row drops its
+   *  "Processing…" sub-line and picks up the finished content. */
+  contentReady: [payload: { id: string }];
 }>();
 
 const loading = ref(false);
@@ -696,15 +707,32 @@ let detailBackend: Backend | null = null;
 // recording stops. This poller drives the inline status chip and tab enabling.
 const progress = useLocalRecordingProgress(() => (detail.value?.isLocal ? detail.value.id : null));
 
+// Cloud meetings have no server-side "processing" status to read, so the chip
+// keys off this session's own upload tracking instead (useMeetingProcessing).
+// A meeting nobody uploaded this session is never tracked and falls through to
+// the plain empty state, unchanged.
+const processingMeetings = useMeetingProcessing();
+const cloudProcessing = computed(
+  () => !!detail.value && !detail.value.isLocal && processingMeetings.isProcessing(detail.value.id)
+);
+
 const showStatusChip = computed(
   () =>
-    !!detail.value?.isLocal &&
-    ['transcribing', 'notes-pending', 'transcript-failed', 'notes-failed'].includes(progress.stage.value)
+    cloudProcessing.value ||
+    (!!detail.value?.isLocal &&
+      ['transcribing', 'notes-pending', 'transcript-failed', 'notes-failed'].includes(progress.stage.value))
 );
+// Cloud has no post-upload failure signal, so its chip is always the spinner
+// variant — there is nothing to offer a Retry for.
 const statusGenerating = computed(
-  () => progress.stage.value === 'transcribing' || progress.stage.value === 'notes-pending'
+  () =>
+    cloudProcessing.value ||
+    progress.stage.value === 'transcribing' ||
+    progress.stage.value === 'notes-pending'
 );
 const statusLabel = computed(() => {
+  // One combined stage server-side: no transcript/notes split like local's.
+  if (cloudProcessing.value) return 'Uploaded — processing transcript & notes…';
   switch (progress.stage.value) {
     case 'transcribing':
       return 'Generating Transcript';
@@ -722,6 +750,30 @@ function onRetry(): void {
   if (progress.stage.value === 'transcript-failed') void progress.retryTranscription();
   else if (progress.stage.value === 'notes-failed') void progress.retryNotes();
 }
+
+// A cloud meeting we were tracking just gained content. Nothing about the list
+// row changes when a transcript lands (same id, timestamp, prepId), so the
+// load() watcher below can't see it — refetch the detail here or the pane keeps
+// showing its empty state after the chip goes away.
+watch(cloudProcessing, (isProcessing, was) => {
+  if (!was || isProcessing) return;
+  // It also goes false when load() clears `detail` for a *different* meeting;
+  // only the still-open one deserves a refetch.
+  const item = props.item;
+  if (item && detail.value?.id === item.id) void load(item);
+});
+
+const TERMINAL_STAGES: LocalProgressStage[] = ['ready', 'transcript-failed', 'notes-failed'];
+
+// The Library row reads its "Processing…" state from the list payload, which is
+// only refetched on a reload. Tell the parent the moment this recording's
+// pipeline settles so the row it is showing stops claiming to be in flight.
+watch(progress.stage, (next, prev) => {
+  const d = detail.value;
+  if (!d?.isLocal) return;
+  if (!TERMINAL_STAGES.includes(next) || TERMINAL_STAGES.includes(prev)) return;
+  emit('contentReady', { id: d.id });
+});
 
 // Local AI Notes can be regenerated from the transcript on demand. Shown only on
 // the AI Notes tab once a note already exists and nothing is in flight (the

--- a/src/views/PendingUploads.test.ts
+++ b/src/views/PendingUploads.test.ts
@@ -9,6 +9,7 @@ const bufferPath = vi.fn();
 const checkSession = vi.fn();
 const combineAndUpload = vi.fn();
 const discardAll = vi.fn();
+const markUploaded = vi.fn();
 
 vi.mock('../tauri', () => ({
   auth: { checkSession: (...a: unknown[]) => checkSession(...a) },
@@ -22,6 +23,9 @@ vi.mock('../tauri', () => ({
 vi.mock('../composables/usePendingUploads', () => ({
   combineAndUpload: (...a: unknown[]) => combineAndUpload(...a),
   discardAll: (...a: unknown[]) => discardAll(...a),
+}));
+vi.mock('../composables/useMeetingProcessing', () => ({
+  useMeetingProcessing: () => ({ markUploaded: (...a: unknown[]) => markUploaded(...a) }),
 }));
 
 import PendingUploads from './PendingUploads.vue';
@@ -109,7 +113,7 @@ describe('PendingUploads', () => {
 
   it('Upload combines+uploads, refreshes, and emits uploaded on success', async () => {
     list.mockResolvedValueOnce(items).mockResolvedValueOnce([]);
-    combineAndUpload.mockResolvedValue(undefined);
+    combineAndUpload.mockResolvedValue([]);
     const wrapper = mount(PendingUploads);
     await flushPromises();
 
@@ -119,6 +123,32 @@ describe('PendingUploads', () => {
     expect(combineAndUpload).toHaveBeenCalledWith(items);
     expect(wrapper.emitted('uploaded')).toHaveLength(1);
     expect(wrapper.find('.pending').exists()).toBe(false);
+  });
+
+  // The retry hands the audio over but the server still has to transcribe it;
+  // tracking each meeting is what puts "Processing…" on its Library row.
+  it('marks every uploaded meeting as processing', async () => {
+    list.mockResolvedValueOnce(items).mockResolvedValueOnce([]);
+    combineAndUpload.mockResolvedValue([5, 9]);
+    const wrapper = mount(PendingUploads);
+    await flushPromises();
+
+    await wrapper.find('.upload').trigger('click');
+    await flushPromises();
+
+    expect(markUploaded.mock.calls).toEqual([[5], [9]]);
+  });
+
+  it('marks nothing when the upload fails', async () => {
+    list.mockResolvedValue(items);
+    combineAndUpload.mockRejectedValue(new Error('offline'));
+    const wrapper = mount(PendingUploads);
+    await flushPromises();
+
+    await wrapper.find('.upload').trigger('click');
+    await flushPromises();
+
+    expect(markUploaded).not.toHaveBeenCalled();
   });
 
   it('shows an error and keeps items when upload fails', async () => {

--- a/src/views/PendingUploads.test.ts
+++ b/src/views/PendingUploads.test.ts
@@ -23,12 +23,18 @@ vi.mock('../tauri', () => ({
 vi.mock('../composables/usePendingUploads', () => ({
   combineAndUpload: (...a: unknown[]) => combineAndUpload(...a),
   discardAll: (...a: unknown[]) => discardAll(...a),
+  PartialUploadError: class PartialUploadError extends Error {
+    constructor(public readonly uploadedMeetingIds: number[], cause: unknown) {
+      super(cause instanceof Error ? cause.message : String(cause));
+    }
+  },
 }));
 vi.mock('../composables/useMeetingProcessing', () => ({
   useMeetingProcessing: () => ({ markUploaded: (...a: unknown[]) => markUploaded(...a) }),
 }));
 
 import PendingUploads from './PendingUploads.vue';
+import { PartialUploadError } from '../composables/usePendingUploads';
 import RecordingAudioPlayer from './RecordingAudioPlayer.vue';
 
 const items = [
@@ -149,6 +155,22 @@ describe('PendingUploads', () => {
     await flushPromises();
 
     expect(markUploaded).not.toHaveBeenCalled();
+  });
+
+  // A partial failure (one group uploaded, another rejected) must not drop
+  // the succeeded meeting on the floor — it still needs to show "Processing…".
+  it('marks succeeded meetings as processing and still shows an error on a partial failure', async () => {
+    list.mockResolvedValueOnce(items).mockResolvedValueOnce([items[1]]);
+    combineAndUpload.mockRejectedValue(new PartialUploadError([5], new Error('offline')));
+    const wrapper = mount(PendingUploads);
+    await flushPromises();
+
+    await wrapper.find('.upload').trigger('click');
+    await flushPromises();
+
+    expect(markUploaded).toHaveBeenCalledWith(5);
+    expect(wrapper.find('.pending-error').text()).toBe('Upload failed — try again.');
+    expect(list).toHaveBeenCalledTimes(2);
   });
 
   it('shows an error and keeps items when upload fails', async () => {

--- a/src/views/PendingUploads.vue
+++ b/src/views/PendingUploads.vue
@@ -52,7 +52,7 @@
 <script setup lang="ts">
 import { ref, onMounted } from 'vue';
 import { auth, pending, type PendingUploadMeta } from '../tauri';
-import { combineAndUpload, discardAll } from '../composables/usePendingUploads';
+import { combineAndUpload, discardAll, PartialUploadError } from '../composables/usePendingUploads';
 import { useMeetingProcessing } from '../composables/useMeetingProcessing';
 import RecordingAudioPlayer from './RecordingAudioPlayer.vue';
 
@@ -141,6 +141,13 @@ async function onUpload(): Promise<void> {
     emit('uploaded');
   } catch (e) {
     console.error('Pending upload failed', e);
+    // A partial failure still uploaded some groups — track those as processing
+    // and refresh so they drop off the pending list, even though we surface
+    // the failure for the group that didn't make it.
+    if (e instanceof PartialUploadError && e.uploadedMeetingIds.length > 0) {
+      for (const id of e.uploadedMeetingIds) processing.markUploaded(id);
+      await refresh();
+    }
     error.value = uploadErrorMessage(e);
   } finally {
     busy.value = false;

--- a/src/views/PendingUploads.vue
+++ b/src/views/PendingUploads.vue
@@ -53,7 +53,10 @@
 import { ref, onMounted } from 'vue';
 import { auth, pending, type PendingUploadMeta } from '../tauri';
 import { combineAndUpload, discardAll } from '../composables/usePendingUploads';
+import { useMeetingProcessing } from '../composables/useMeetingProcessing';
 import RecordingAudioPlayer from './RecordingAudioPlayer.vue';
+
+const processing = useMeetingProcessing();
 
 const emit = defineEmits<{ uploaded: [] }>();
 
@@ -129,7 +132,11 @@ async function onUpload(): Promise<void> {
       error.value = 'Upload failed — sign in to Ari again, then retry.';
       return;
     }
-    await combineAndUpload(items.value);
+    const meetingIds = await combineAndUpload(items.value);
+    // The audio is in, but the server still has to transcribe it. Track each
+    // meeting so its Library row and detail panel say "processing" instead of
+    // showing the same empty state as a meeting that will never have notes.
+    for (const id of meetingIds) processing.markUploaded(id);
     await refresh();
     emit('uploaded');
   } catch (e) {


### PR DESCRIPTION
<!--
Thanks for contributing to oats! A few quick things before you open this PR.
See CONTRIBUTING.md for the full guide.
-->

## What does this PR do?

Fixes #315

<!-- A short summary of the change and the problem it solves. Link any related issue, e.g. "Closes #123". -->

## Type of change

<!-- Releases are automated by release-please from your commit messages. -->
<!-- Make sure your PR title / commits follow Conventional Commits: -->
<!--   feat: ...        → minor bump        fix: ...   → patch bump -->
<!--   feat!: / BREAKING CHANGE: → major bump   chore/docs/refactor: → no release -->

- [ ] `fix:` — bug fix
- [x] `feat:` — new feature
- [ ] `feat!:` / `BREAKING CHANGE:` — breaking change
- [ ] `docs:` / `chore:` / `refactor:` — no user-facing release

## How was this tested?

<!-- Did you run the frontend tests (`npm test`)? Test manually with which backend (Ariso / Local)? On which OS/platform? -->

## Screenshots / recordings

<!-- For any UI change, drop a before/after screenshot or short clip here. -->

## Checklist

- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I ran `npm test` and the suite passes
- [x] I tested the change in the app (note which backend above)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added processing indicators while meeting transcripts or notes are being generated.
  * Meeting details and the library now refresh automatically when content becomes available.
  * Uploaded meetings, including cloud uploads, are tracked until processing completes.
  * Pending uploads continue tracking successfully uploaded meetings.

* **Bug Fixes**
  * Improved handling of incomplete content, transient processing failures, and recording completion updates.
  * Partial upload failures now preserve successful uploads while displaying the failure.
  * Prevented unnecessary library and meeting-detail refreshes when processing has not completed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->