### PR TITLE
fix(library): stop the list↔detail reload loop on an empty transcript

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1562,6 +1562,8 @@ pub fn list_local_recordings() -> Result<Vec<crate::storage::RecordingSummary>, 
     for s in &mut summaries {
         if vault_notes.contains_key(&s.id) {
             s.has_note = true;
+            // A present note always wins over a stale `notes_error`.
+            s.notes_status = crate::storage::NotesStatus::Ready;
         }
         if let Some(af) = &s.audio_file {
             // New recording: audio lives in the vault; reflect real existence
@@ -3166,6 +3168,31 @@ mod tests {
 
         let list = list_local_recordings().unwrap();
         assert!(list.iter().find(|s| s.id == id).unwrap().has_note);
+        unsafe { std::env::remove_var("ARISO_ROOT"); }
+    }
+
+    #[test]
+    fn list_local_recordings_vault_note_makes_notes_status_ready() {
+        // SAFETY: command tests run with --test-threads=1 (see plan conventions),
+        // so the process-wide ARISO_ROOT mutation below has no concurrent writer.
+        let tmp = tempfile::tempdir().unwrap();
+        unsafe { std::env::set_var("ARISO_ROOT", tmp.path()); }
+        let root = crate::vault::meta_root().unwrap();
+        let id = "2026-06-02T10-00-00Z";
+        let dir = crate::storage::create_recording_dir(&root, id).unwrap();
+        let mut meta = test_meta(id);
+        meta.audio_file = Some("clip.mp3".into());
+        // A stale error from an earlier attempt: the vault note that exists now
+        // must still win, exactly as `local_recording_status` reports it.
+        meta.notes_error = Some("boom".into());
+        crate::storage::write_meta(&dir, &meta).unwrap();
+        crate::vault::write_note("2026-06-02 clip", &meta, "clip.mp3", "b").unwrap();
+
+        let list = list_local_recordings().unwrap();
+        assert_eq!(
+            list.iter().find(|s| s.id == id).unwrap().notes_status,
+            crate::storage::NotesStatus::Ready
+        );
         unsafe { std::env::remove_var("ARISO_ROOT"); }
     }
 

--- a/src-tauri/src/storage.rs
+++ b/src-tauri/src/storage.rs
@@ -147,6 +147,11 @@ pub struct RecordingSummary {
     pub has_note: bool,
     /// Whether `transcript.md` exists in the recording's directory.
     pub has_transcript: bool,
+    /// AI-notes outcome, derived like [`RecordingStatusView::notes_status`] so
+    /// the Library row can tell a settled note-less recording from one still
+    /// generating. Like `has_note`, this layer only sees the legacy
+    /// `ari-note.md`; the command layer's vault overlay upgrades it to `Ready`.
+    pub notes_status: NotesStatus,
     /// The recording's vault audio attachment name (from meta), used by the
     /// command layer to verify the attachment still exists. Not serialized to
     /// the frontend.
@@ -532,6 +537,7 @@ pub fn list_recordings(root: &Path) -> Result<Vec<RecordingSummary>, String> {
         match read_meta(&entry.path()) {
             Ok(m) => {
                 let recording_dir = entry.path();
+                let has_note = recording_dir.join("ari-note.md").is_file();
                 out.push(RecordingSummary {
                     id: m.id,
                     title: m.title,
@@ -541,8 +547,9 @@ pub fn list_recordings(root: &Path) -> Result<Vec<RecordingSummary>, String> {
                     last_clip_end_at: m.last_clip_end_at,
                     has_audio: m.audio_file.is_some()
                         || recording_dir.join("recording.mp3").is_file(),
-                    has_note: recording_dir.join("ari-note.md").is_file(),
+                    has_note,
                     has_transcript: recording_dir.join("transcript.md").is_file(),
+                    notes_status: derive_notes_status(has_note, m.notes_error.as_deref()),
                     audio_file: m.audio_file.clone(),
                 });
             }
@@ -743,6 +750,35 @@ mod tests {
         assert!(!list[1].has_audio);
         assert!(!list[1].has_note);
         assert!(!list[1].has_transcript);
+    }
+
+    #[test]
+    fn lists_recordings_carry_derived_notes_status() {
+        // The Library row can only stop claiming "Processing…" for a recording
+        // whose notes settled without a note if the list says so.
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        let cases = [
+            ("2026-06-01T10-00-00Z", None, false, NotesStatus::Pending),
+            ("2026-06-02T10-00-00Z", Some(NO_SPEECH_NOTES_ERROR), false, NotesStatus::EmptyTranscript),
+            ("2026-06-03T10-00-00Z", Some("boom"), false, NotesStatus::Failed),
+            ("2026-06-04T10-00-00Z", Some("boom"), true, NotesStatus::Ready),
+        ];
+        for (id, notes_error, has_note, _) in &cases {
+            let dir = create_recording_dir(root, id).unwrap();
+            let mut m = meta_with(id, &id.replace("-00-00Z", ":00:00Z"));
+            m.notes_error = notes_error.map(str::to_string);
+            write_meta(&dir, &m).unwrap();
+            if *has_note {
+                std::fs::write(dir.join("ari-note.md"), b"notes").unwrap();
+            }
+        }
+
+        let list = list_recordings(root).unwrap();
+        for (id, _, _, expected) in &cases {
+            let s = list.iter().find(|s| s.id == *id).unwrap();
+            assert_eq!(s.notes_status, *expected, "{id}");
+        }
     }
 
     #[test]

--- a/src/composables/useBackend.test.ts
+++ b/src/composables/useBackend.test.ts
@@ -164,6 +164,22 @@ describe('LocalBackend', () => {
     ]);
   });
 
+  // The Library row needs it to tell a settled note-less recording from one
+  // whose notes are still generating.
+  it('carries the derived notes status onto local rows', async () => {
+    listRecordings.mockResolvedValue([
+      {
+        id: 'a', title: 'Silent', createdAt: '2026-06-01T09:00:00Z', durationSeconds: 60,
+        status: 'done', hasAudio: true, hasNote: false, hasTranscript: true,
+        notesStatus: 'empty-transcript',
+      },
+    ]);
+    const [row] = await new LocalBackend().listMeetings();
+    expect(row.files).toEqual({
+      hasAudio: true, hasNote: false, hasTranscript: true, notesStatus: 'empty-transcript',
+    });
+  });
+
   it('returns nothing for a blank local query without hitting the bridge', async () => {
     const rows = await new LocalBackend().searchMeetings('   ');
     expect(rows).toEqual([]);

--- a/src/composables/useBackend.ts
+++ b/src/composables/useBackend.ts
@@ -1,4 +1,12 @@
-import { local, auth, pending, api, getBackendSetting, type RecordingSummary } from '../tauri';
+import {
+  local,
+  auth,
+  pending,
+  api,
+  getBackendSetting,
+  type NotesStatus,
+  type RecordingSummary,
+} from '../tauri';
 import {
   useMeetingApi,
   type AudioSpeaker,
@@ -54,8 +62,9 @@ export interface MeetingListItem {
   durationSeconds?: number;
   /** Local recordings only. */
   status?: RecordingSummary['status'];
-  /** Local recordings only — drives the row's audio/note/transcript controls. */
-  files?: { hasAudio: boolean; hasNote: boolean; hasTranscript: boolean };
+  /** Local recordings only — drives the row's audio/note/transcript controls.
+   *  `notesStatus` lets the row tell settled notes from ones still generating. */
+  files?: { hasAudio: boolean; hasNote: boolean; hasTranscript: boolean; notesStatus?: NotesStatus };
   /** Remote search only: a short backend-provided match preview when available. */
   snippet?: string | null;
   /** Remote search only: the exact matched text, when the backend returns it. */
@@ -297,6 +306,7 @@ function recordingToListItem(r: RecordingSummary): MeetingListItem {
       hasAudio: r.hasAudio,
       hasNote: r.hasNote,
       hasTranscript: r.hasTranscript,
+      notesStatus: r.notesStatus,
     },
   };
 }

--- a/src/tauri.ts
+++ b/src/tauri.ts
@@ -334,6 +334,7 @@ export interface RecordingSummary {
   hasAudio: boolean;
   hasNote: boolean;
   hasTranscript: boolean;
+  notesStatus: NotesStatus;
 }
 
 /** `empty-transcript`: nothing was said, so notes were deliberately skipped —

--- a/src/views/LibraryView.test.ts
+++ b/src/views/LibraryView.test.ts
@@ -718,6 +718,25 @@ describe('LibraryView', () => {
       expect(wrapper.get('.meeting-item').find('.mi-sub--processing').exists()).toBe(false);
     });
 
+    // A missing note only implies "still generating" while the list can't say
+    // otherwise. Once it reports the notes settled without one — nothing was
+    // said, or generation failed — a spinning row would be a lie, and it would
+    // make every content-ready report from the open detail reload the list.
+    it.each(['empty-transcript', 'failed'])(
+      'shows the normal sub-line for a recent recording whose notes settled as %s',
+      async (notesStatus) => {
+        const wrapper = await mountWithRows([
+          item({
+            id: 'a',
+            timestamp: new Date(Date.now() - 60_000).toISOString(),
+            status: 'done',
+            files: { hasAudio: true, hasTranscript: true, hasNote: false, notesStatus },
+          }),
+        ]);
+        expect(wrapper.get('.meeting-item').find('.mi-sub--processing').exists()).toBe(false);
+      }
+    );
+
     // The window is measured from the end, so a long recording isn't already
     // stale the moment it stops.
     it('measures the window from the end of a long recording, not its start', async () => {

--- a/src/views/LibraryView.vue
+++ b/src/views/LibraryView.vue
@@ -579,11 +579,17 @@ function rowProcessingLabel(m: MeetingListItem): string | null {
     // a lie.
     if (m.status === 'recording' || m.status === 'transcribing') return PROCESSING_LABEL;
     // "Has a transcript but no note" is an *inference* that notes are still
-    // generating, and it can't tell a running pipeline from one that never
-    // finished (telling notes-pending from notes-failed needs the per-recording
-    // status view, which the list payload doesn't carry). Generation runs for
-    // minutes, so bound it: an old recording with no note is stuck, not busy.
-    if (m.status === 'done' && m.files?.hasTranscript && !m.files?.hasNote) {
+    // generating. It holds only while the notes are still pending: a recording
+    // that settled without a note (nothing was said, or generation failed) is
+    // done, and its detail panel names why. Even pending can't tell a running
+    // pipeline from one that died mid-generation, so bound it: generation runs
+    // for minutes, and an old recording with no note is stuck, not busy.
+    if (
+      m.status === 'done' &&
+      m.files?.hasTranscript &&
+      !m.files.hasNote &&
+      (m.files.notesStatus ?? 'pending') === 'pending'
+    ) {
       return finishedRecently(m) ? PROCESSING_LABEL : null;
     }
     return null;

--- a/src/views/MeetingDetailView.test.ts
+++ b/src/views/MeetingDetailView.test.ts
@@ -1105,6 +1105,24 @@ describe('MeetingDetailView local generation progress', () => {
     expect(wrapper.emitted('contentReady')).toEqual([[{ id: '7' }]]);
   });
 
+  // The Library answers a report by refetching its list and swapping in the
+  // fresh row. That row is a new object with the same fields, so reloading on it
+  // would restart the poll, re-report the same settled stage, and loop forever.
+  it('does not reload or re-report when a list refresh hands it an identical row', async () => {
+    recordingStatus.mockResolvedValue({
+      status: 'done', hasTranscript: true, hasNote: false, notesStatus: 'empty-transcript',
+    });
+    const wrapper = await mountLocal(detail({ isLocal: true, hasTranscript: true }));
+    expect(wrapper.emitted('contentReady')).toEqual([[{ id: '7' }]]);
+    expect(getMeetingDetail).toHaveBeenCalledTimes(1);
+
+    await wrapper.setProps({ item: { ...localItem, files: { ...localItem.files! } } });
+    await flushPromises();
+
+    expect(getMeetingDetail).toHaveBeenCalledTimes(1);
+    expect(wrapper.emitted('contentReady')).toEqual([[{ id: '7' }]]);
+  });
+
   it('says nothing for an Ariso meeting, which has no local pipeline', async () => {
     const wrapper = await mountLocal(detail({ isLocal: false, digest: 'A digest' }));
     await flushPromises();

--- a/src/views/MeetingDetailView.vue
+++ b/src/views/MeetingDetailView.vue
@@ -1156,15 +1156,18 @@ async function load(item: MeetingListItem | null): Promise<void> {
 
 // Watch stable detail fields only. User-note autosaves must not reload the
 // whole pane or change AI Notes tab visibility while the user switches tabs.
+// One source per field, so Vue compares the values: a list refresh swaps in a
+// fresh row object with the same fields, and reloading on that would restart
+// the progress poll and re-emit `contentReady` into another refresh — a loop.
 watch(
-  () => [
-    props.item?.id,
-    props.item?.timestamp,
-    props.item?.durationSeconds,
-    props.item?.files?.hasTranscript,
+  [
+    () => props.item?.id,
+    () => props.item?.timestamp,
+    () => props.item?.durationSeconds,
+    () => props.item?.files?.hasTranscript,
     // The detail carries prepId from the row, so a row that gains one (a prep
     // created after the list loaded) must reload for its Prep tab to appear.
-    props.item?.prepId,
+    () => props.item?.prepId,
   ],
   () => load(props.item),
   { immediate: true }


### PR DESCRIPTION
## What does this PR do?

> **Stacked on #373** — the base is `fix/no-notes-from-speechless-transcript`, since this depends on its `empty-transcript` notes status. Merge #373 first.

Opening a recent recording where nothing was said locks the Meetings window into a loop that runs about 5 times a second. The pane stays on "Loading meeting…", the TipTap notes editor re-mounts on every pass, and devtools shows a constant stream of `plugin:store|load` / `plugin:store|get` / `list_local_recordings` requests. The page never actually reloads; this is a render loop.

In the running app, over 4 seconds: `plugin:store|load` ×42, `plugin:store|get` ×41, `read_recording_file` ×41, `list_local_recordings` ×21, `local_recording_status` ×20. The editor re-mounted ~128 times in a few seconds, and the webview sat at ~64% CPU.

**The loop**
1. The detail panel's poll sees `notes-empty-transcript`. #373 made that a terminal stage, so the panel emits `contentReady`.
2. `LibraryView.onContentReady` refetches the list if the row claims to be processing. `rowProcessingLabel` guesses "Processing…" for any recording that has a transcript, has no note and ended less than an hour ago. An empty-transcript recording always fits that, so every report triggers a refetch.
3. The refetch swaps in a new `selectedItem` object. The detail panel's reload watcher returned a new array on every run, so a row with identical fields still reloaded the pane.
4. `load()` resets the poll to `idle`, the next poll reaches the same settled stage again, the panel emits `contentReady` again, and the cycle restarts at step 2.

**The fix** breaks two links in that cycle:
- **Row label:** `list_local_recordings` now includes the derived `notesStatus`, using the same `derive_notes_status` as `local_recording_status`, and a vault note still counts as `ready`. The row only guesses "Processing…" while notes are `pending`. A recording that finished without a note, as `empty-transcript` or `failed`, shows its normal time and duration. That also closes the same loop for a notes failure within the hour.
- **Detail watcher:** the watcher now watches each field separately, so Vue compares the values. A refreshed row with the same fields no longer reloads the pane. The existing cloud-meeting comments already assumed it worked this way.

## Type of change

- [x] `fix:` — bug fix
- [ ] `feat:` — new feature
- [ ] `feat!:` / `BREAKING CHANGE:` — breaking change
- [ ] `docs:` / `chore:` / `refactor:` — no user-facing release

## How was this tested?

- Each new test failed for the expected reason before the fix went in:
  - Rust `lists_recordings_carry_derived_notes_status` (pending / empty-transcript / failed / ready).
  - Rust `list_local_recordings_vault_note_makes_notes_status_ready`.
  - `useBackend`: the local row carries `notesStatus`.
  - `LibraryView`: a recent row whose notes finished as `empty-transcript` or `failed` shows its normal sub-line.
  - `MeetingDetailView`: an identical row swap neither reloads the pane nor reports `contentReady` a second time.
- `npm test`: 868 passed. `cargo test -- --test-threads=1`: 318 passed.
- **Local backend, macOS (Apple Silicon):** first reproduced the loop live through the `oats-desktop` MCP server. After the fix, `list_local_recordings` returns `notesStatus: "empty-transcript"` for both silent recordings, and the Meetings window made no reload calls over 4 seconds.
- **Not covered end to end:** by the time the fix was ready, the silent recordings were older than the one-hour "Processing…" window, which would hide the loop even without the fix. To check: record a few seconds of silence and open it right away. It should show the "Empty transcript" chip and the pane should stay put.

## Screenshots / recordings

N/A: the only visible change is that the row reads "12:13 PM • 1min" instead of "Processing…", and the pane no longer sticks on "Loading meeting…".

## Checklist

- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I ran `npm test` and the suite passes
- [ ] I tested the change in the app (note which backend above) — partially: see "Not covered end to end" above

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Recording notes now accurately show their current state, including ready, pending, empty-transcript, and failed outcomes.
  - Library recordings no longer remain stuck on “Processing…” after note generation settles or exceeds the processing window.
  - Existing notes correctly override stale error indicators.
  - Meeting details no longer reload or restart progress behavior when refreshed data is unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->