### PR TITLE
feat: tweak term

### DIFF
--- a/src/views/UpNextCard.test.ts
+++ b/src/views/UpNextCard.test.ts
@@ -130,17 +130,19 @@ describe('UpNextCard', () => {
     expect(wrapper.emitted('select')?.[0]?.[0]).toMatchObject({ id: 'a' });
   });
 
-  it('emits record when the Impromptu Meeting button is clicked', async () => {
+  it('emits record when the New Meeting button is clicked', async () => {
     const wrapper = mountCard([meeting({ id: 'a' })]);
     await flushPromises();
-    await wrapper.find('.impromptu-btn').trigger('click');
+    expect(wrapper.find('.new-meeting-label').text()).toBe('New Meeting');
+    await wrapper.find('.new-meeting-btn').trigger('click');
     expect(wrapper.emitted('record')).toHaveLength(1);
   });
 
-  it('shows the Impromptu Meeting button even with no upcoming meetings', async () => {
+  it('shows the New Meeting button even with no upcoming meetings', async () => {
     const wrapper = mountCard([meeting({ id: 'past', timestamp: '2020-01-01T00:00:00Z', endTimestamp: '2020-01-01T01:00:00Z' })]);
     await flushPromises();
-    expect(wrapper.find('.impromptu-btn').exists()).toBe(true);
+    expect(wrapper.find('.new-meeting-btn').exists()).toBe(true);
+    expect(wrapper.find('.new-meeting-label').text()).toBe('New Meeting');
   });
 
   it('pages between upcoming meetings with the chevrons', async () => {

--- a/src/views/UpNextCard.vue
+++ b/src/views/UpNextCard.vue
@@ -2,15 +2,15 @@
   <div class="up-next">
     <!-- Big serif date/time heading for the empty home state. -->
     <p class="greeting">{{ greeting }}</p>
-    <!-- Greeting prompt: oats mark + chat bubble, with the impromptu-record CTA
+    <!-- Greeting prompt: oats mark + chat bubble, with the new-meeting CTA
          tucked under the bubble's bottom-right corner. -->
     <div class="prompt">
       <img class="prompt-logo" :src="oatsLogo" alt="oats" />
       <div class="prompt-body">
-        <p class="prompt-bubble">Ready for the next meet? Or do you want to spin up an impromptu meeting?</p>
-        <button class="impromptu-btn" type="button" title="Start an impromptu recording" @click="$emit('record')">
-          <span class="impromptu-label">Impromptu Meeting</span>
-          <span class="impromptu-icon" aria-hidden="true">
+        <p class="prompt-bubble">Ready for the next meet? Or do you want to spin up a new meeting?</p>
+        <button class="new-meeting-btn" type="button" title="Start a new recording" @click="$emit('record')">
+          <span class="new-meeting-label">New Meeting</span>
+          <span class="new-meeting-icon" aria-hidden="true">
             <svg viewBox="0 0 16 16">
               <circle cx="8" cy="8" r="6.5" fill="none" stroke="#e0443e" stroke-width="1.5" />
               <circle cx="8" cy="8" r="3.5" fill="#e0443e" />
@@ -387,9 +387,9 @@ function rowSub(m: MeetingListItem): string {
   color: #1c1c1c;
 }
 
-/* Primary split CTA — black "Impromptu Meeting" label + record-dot segment,
+/* Primary split CTA — black "New Meeting" label + record-dot segment,
    overlapping the bubble's bottom-right corner. */
-.impromptu-btn {
+.new-meeting-btn {
   align-self: flex-end;
   position: relative;
   z-index: 1;
@@ -406,8 +406,8 @@ function rowSub(m: MeetingListItem): string {
   font-family: inherit;
   transition: transform 0.1s, box-shadow 0.1s;
 }
-.impromptu-btn:hover { box-shadow: 1px 1px 0 rgba(0, 0, 0, 0.12); transform: translate(1px, 1px); }
-.impromptu-label {
+.new-meeting-btn:hover { box-shadow: 1px 1px 0 rgba(0, 0, 0, 0.12); transform: translate(1px, 1px); }
+.new-meeting-label {
   display: flex;
   align-items: center;
   padding: 8px 12px 8px 16px;
@@ -416,14 +416,14 @@ function rowSub(m: MeetingListItem): string {
   color: #ffffff;
   white-space: nowrap;
 }
-.impromptu-icon {
+.new-meeting-icon {
   display: flex;
   align-items: center;
   justify-content: center;
   padding: 8px;
   border-left: 1px solid rgba(255, 255, 255, 0.22);
 }
-.impromptu-icon svg { width: 16px; height: 16px; display: block; }
+.new-meeting-icon svg { width: 16px; height: 16px; display: block; }
 
 /* "Up Next • …" label row with the prev/next chevrons. */
 .up-next-head {


### PR DESCRIPTION
<!--
Thanks for contributing to oats! A few quick things before you open this PR.
See CONTRIBUTING.md for the full guide.
-->

## What does this PR do?

closes #362

<!-- A short summary of the change and the problem it solves. Link any related issue, e.g. "Closes #123". -->

## Type of change

<!-- Releases are automated by release-please from your commit messages. -->
<!-- Make sure your PR title / commits follow Conventional Commits: -->
<!--   feat: ...        → minor bump        fix: ...   → patch bump -->
<!--   feat!: / BREAKING CHANGE: → major bump   chore/docs/refactor: → no release -->

- [ ] `fix:` — bug fix
- [x] `feat:` — new feature
- [ ] `feat!:` / `BREAKING CHANGE:` — breaking change
- [ ] `docs:` / `chore:` / `refactor:` — no user-facing release

## How was this tested?

<!-- Did you run the frontend tests (`npm test`)? Test manually with which backend (Ariso / Local)? On which OS/platform? -->

## Screenshots / recordings

<!-- For any UI change, drop a before/after screenshot or short clip here. -->

## Checklist

- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I ran `npm test` and the suite passes
- [x] I tested the change in the app (note which backend above)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **UI Updates**
  - Renamed the empty-state recording button from “Impromptu Meeting” to “New Meeting.”
  - Updated the related prompt and title text to match the new label.
  - The button continues to start a recording with the same appearance and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->