### PR TITLE
fix(notes): never generate notes from a speechless transcript

### DIFF
--- a/src-tauri/src/storage.rs
+++ b/src-tauri/src/storage.rs
@@ -26,7 +26,18 @@ pub enum NotesStatus {
     Pending,
     Ready,
     Failed,
+    /// Nothing was said in the recording, so notes were deliberately skipped.
+    /// Distinct from `Failed`: there is no fault to retry, and the UI names the
+    /// empty transcript instead of blaming notes generation.
+    #[serde(rename = "empty-transcript")]
+    EmptyTranscript,
 }
+
+/// Reason stored in `meta.notes_error` when a recording carries no speech.
+/// `derive_notes_status` recognizes it, so this is the single source of truth
+/// linking the skip (in `transcribe`) to the status the UI renders.
+pub const NO_SPEECH_NOTES_ERROR: &str =
+    "no speech detected in this recording — notes generation skipped";
 
 /// Classify AI-notes generation from the note file's presence and any recorded
 /// `notes_error`. A present `ari-note.md` always means success (a stale error
@@ -34,6 +45,8 @@ pub enum NotesStatus {
 pub fn derive_notes_status(has_note: bool, notes_error: Option<&str>) -> NotesStatus {
     if has_note {
         NotesStatus::Ready
+    } else if notes_error == Some(NO_SPEECH_NOTES_ERROR) {
+        NotesStatus::EmptyTranscript
     } else if notes_error.is_some() {
         NotesStatus::Failed
     } else {
@@ -1010,6 +1023,24 @@ mod tests {
     #[test]
     fn derive_notes_status_pending_when_no_note_no_error() {
         assert_eq!(derive_notes_status(false, None), NotesStatus::Pending);
+    }
+
+    #[test]
+    fn derive_notes_status_empty_transcript_for_the_no_speech_reason() {
+        // A recording with nothing said isn't a failure to report and retry —
+        // the UI names it for what it is.
+        assert_eq!(
+            derive_notes_status(false, Some(NO_SPEECH_NOTES_ERROR)),
+            NotesStatus::EmptyTranscript
+        );
+    }
+
+    #[test]
+    fn notes_status_empty_transcript_serializes_kebab_case() {
+        assert_eq!(
+            serde_json::to_string(&NotesStatus::EmptyTranscript).unwrap(),
+            r#""empty-transcript""#
+        );
     }
 
     #[test]

--- a/src-tauri/src/transcribe.rs
+++ b/src-tauri/src/transcribe.rs
@@ -177,10 +177,6 @@ fn transcript_changed(before: &Option<Vec<u8>>, after: &Option<Vec<u8>>) -> bool
     before != after
 }
 
-/// Reason recorded in `meta.notes_error` when a recording carries no speech.
-const NO_SPEECH_NOTES_ERROR: &str =
-    "no speech detected in this recording — notes generation skipped";
-
 /// Body of a rendered transcript, with the leading YAML frontmatter removed.
 fn transcript_body(md: &str) -> &str {
     let Some(rest) = md.strip_prefix("---\n") else {
@@ -260,7 +256,7 @@ async fn process_notes(dir: PathBuf, models: PathBuf, mut meta: RecordingMeta) {
         .as_deref()
         .is_some_and(|bytes| !transcript_has_speech(&String::from_utf8_lossy(bytes)))
     {
-        meta.notes_error = Some(NO_SPEECH_NOTES_ERROR.to_string());
+        meta.notes_error = Some(storage::NO_SPEECH_NOTES_ERROR.to_string());
         let _ = storage::write_meta(&dir, &meta);
         return;
     }

--- a/src-tauri/src/transcribe.rs
+++ b/src-tauri/src/transcribe.rs
@@ -177,6 +177,44 @@ fn transcript_changed(before: &Option<Vec<u8>>, after: &Option<Vec<u8>>) -> bool
     before != after
 }
 
+/// Reason recorded in `meta.notes_error` when a recording carries no speech.
+const NO_SPEECH_NOTES_ERROR: &str =
+    "no speech detected in this recording — notes generation skipped";
+
+/// Body of a rendered transcript, with the leading YAML frontmatter removed.
+fn transcript_body(md: &str) -> &str {
+    let Some(rest) = md.strip_prefix("---\n") else {
+        return md;
+    };
+    match rest.find("\n---\n") {
+        Some(i) => &rest[i + "\n---\n".len()..],
+        None => md,
+    }
+}
+
+/// Whether `line` is one of `render_markdown`'s `**Speaker 1** [00:00:00]`
+/// headers rather than transcribed speech.
+fn is_speaker_header(line: &str) -> bool {
+    let line = line.trim();
+    let Some(rest) = line.strip_prefix("**") else {
+        return false;
+    };
+    line.ends_with(']') && rest.find("** [").is_some_and(|label_len| label_len > 0)
+}
+
+/// Whether a rendered transcript carries any spoken words.
+///
+/// A recording whose microphone delivered pure silence still produces a
+/// well-formed transcript — frontmatter plus a speaker header with an empty
+/// body — and the notes model answers that by inventing a meeting that never
+/// happened. Everything that is neither frontmatter nor a speaker header counts
+/// as speech.
+fn transcript_has_speech(md: &str) -> bool {
+    transcript_body(md)
+        .lines()
+        .any(|line| !line.trim().is_empty() && !is_speaker_header(line))
+}
+
 /// Current instant as an RFC3339 string.
 fn now_rfc3339() -> String {
     chrono::Utc::now().to_rfc3339()
@@ -215,6 +253,17 @@ async fn process_notes(dir: PathBuf, models: PathBuf, mut meta: RecordingMeta) {
     // Capture the transcript this run generates from; if it changes while notes
     // run (a later append/regeneration), a newer run owns the result — discard.
     let before = std::fs::read(&transcript_path).ok();
+    // A speechless transcript gives the notes model nothing to summarize, and it
+    // fills the gap by fabricating a meeting. Refuse the run rather than write a
+    // plausible-looking note about something that was never said.
+    if before
+        .as_deref()
+        .is_some_and(|bytes| !transcript_has_speech(&String::from_utf8_lossy(bytes)))
+    {
+        meta.notes_error = Some(NO_SPEECH_NOTES_ERROR.to_string());
+        let _ = storage::write_meta(&dir, &meta);
+        return;
+    }
     let outcome = run_notes(&transcript_path, &models).await;
     if transcript_changed(&before, &std::fs::read(&transcript_path).ok()) {
         return;
@@ -1160,6 +1209,43 @@ mod tests {
         let meta = crate::storage::read_meta(&dir).unwrap();
         assert_eq!(meta.status, RecordingStatus::Done);
         assert!(meta.notes_error.is_some());
+        unsafe { std::env::remove_var("ARISO_ROOT"); }
+    }
+
+    #[tokio::test]
+    async fn finalize_skips_notes_when_transcript_has_no_speech() {
+        let tmp = tempfile::tempdir().unwrap();
+        // A silent recording (dead mic, nothing playing): STT returns a segment
+        // with no text, so the transcript body is only a speaker header. The
+        // notes model must not be asked to invent a meeting from that.
+        let json = r#"{"language":"en","durationSeconds":45.0,"segments":[{"speaker":"model-speaker-0","text":"","start":0.0,"end":0.0}]}"#;
+        let stub = write_stub(
+            tmp.path(),
+            StubBehavior::transcribe_success(json)
+                .with_notes(StubOutcome::success("# Notes\n- fabricated meeting")),
+        );
+        unsafe { std::env::set_var("ARISO_STT_BIN", &stub); }
+        unsafe { std::env::set_var("ARISO_ROOT", tmp.path()); }
+
+        let (res, notes_handle) = finalize_core(
+            tmp.path(), b"audio".to_vec(),
+            "T".into(), "2026-06-02T14:30:05Z".into(), 45,
+        ).await.unwrap();
+        notes_handle.await.unwrap();
+        unsafe { std::env::remove_var("ARISO_STT_BIN"); }
+
+        assert_eq!(res.status, RecordingStatus::Done);
+        assert!(
+            crate::vault::read_note(&res.id).unwrap().is_none(),
+            "a speechless transcript must not produce AI notes"
+        );
+        let dir = crate::storage::recordings_dir(tmp.path()).join(&res.id);
+        let meta = crate::storage::read_meta(&dir).unwrap();
+        assert!(
+            meta.notes_error.as_deref().unwrap_or("").contains("no speech"),
+            "expected a no-speech reason, got: {:?}",
+            meta.notes_error
+        );
         unsafe { std::env::remove_var("ARISO_ROOT"); }
     }
 

--- a/src-tauri/src/transcribe.rs
+++ b/src-tauri/src/transcribe.rs
@@ -256,6 +256,12 @@ async fn process_notes(dir: PathBuf, models: PathBuf, mut meta: RecordingMeta) {
         .as_deref()
         .is_some_and(|bytes| !transcript_has_speech(&String::from_utf8_lossy(bytes)))
     {
+        // Re-check against the current transcript: an append/regeneration may
+        // have raced this branch between the read above and here, and a newer
+        // run owns the result — don't clobber it with a stale notes_error.
+        if transcript_changed(&before, &std::fs::read(&transcript_path).ok()) {
+            return;
+        }
         meta.notes_error = Some(storage::NO_SPEECH_NOTES_ERROR.to_string());
         let _ = storage::write_meta(&dir, &meta);
         return;

--- a/src/composables/useLocalRecordingProgress.test.ts
+++ b/src/composables/useLocalRecordingProgress.test.ts
@@ -37,6 +37,11 @@ describe('deriveStage', () => {
   it('maps done+notes failed to notes-failed', () => {
     expect(deriveStage(view({ status: 'done', hasTranscript: true, notesStatus: 'failed' }))).toBe('notes-failed');
   });
+  it('maps done+empty transcript to notes-empty-transcript', () => {
+    expect(
+      deriveStage(view({ status: 'done', hasTranscript: true, notesStatus: 'empty-transcript' }))
+    ).toBe('notes-empty-transcript');
+  });
   it('maps done+note ready to ready', () => {
     expect(deriveStage(view({ status: 'done', hasTranscript: true, hasNote: true, notesStatus: 'ready' }))).toBe('ready');
   });

--- a/src/composables/useLocalRecordingProgress.ts
+++ b/src/composables/useLocalRecordingProgress.ts
@@ -8,6 +8,8 @@ export type LocalProgressStage =
   | 'transcript-failed'
   | 'notes-pending'
   | 'notes-failed'
+  /** Nothing was said: notes were skipped, and no retry can change that. */
+  | 'notes-empty-transcript'
   | 'ready';
 
 /** Derive the UI stage from a recording's status view. A present note ('ready')
@@ -18,6 +20,7 @@ export function deriveStage(s: RecordingStatusView | null): LocalProgressStage {
   if (s.status === 'recording' || s.status === 'transcribing') return 'transcribing';
   // status === 'done'
   if (s.hasNote || s.notesStatus === 'ready') return 'ready';
+  if (s.notesStatus === 'empty-transcript') return 'notes-empty-transcript';
   if (s.notesStatus === 'failed') return 'notes-failed';
   return 'notes-pending';
 }

--- a/src/tauri.ts
+++ b/src/tauri.ts
@@ -336,7 +336,9 @@ export interface RecordingSummary {
   hasTranscript: boolean;
 }
 
-export type NotesStatus = 'pending' | 'ready' | 'failed';
+/** `empty-transcript`: nothing was said, so notes were deliberately skipped —
+ *  not a failure, and nothing a retry can fix. */
+export type NotesStatus = 'pending' | 'ready' | 'failed' | 'empty-transcript';
 
 /** Mirrors the Rust `RecordingStatusView`. Drives the detail panel's local
  *  generation poller (tab enable/disable + the inline status chip). */

--- a/src/views/MeetingDetailView.test.ts
+++ b/src/views/MeetingDetailView.test.ts
@@ -965,6 +965,19 @@ describe('MeetingDetailView local generation progress', () => {
     expect(retryNotes).toHaveBeenCalledWith('7');
   });
 
+  it('names an empty transcript instead of blaming notes, with no Retry', async () => {
+    recordingStatus.mockResolvedValue({
+      status: 'done', hasTranscript: true, hasNote: false, notesStatus: 'empty-transcript',
+    });
+    const wrapper = await mountLocal(detail({ isLocal: true, hasTranscript: true }));
+    await flushPromises();
+
+    expect(wrapper.find('.tab-status-label').text()).toBe('Empty transcript');
+    // Nothing was said — regenerating cannot produce notes, so offering a retry
+    // would promise a fix that does not exist.
+    expect(wrapper.find('.tab-retry').exists()).toBe(false);
+  });
+
   it('shows a Retry button on transcript failure and calls retryTranscription', async () => {
     recordingStatus.mockResolvedValue({
       status: 'failed', hasTranscript: false, hasNote: false, notesStatus: 'pending',

--- a/src/views/MeetingDetailView.vue
+++ b/src/views/MeetingDetailView.vue
@@ -182,7 +182,7 @@
             {{ statusLabel }}
           </span>
           <button
-            v-if="!statusGenerating"
+            v-if="showRetry"
             class="tab-retry"
             type="button"
             :disabled="progress.retrying.value"
@@ -720,7 +720,7 @@ const showStatusChip = computed(
   () =>
     cloudProcessing.value ||
     (!!detail.value?.isLocal &&
-      ['transcribing', 'notes-pending', 'transcript-failed', 'notes-failed'].includes(progress.stage.value))
+      ['transcribing', 'notes-pending', 'transcript-failed', 'notes-failed', 'notes-empty-transcript'].includes(progress.stage.value))
 );
 // Cloud has no post-upload failure signal, so its chip is always the spinner
 // variant — there is nothing to offer a Retry for.
@@ -742,10 +742,18 @@ const statusLabel = computed(() => {
       return 'Transcript failed';
     case 'notes-failed':
       return 'AI Notes failed';
+    case 'notes-empty-transcript':
+      return 'Empty transcript';
     default:
       return '';
   }
 });
+// An empty transcript is a settled outcome, not a fault: nothing was said, so
+// re-running generation would only reach the same conclusion. Every other
+// non-generating stage has a real retry to offer.
+const showRetry = computed(
+  () => !statusGenerating.value && progress.stage.value !== 'notes-empty-transcript'
+);
 function onRetry(): void {
   if (progress.stage.value === 'transcript-failed') void progress.retryTranscription();
   else if (progress.stage.value === 'notes-failed') void progress.retryNotes();
@@ -763,7 +771,12 @@ watch(cloudProcessing, (isProcessing, was) => {
   if (item && detail.value?.id === item.id) void load(item);
 });
 
-const TERMINAL_STAGES: LocalProgressStage[] = ['ready', 'transcript-failed', 'notes-failed'];
+const TERMINAL_STAGES: LocalProgressStage[] = [
+  'ready',
+  'transcript-failed',
+  'notes-failed',
+  'notes-empty-transcript',
+];
 
 // The Library row reads its "Processing…" state from the list payload, which is
 // only refetched on a reload. Tell the parent the moment this recording's


### PR DESCRIPTION
A recording whose microphone delivered pure silence still produces a well-formed transcript: YAML frontmatter plus a `**Speaker 1** [00:00:00]` header with an empty body. Handed that, the local notes model fills the gap by inventing a meeting — one such 45-second silent recording produced a full summary, key points, a decision, and a dated action item about a marketing campaign that was never discussed.

Gate `process_notes` on `transcript_has_speech()`, which strips the frontmatter and the speaker headers and asks whether anything is left. When nothing is, record `meta.notes_error` and never invoke the sidecar. Covers regeneration too, since `retry_notes_core` funnels through `process_notes`.

<!--
Thanks for contributing to oats! A few quick things before you open this PR.
See CONTRIBUTING.md for the full guide.
-->

## What does this PR do?

<!-- A short summary of the change and the problem it solves. Link any related issue, e.g. "Closes #123". -->

## Type of change

<!-- Releases are automated by release-please from your commit messages. -->
<!-- Make sure your PR title / commits follow Conventional Commits: -->
<!--   feat: ...        → minor bump        fix: ...   → patch bump -->
<!--   feat!: / BREAKING CHANGE: → major bump   chore/docs/refactor: → no release -->

- [ ] `fix:` — bug fix
- [x] `feat:` — new feature
- [ ] `feat!:` / `BREAKING CHANGE:` — breaking change
- [ ] `docs:` / `chore:` / `refactor:` — no user-facing release

## How was this tested?

<!-- Did you run the frontend tests (`npm test`)? Test manually with which backend (Ariso / Local)? On which OS/platform? -->

## Screenshots / recordings

<!-- For any UI change, drop a before/after screenshot or short clip here. -->

## Checklist

- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I ran `npm test` and the suite passes
- [x] I tested the change in the app (note which backend above)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated “Empty transcript” status for recordings where no speech is detected.
  * Silent recordings remain marked as complete while clearly indicating why notes were not generated.
  * Added a dedicated progress stage for completed recordings with empty transcripts.

* **Bug Fixes**
  * Prevented outdated notes-generation results from overwriting newer transcript changes.
  * Retry remains available for other notes-generation failures, while empty transcripts do not offer retry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->