### PR TITLE
ci: triage CodeRabbit minor findings in apply-fixes

### DIFF
--- a/.github/apply-fixes-prompt.md
+++ b/.github/apply-fixes-prompt.md
@@ -1,7 +1,8 @@
 You are running inside a GitHub Actions job. CodeRabbit is the merge
 gate — your job is to apply the major/critical findings that CodeRabbit
-and shawnzhu have raised on this PR, so the next CodeRabbit re-review
-can clear them.
+and shawnzhu have raised on this PR, plus any minor CodeRabbit findings
+that are genuine true positives, so the next CodeRabbit re-review can
+clear them.
 
 This repo is a Tauri app: Vue 3 + TypeScript in `src/`, Rust backend in
 `src-tauri/`. The frontend has a Vitest suite. Verification is:
@@ -24,24 +25,39 @@ has this shape:
     {"threadId": "...", "rootCommentId": 123, "path": "...", "line": 42,
      "body": "..."}
   ],
+  "coderabbit_minor": [
+    {"threadId": "...", "rootCommentId": 789, "path": "...", "line": 8,
+     "body": "..."}
+  ],
   "shawnzhu": [
     {"threadId": "...", "rootCommentId": 456, "path": "...", "line": 17,
-     "body": "..."}
+     "body": "...", "replies": [{"author": "...", "body": "..."}]}
   ]
 }
 ```
 
 `coderabbit` entries are unresolved review threads where the root
 comment is from `coderabbitai[bot]` and matches the major-finding
-pattern (`⚠️ Potential issue`, `🛑`, security/data-loss/race-condition).
+pattern (`🔴 Critical`, `🟠 Major`, `🛑`, security/data-loss/race-condition).
+
+`coderabbit_minor` entries are unresolved CodeRabbit threads carrying
+the `🟡 Minor` badge (and not matching the major pattern). These are
+held to a stricter bar — see "Minor findings" below.
 
 `shawnzhu` entries are unresolved review threads where the root comment
 is from `shawnzhu` — all of them, no severity filter. Treat each as
 actionable unless triage says otherwise.
 
+Every entry also carries `replies` — the thread's later comments, oldest
+first, as `{"author", "body"}`. Read them: a reviewer may already have
+explained why a finding is intended, or narrowed what they want.
+Threads this workflow (`github-actions`) already replied to are
+excluded, unless a human reviewer followed up after that reply — in
+that case the follow-up overrides the earlier triage; act on it.
+
 ## Step 1 — Triage each finding
 
-For each entry in both arrays, classify:
+For each entry in all three arrays, classify:
 
 - **valid-unaddressed** — real issue, not yet fixed in this PR. **Apply
   a fix.**
@@ -53,6 +69,41 @@ For each entry in both arrays, classify:
 
 Read the diff and surrounding file context before deciding. Use `Read`,
 `Grep`, and `git diff origin/<base>...HEAD -- <path>` as needed.
+
+### Minor findings (`coderabbit_minor`)
+
+The default for a minor finding is **skip**. Every edit costs a new
+commit and a re-review cycle, and CodeRabbit's minors are often wrong
+or not worth it. Classify a minor as `valid-unaddressed` only if you
+can answer "yes" to all of these:
+
+1. **It is a true positive.** You traced the actual code path — not
+   just the snippet CodeRabbit quoted — and confirmed the defect
+   exists: wrong result, crash/panic, unhandled error, leak, a race you
+   can describe step by step, or a test that asserts the wrong thing or
+   can't fail.
+2. **It is reachable here.** The triggering input or state can
+   actually occur in this app. Check callers and invariants; a guard
+   for a case the code already rules out is not a fix.
+3. **It is introduced or touched by this PR.** Check
+   `git diff origin/<base>...HEAD`. Pre-existing issues on lines the
+   PR doesn't touch are out of scope.
+4. **The fix is small and local.** A few lines in the flagged area,
+   no new abstractions, no behavior change beyond the defect.
+
+Skip (classify as `false-positive`) minors that are:
+
+- Style, naming, formatting, readability, or "consider…" refactors.
+- Hypothetical edge cases, defensive checks for already-guaranteed
+  invariants, or "for robustness" additions.
+- Extra logging, comments, docs, or tests added only for coverage.
+- Correct in general but based on a wrong reading of this code (for
+  example, CodeRabbit missed a guard, caller, or invariant elsewhere).
+
+When unsure, skip — and say in the reply what you checked, e.g.
+"Skipping (minor, not a true positive): `foo` is only called after
+`bar` validates the input." Majors and `shawnzhu` findings keep the
+normal bar above.
 
 ## Step 2 — Apply fixes
 
@@ -117,7 +168,9 @@ Skipped (already-fixed):
 ```
 
 Then write a JSON array to `/tmp/thread-replies.json` describing the
-replies to post on each thread:
+replies to post — one per finding across all three arrays, skipped
+minors included. That reply is the triage record: the next run skips
+any thread that already has one.
 
 ```json
 [

--- a/.github/workflows/apply-fixes.yml
+++ b/.github/workflows/apply-fixes.yml
@@ -1,8 +1,9 @@
 name: Apply review fixes
 
 # Triggered when CodeRabbit or shawnzhu submits a PR review. Fetches the
-# major/critical findings, runs Claude with edit tools to apply them,
-# verifies the Tauri + Rust builds, then commits + pushes as
+# major/critical and minor findings, runs Claude with edit tools to apply
+# them (minors only when triage confirms a true positive), verifies the
+# Tauri + Rust builds, then commits + pushes as
 # github-actions[bot]. CodeRabbit re-reviews the new commit and posts
 # the merge verdict (configured by .coderabbit.yaml). This workflow does
 # not gate merges itself.
@@ -28,6 +29,14 @@ env:
   # as "majors". The keyword alternatives still catch severe issues by
   # content even if the badge wording shifts.
   MAJOR_PATTERN: '🛑|🔴 Critical|🟠 Major|security|data loss|race condition'
+  # CodeRabbit's 🟡 Minor badge. Minors go to Claude in their own bucket
+  # and are held to a stricter bar — fixed only when triage confirms a
+  # true positive (see .github/apply-fixes-prompt.md). 🔵 Trivial and
+  # nitpicks are still ignored.
+  MINOR_PATTERN: '🟡 Minor'
+  # GraphQL login of the identity that posts this workflow's thread
+  # replies (github-actions[bot], [bot] suffix stripped).
+  ACTIONS_BOT_GQL: "github-actions"
 
 jobs:
   apply-fixes:
@@ -122,51 +131,68 @@ jobs:
             ' \
             | jq -s '[.[] | .data.repository.pullRequest.reviewThreads.nodes[]]')
 
-          # Split into coderabbit majors + shawnzhu (all unresolved inline).
-          # Resolved threads are dropped (already handled).
+          # Split into coderabbit majors, coderabbit minors, and shawnzhu
+          # (all unresolved inline). Resolved threads are dropped (already
+          # handled). So are threads this workflow already replied to,
+          # unless a human reviewer followed up after that reply: skipped
+          # findings stay unresolved, and without this every CodeRabbit
+          # re-review would re-triage them and post a duplicate reply.
           jq \
             --arg cr "$CODERABBIT_GQL" \
+            --arg bot "$ACTIONS_BOT_GQL" \
             --arg human "$HUMAN_REVIEWERS" \
             --arg major "$MAJOR_PATTERN" \
+            --arg minor "$MINOR_PATTERN" \
             '
+            def finding:
+              {threadId: .id, path, line,
+               rootCommentId: .comments.nodes[0].databaseId,
+               body: .comments.nodes[0].body,
+               replies: [.comments.nodes[1:][]
+                         | {author: (.author.login // ""), body}]};
             ($human | split(",") | map(gsub("^\\s+|\\s+$"; ""))) as $humans
-            | . as $threads
+            | [
+                .[]
+                | select(.isResolved == false)
+                | (.comments.nodes | map(.author.login // "")) as $authors
+                | ($authors | indices($bot) | last) as $replied_at
+                | select($replied_at == null
+                         or any($authors[($replied_at + 1):][]; IN($humans[])))
+              ] as $threads
+            | [$threads[] | select((.comments.nodes[0].author.login // "") == $cr)] as $cr_threads
             | {
                 coderabbit: [
-                  $threads[]
-                  | select(.isResolved == false)
-                  | select((.comments.nodes[0].author.login // "") == $cr)
+                  $cr_threads[]
                   | select(.comments.nodes[0].body | test($major; "i"))
-                  | {threadId: .id, path, line,
-                     rootCommentId: .comments.nodes[0].databaseId,
-                     body: .comments.nodes[0].body}
+                  | finding
+                ],
+                coderabbit_minor: [
+                  $cr_threads[]
+                  | select(.comments.nodes[0].body | test($major; "i") | not)
+                  | select(.comments.nodes[0].body | test($minor))
+                  | finding
                 ],
                 shawnzhu: [
                   $threads[]
-                  | select(.isResolved == false)
-                  # Bind author.login first; otherwise `$humans | index(…)`
-                  # would re-evaluate the path expression against $humans
-                  # (an array) and error out.
-                  | (.comments.nodes[0].author.login // "") as $login
-                  | select(($humans | index($login)) != null)
-                  | {threadId: .id, path, line,
-                     rootCommentId: .comments.nodes[0].databaseId,
-                     body: .comments.nodes[0].body}
+                  | select((.comments.nodes[0].author.login // "") | IN($humans[]))
+                  | finding
                 ]
               }
             ' <<< "$threads_json" > "$RUNNER_TEMP/actionable-findings.json"
 
           cr_count=$(jq '.coderabbit | length' "$RUNNER_TEMP/actionable-findings.json")
+          minor_count=$(jq '.coderabbit_minor | length' "$RUNNER_TEMP/actionable-findings.json")
           sz_count=$(jq '.shawnzhu | length' "$RUNNER_TEMP/actionable-findings.json")
-          total=$((cr_count + sz_count))
+          total=$((cr_count + minor_count + sz_count))
           echo "CodeRabbit majors: $cr_count"
+          echo "CodeRabbit minors: $minor_count"
           echo "shawnzhu comments: $sz_count"
           echo "total=$total" >> "$GITHUB_OUTPUT"
 
       - name: Exit early if nothing actionable
         if: steps.findings.outputs.total == '0'
         run: |
-          echo "No unresolved major findings to apply. Done."
+          echo "No unresolved, untriaged findings to apply. Done."
           exit 0
 
       - name: Run Claude to triage + apply fixes


### PR DESCRIPTION
## Summary

- **Minor findings now reach Claude.** CodeRabbit `🟡 Minor` threads go into a new `coderabbit_minor` bucket. The prompt sets a stricter bar for them: skip by default, and fix only if Claude has traced the code and confirmed a real bug, the failing case can actually happen in this app, the PR introduced it, and the fix is a few lines. Style tweaks, "consider…" suggestions, defensive checks and coverage-only tests are skipped, and the skip reply has to say what was checked. `🔵 Trivial` and nitpicks are still ignored. Majors and `shawnzhu` comments keep the normal bar.
- **No duplicate triage.** Threads the workflow already replied to are dropped unless a human replied after the bot. Skipped findings stay unresolved, and each fix commit triggers a CodeRabbit re-review, so without this every run would post another "Skipping" reply. Adding minors would make that much worse.
- **Thread context.** Each finding now includes the thread's later replies, so Claude sees reviewer follow-ups (e.g. "this is intended").
- Corrects the prompt's description of the major pattern: it said `⚠️ Potential issue`, which the workflow no longer matches.

## Test plan

- [x] Ran the updated jq filter on real threads from #372 (2 unresolved minors → `coderabbit_minor`) and #373 (minor thread whose replies come through).
- [x] Ran it on 15 synthetic edge cases: Trivial, resolved, already-triaged and look-alike bot threads (e.g. `coderabbit-junior`) are excluded; a human reply after the bot's reply brings the thread back; a minor that mentions a race condition is treated as a major; an empty thread doesn't crash.
- [x] YAML parses. actionlint reports only SC2016 (info) on the GraphQL query, which was already there before this change.
- [ ] The workflow itself hasn't run yet. Check the next CodeRabbit review on a PR that has minor findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The automated fix workflow now identifies and triages minor review findings alongside major and critical findings.
  * Findings are categorized by severity and source, with follow-up replies preserved for review.
  * The workflow reports counts for each finding category and supports human follow-up overrides.

* **Documentation**
  * Added guidance for validating, skipping, and responding to minor findings.
  * Updated workflow documentation to clarify finding collection and triage behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->