### PR TITLE
feat: add delete action for local meeting notes

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -2065,7 +2065,8 @@ pub fn rename_local_recording(id: String, title: String) -> Result<(), String> {
 /// then its own directory (`meta.json`, `transcript.md`, `segments.json`, the
 /// user note, and any legacy `ari-note.md` / `recording.mp3`).
 ///
-/// Refuses while the recording is still `Recording` or `Transcribing`: those
+/// Refuses while the recording is still `Recording` or `Transcribing`, or
+/// while AI notes are still `Pending` on an otherwise-`Done` recording: those
 /// pipelines run in detached tasks that would re-create files underneath the
 /// delete — and because `write_note` targets the vault root (which survives),
 /// a deleted note could reappear in Obsidian with no library row pointing at
@@ -2084,6 +2085,22 @@ pub fn delete_local_recording(id: String) -> Result<(), String> {
         crate::storage::RecordingStatus::Recording | crate::storage::RecordingStatus::Transcribing
     ) {
         return Err("this recording is still being processed — try again once it finishes".to_string());
+    }
+    if meta.status == crate::storage::RecordingStatus::Done {
+        // Same derivation as `local_recording_status`. A `Failed` recording
+        // never reached notes generation, so this check is scoped to `Done` —
+        // otherwise a failed transcription (no note, no notes_error) would
+        // misread as notes-pending and become permanently undeletable.
+        let has_note =
+            dir.join("ari-note.md").is_file() || crate::vault::find_note(&id)?.is_some();
+        let notes_status =
+            crate::storage::derive_notes_status(has_note, meta.notes_error.as_deref());
+        if notes_status == crate::storage::NotesStatus::Pending {
+            return Err(
+                "AI notes are still generating for this recording — try again once they finish"
+                    .to_string(),
+            );
+        }
     }
     crate::vault::delete_recording_artifacts(&id, meta.audio_file.as_deref())?;
     std::fs::remove_dir_all(&dir).map_err(|e| format!("delete recording files: {e}"))
@@ -3054,6 +3071,45 @@ mod tests {
             assert!(dir.exists(), "recording must survive a refused delete");
             std::fs::remove_dir_all(&dir).unwrap();
         }
+        unsafe { std::env::remove_var("ARISO_ROOT"); }
+    }
+
+    #[test]
+    fn delete_local_recording_refuses_while_notes_are_pending() {
+        let tmp = tempfile::tempdir().unwrap();
+        // SAFETY: see above.
+        unsafe { std::env::set_var("ARISO_ROOT", tmp.path()); }
+        let root = crate::vault::meta_root().unwrap();
+        let id = "2026-06-02T14-30-05Z";
+        let dir = crate::storage::create_recording_dir(&root, id).unwrap();
+        // `Done` with no note and no notes_error: the transcript finished but
+        // the detached notes task hasn't written its outcome yet.
+        crate::storage::write_meta(&dir, &test_meta(id)).unwrap();
+
+        // A concurrent `process_notes` finishing here would recreate the vault
+        // note out from under a delete that raced ahead of it.
+        assert!(delete_local_recording(id.to_string()).is_err());
+        assert!(dir.exists(), "recording must survive a refused delete");
+        unsafe { std::env::remove_var("ARISO_ROOT"); }
+    }
+
+    #[test]
+    fn delete_local_recording_allows_failed_transcription_with_no_note() {
+        let tmp = tempfile::tempdir().unwrap();
+        // SAFETY: see above.
+        unsafe { std::env::set_var("ARISO_ROOT", tmp.path()); }
+        let root = crate::vault::meta_root().unwrap();
+        let id = "2026-06-02T14-30-05Z";
+        let dir = crate::storage::create_recording_dir(&root, id).unwrap();
+        let mut meta = test_meta(id);
+        meta.status = crate::storage::RecordingStatus::Failed;
+        crate::storage::write_meta(&dir, &meta).unwrap();
+
+        // A failed transcription never reaches notes generation, so the
+        // (has_note=false, notes_error=None) combination here must not be
+        // misread as notes-pending.
+        delete_local_recording(id.to_string()).unwrap();
+        assert!(!dir.exists(), "recording dir should be gone");
         unsafe { std::env::remove_var("ARISO_ROOT"); }
     }
 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1682,8 +1682,12 @@ pub fn pending_uploads_path() -> Result<String, String> {
 /// (e.g. `2026-06-02T14-30-05Z`), so the guard never rejects legitimate ids.
 fn recording_dir(id: &str) -> Result<std::path::PathBuf, String> {
     // Reject ids that could escape the recordings dir. `:` is blocked too so a
-    // Windows drive-relative form (e.g. `C:foo`) can never slip past the guard.
+    // Windows drive-relative form (e.g. `C:foo`) can never slip past the guard,
+    // and a bare `.` is blocked because it resolves to the recordings root
+    // itself — harmless for a read, but `delete_local_recording` would take the
+    // whole directory with it.
     if id.is_empty()
+        || id == "."
         || id.contains('/')
         || id.contains('\\')
         || id.contains(':')
@@ -2055,6 +2059,34 @@ pub fn rename_local_recording(id: String, title: String) -> Result<(), String> {
         meta.audio_file = Some(new_audio_file);
     }
     crate::storage::write_meta(&dir, &meta)
+}
+
+/// Permanently delete a local recording: its vault note and audio attachment,
+/// then its own directory (`meta.json`, `transcript.md`, `segments.json`, the
+/// user note, and any legacy `ari-note.md` / `recording.mp3`).
+///
+/// Refuses while the recording is still `Recording` or `Transcribing`: those
+/// pipelines run in detached tasks that would re-create files underneath the
+/// delete — and because `write_note` targets the vault root (which survives),
+/// a deleted note could reappear in Obsidian with no library row pointing at
+/// it. The UI hides the action in those states; this is defense in depth.
+///
+/// Vault artifacts go first on purpose. If that step fails nothing is lost and
+/// the library row remains as a retry handle; if the directory removal fails
+/// the row still remains, and a retry is idempotent. The reverse order could
+/// orphan a vault note with no way to reach it from the UI.
+#[tauri::command]
+pub fn delete_local_recording(id: String) -> Result<(), String> {
+    let dir = recording_dir(&id)?;
+    let meta = crate::storage::read_meta(&dir)?;
+    if matches!(
+        meta.status,
+        crate::storage::RecordingStatus::Recording | crate::storage::RecordingStatus::Transcribing
+    ) {
+        return Err("this recording is still being processed — try again once it finishes".to_string());
+    }
+    crate::vault::delete_recording_artifacts(&id, meta.audio_file.as_deref())?;
+    std::fs::remove_dir_all(&dir).map_err(|e| format!("delete recording files: {e}"))
 }
 
 /// Read the user-authored local note artifact used by the Library editor.
@@ -2693,6 +2725,9 @@ mod tests {
         assert!(recording_dir("a\\b").is_err());
         assert!(recording_dir("C:foo").is_err());
         assert!(recording_dir("foo/../bar").is_err());
+        // "." slips past a `..`-only check but resolves to the recordings root
+        // itself — which `delete_local_recording` would try to remove wholesale.
+        assert!(recording_dir(".").is_err());
     }
 
     #[test]
@@ -2952,6 +2987,90 @@ mod tests {
         let res = rename_local_recording("2026-06-02T14-30-05Z".to_string(), "New".to_string());
         assert!(res.is_err());
         unsafe { std::env::remove_var("ARISO_ROOT"); }
+    }
+
+    #[test]
+    fn delete_local_recording_removes_dir_and_vault_artifacts() {
+        let tmp = tempfile::tempdir().unwrap();
+        // SAFETY: see above.
+        unsafe { std::env::set_var("ARISO_ROOT", tmp.path()); }
+        let id = "2026-06-02T14-30-05Z";
+        let dir = crate::storage::create_recording_dir(&crate::vault::meta_root().unwrap(), id).unwrap();
+        let mut meta = test_meta(id);
+        meta.audio_file = Some("2026-06-02 Old.mp3".into());
+        crate::storage::write_meta(&dir, &meta).unwrap();
+        std::fs::write(dir.join("transcript.md"), b"transcript").unwrap();
+        std::fs::write(dir.join("user-note.md"), b"my note").unwrap();
+        crate::vault::write_audio("2026-06-02 Old.mp3", b"aud").unwrap();
+        crate::vault::write_note("2026-06-02 Old", &meta, "2026-06-02 Old.mp3", "body").unwrap();
+
+        delete_local_recording(id.to_string()).unwrap();
+
+        assert!(!dir.exists(), "recording dir should be gone");
+        let root = crate::vault::vault_root().unwrap();
+        assert!(!crate::vault::note_path(&root, "2026-06-02 Old").exists());
+        assert!(!crate::vault::audio_path(&root, "2026-06-02 Old.mp3").exists());
+        unsafe { std::env::remove_var("ARISO_ROOT"); }
+    }
+
+    #[test]
+    fn delete_local_recording_handles_legacy_recording_without_audio_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        // SAFETY: see above.
+        unsafe { std::env::set_var("ARISO_ROOT", tmp.path()); }
+        let id = "2026-06-02T14-30-05Z";
+        let dir = crate::storage::create_recording_dir(&crate::vault::meta_root().unwrap(), id).unwrap();
+        // Legacy recordings predate the vault: audio and note live in the
+        // recording dir itself, and `meta.audio_file` is absent.
+        crate::storage::write_meta(&dir, &test_meta(id)).unwrap();
+        std::fs::write(dir.join("recording.mp3"), b"aud").unwrap();
+        std::fs::write(dir.join("ari-note.md"), b"note").unwrap();
+
+        delete_local_recording(id.to_string()).unwrap();
+
+        assert!(!dir.exists(), "recording dir should be gone");
+        unsafe { std::env::remove_var("ARISO_ROOT"); }
+    }
+
+    #[test]
+    fn delete_local_recording_refuses_while_still_in_flight() {
+        let tmp = tempfile::tempdir().unwrap();
+        // SAFETY: see above.
+        unsafe { std::env::set_var("ARISO_ROOT", tmp.path()); }
+        let root = crate::vault::meta_root().unwrap();
+        for status in [
+            crate::storage::RecordingStatus::Recording,
+            crate::storage::RecordingStatus::Transcribing,
+        ] {
+            let id = "2026-06-02T14-30-05Z";
+            let dir = crate::storage::create_recording_dir(&root, id).unwrap();
+            let mut meta = test_meta(id);
+            meta.status = status;
+            crate::storage::write_meta(&dir, &meta).unwrap();
+
+            // Deleting mid-flight would let the in-progress finalize/STT task
+            // re-create files (including a now-orphaned vault note).
+            assert!(delete_local_recording(id.to_string()).is_err());
+            assert!(dir.exists(), "recording must survive a refused delete");
+            std::fs::remove_dir_all(&dir).unwrap();
+        }
+        unsafe { std::env::remove_var("ARISO_ROOT"); }
+    }
+
+    #[test]
+    fn delete_local_recording_rejects_missing_recording() {
+        let tmp = tempfile::tempdir().unwrap();
+        // SAFETY: see above.
+        unsafe { std::env::set_var("ARISO_ROOT", tmp.path()); }
+        assert!(delete_local_recording("2026-06-02T14-30-05Z".to_string()).is_err());
+        unsafe { std::env::remove_var("ARISO_ROOT"); }
+    }
+
+    #[test]
+    fn delete_local_recording_rejects_traversal_id() {
+        // Validation runs before any filesystem access, so no ARISO_ROOT needed.
+        assert!(delete_local_recording("../../etc".to_string()).is_err());
+        assert!(delete_local_recording("a/b".to_string()).is_err());
     }
 
     #[test]

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -218,6 +218,7 @@ fn main() {
             commands::open_recording_file,
             commands::copy_recording_file,
             commands::rename_local_recording,
+            commands::delete_local_recording,
             commands::buffer_pending_audio,
             commands::discard_pending_audio,
             commands::list_pending_uploads,

--- a/src/composables/useBackend.test.ts
+++ b/src/composables/useBackend.test.ts
@@ -11,6 +11,7 @@ const modelStatus = vi.fn();
 const getBackendSetting = vi.fn();
 const uploadAudio = vi.fn();
 const renameRecording = vi.fn();
+const deleteRecording = vi.fn();
 const updateMeetingNotesTitle = vi.fn();
 const bufferPendingAudio = vi.fn();
 const discardPendingAudio = vi.fn();
@@ -32,6 +33,7 @@ vi.mock('../tauri', () => ({
     modelStatus: () => modelStatus(),
     listRecordings: () => listRecordings(),
     renameRecording: (...a: unknown[]) => renameRecording(...a),
+    deleteRecording: (...a: unknown[]) => deleteRecording(...a),
     readRecordingAudio: (...a: unknown[]) => readRecordingAudio(...a),
   },
   auth: { checkSession: () => checkSession() },
@@ -475,6 +477,26 @@ describe('LocalBackend clips', () => {
   it('deleteMeetingClip rejects as unsupported', async () => {
     const item = { id: 'a', title: 'T', timestamp: 't' };
     await expect(new LocalBackend().deleteMeetingClip(item, 'x')).rejects.toThrow(/not supported/i);
+  });
+});
+
+describe('whole-note delete', () => {
+  it('LocalBackend.deleteMeeting deletes the local recording', async () => {
+    deleteRecording.mockResolvedValue(undefined);
+    const item = { id: 'rec-1', title: 'T', timestamp: 't' };
+    await new LocalBackend().deleteMeeting(item);
+    expect(deleteRecording).toHaveBeenCalledWith('rec-1');
+  });
+
+  it('LocalBackend.deleteMeeting propagates a backend failure', async () => {
+    deleteRecording.mockRejectedValue(new Error('disk on fire'));
+    const item = { id: 'rec-1', title: 'T', timestamp: 't' };
+    await expect(new LocalBackend().deleteMeeting(item)).rejects.toThrow('disk on fire');
+  });
+
+  it('ArisoBackend.deleteMeeting rejects as unsupported', async () => {
+    const item = { id: '42', title: 'T', timestamp: 't' };
+    await expect(new ArisoBackend().deleteMeeting(item)).rejects.toThrow(/not supported/i);
   });
 });
 

--- a/src/composables/useBackend.ts
+++ b/src/composables/useBackend.ts
@@ -209,6 +209,9 @@ export interface Backend {
   getMeetingAudio(item: MeetingListItem, transcriptId?: string): Promise<ArrayBuffer | null>;
   /** Delete a single recording clip by transcript_id. Ariso only; local throws. */
   deleteMeetingClip(item: MeetingListItem, transcriptId: string): Promise<void>;
+  /** Permanently delete a whole meeting note and everything under it. Local
+   *  only; Ariso throws (the server owns its own retention). */
+  deleteMeeting(item: MeetingListItem): Promise<void>;
 }
 
 interface RawMeetingSummary {
@@ -499,6 +502,10 @@ export class ArisoBackend implements Backend {
     const { deleteMeetingRecordingClip } = useMeetingApi();
     await deleteMeetingRecordingClip(item.id, transcriptId);
   }
+
+  async deleteMeeting(): Promise<void> {
+    throw new Error('Deleting a meeting is not supported for Ariso meetings');
+  }
 }
 
 export class LocalBackend implements Backend {
@@ -611,6 +618,10 @@ export class LocalBackend implements Backend {
 
   async deleteMeetingClip(): Promise<void> {
     throw new Error('Deleting individual recordings is not supported for local meetings');
+  }
+
+  async deleteMeeting(item: MeetingListItem): Promise<void> {
+    await local.deleteRecording(item.id);
   }
 }
 

--- a/src/tauri.ts
+++ b/src/tauri.ts
@@ -433,6 +433,12 @@ export const local = {
   renameRecording(id: string, title: string): Promise<void> {
     return invoke('rename_local_recording', { id, title });
   },
+  /** Permanently delete a local recording: its vault note + audio attachment
+   *  and its whole `~/.ariso/recordings/<id>/` directory. Rejects while the
+   *  recording is still recording or transcribing. */
+  deleteRecording(id: string): Promise<void> {
+    return invoke('delete_local_recording', { id });
+  },
   modelStatus(): Promise<ModelStatus> {
     return invoke<ModelStatus>('local_model_status');
   },

--- a/src/views/LibraryView.test.ts
+++ b/src/views/LibraryView.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { mount, flushPromises, enableAutoUnmount } from '@vue/test-utils';
+import { nextTick } from 'vue';
 
 const listMeetings = vi.fn();
 const searchMeetings = vi.fn();
@@ -19,6 +20,7 @@ const getAllWebviewWindows = vi.fn(() => Promise.resolve([] as { label: string }
 const emitNotificationsSync = vi.fn(() => Promise.resolve());
 const getMeetingPrep = vi.fn();
 const openPrepTab = vi.fn();
+const saveNotesNow = vi.fn(() => Promise.resolve());
 const listPendingUploads = vi.fn(() => Promise.resolve([]));
 const minimizeWindow = vi.fn(() => Promise.resolve());
 const toggleMaximizeWindow = vi.fn(() => Promise.resolve());
@@ -157,11 +159,11 @@ function item(over: Record<string, unknown>) {
 // chrome (selection, the recorder strip, the titlebar button).
 const detailStub = {
   name: 'MeetingDetailView',
-  emits: ['close', 'title-updated', 'content-ready'],
+  emits: ['close', 'title-updated', 'content-ready', 'deleted'],
   props: ['item'],
   methods: {
     openPrepTab: (meetingId?: string) => openPrepTab(meetingId),
-    saveNotesNow: () => Promise.resolve(),
+    saveNotesNow: () => saveNotesNow(),
   },
   template:
     '<div class="detail-stub" :data-meeting="item?.id" :data-prep="item?.prepId"><button class="btn-close" @click="$emit(\'close\')">x</button></div>',
@@ -827,6 +829,53 @@ describe('LibraryView', () => {
       await flushPromises();
 
       expect(listMeetings).not.toHaveBeenCalled();
+    });
+
+    // The detail panel performs the delete; the list has to stop showing the row.
+    describe('a deleted local note', () => {
+      it('drops the row and clears the selection, then re-syncs from disk', async () => {
+        const wrapper = await mountWithRows([item({ id: 'a' }), item({ id: 'b' })]);
+        await wrapper.get('.meeting-item').trigger('click');
+        await flushPromises();
+        listMeetings.mockClear();
+        listMeetings.mockResolvedValue([item({ id: 'b' })]);
+
+        wrapper.findComponent({ name: 'MeetingDetailView' }).vm.$emit('deleted', { id: 'a' });
+        await flushPromises();
+
+        const rows = wrapper.findAll('.meeting-item');
+        expect(rows).toHaveLength(1);
+        expect(rows[0].text()).not.toContain('a');
+        // Selection cleared -> the detail pane is replaced by the Up Next card.
+        expect(wrapper.findComponent({ name: 'MeetingDetailView' }).exists()).toBe(false);
+        expect(listMeetings).toHaveBeenCalled();
+      });
+
+      it('drops the row immediately, without waiting on the list reload', async () => {
+        const wrapper = await mountWithRows([item({ id: 'a' }), item({ id: 'b' })]);
+        await wrapper.get('.meeting-item').trigger('click');
+        await flushPromises();
+        // A reload that never settles: the row must still be gone from the UI.
+        listMeetings.mockReturnValue(new Promise(() => {}));
+
+        wrapper.findComponent({ name: 'MeetingDetailView' }).vm.$emit('deleted', { id: 'a' });
+        await nextTick();
+
+        expect(wrapper.findAll('.meeting-item')).toHaveLength(1);
+      });
+
+      it('does not autosave the notes of the recording it just deleted', async () => {
+        const wrapper = await mountWithRows([item({ id: 'a' })]);
+        await wrapper.get('.meeting-item').trigger('click');
+        await flushPromises();
+        saveNotesNow.mockClear();
+
+        wrapper.findComponent({ name: 'MeetingDetailView' }).vm.$emit('deleted', { id: 'a' });
+        await flushPromises();
+
+        // The folder is gone; the usual pre-selection-change flush must be skipped.
+        expect(saveNotesNow).not.toHaveBeenCalled();
+      });
     });
   });
 

--- a/src/views/LibraryView.vue
+++ b/src/views/LibraryView.vue
@@ -235,6 +235,7 @@
           @close="clearSelection"
           @title-updated="onTitleUpdated"
           @content-ready="onContentReady"
+          @deleted="onNoteDeleted"
         />
         <UpNextCard
           v-else
@@ -680,6 +681,25 @@ function onTitleUpdated(payload: { id: string; title: string }): void {
   }
 }
 
+// The open local note was deleted from the detail panel. Drop the row and the
+// selection right away so the list reflects it without waiting on a round trip,
+// then reload from disk so the removal survives navigation and relaunch.
+//
+// Deliberately does NOT go through `clearSelection()`: that flushes the notes
+// editor via `saveNotesNow()`, and the recording's folder no longer exists.
+function onNoteDeleted(payload: { id: string }): void {
+  meetings.value = meetings.value.filter((m) => m.id !== payload.id);
+  pinnedMeetings.value.delete(payload.id);
+  if (selectedItem.value?.id === payload.id) {
+    // Invalidate any in-flight selection so a racing `selectMeeting` can't
+    // re-seat the deleted note after this clears it.
+    selectionReqId++;
+    selectedItem.value = null;
+    userSelectedMeetingId.value = null;
+  }
+  void loadMeetings(false, true);
+}
+
 // The open local recording finished generating. Its row still shows the stale
 // "Processing…" sub-line the list payload described, so pull fresh list data —
 // but only when the row actually claims to be processing, so simply opening an
@@ -741,9 +761,12 @@ let loadMeetingsRequest = 0;
 // lands on the first visible grouped row, not the backend's raw list order.
 // Refresh-driven reloads (window focus/move, upload completion) pass false so
 // they never yank the user off the Up Next greeting/card view back into detail.
-async function loadMeetings(autoSelectFirst = false): Promise<void> {
+// `silent` re-syncs the list without the full-list "Loading…" placeholder, for
+// callers that have already updated the UI optimistically and only need disk to
+// confirm — blanking the list there would undo the immediate feedback.
+async function loadMeetings(autoSelectFirst = false, silent = false): Promise<void> {
   const requestId = ++loadMeetingsRequest;
-  loading.value = true;
+  if (!silent) loading.value = true;
   error.value = null;
   try {
     const backend = await getActiveBackend();
@@ -784,7 +807,7 @@ async function loadMeetings(autoSelectFirst = false): Promise<void> {
     console.error('Failed to list meetings', e);
     error.value = 'Could not load meetings.';
   } finally {
-    if (requestId === loadMeetingsRequest) loading.value = false;
+    if (requestId === loadMeetingsRequest && !silent) loading.value = false;
   }
 }
 

--- a/src/views/MeetingDetailView.test.ts
+++ b/src/views/MeetingDetailView.test.ts
@@ -9,6 +9,7 @@ const getMeetingTranscript = vi.fn();
 const renameMeeting = vi.fn();
 const getMeetingAudio = vi.fn();
 const deleteMeetingClip = vi.fn();
+const deleteMeeting = vi.fn();
 const getMeetingPrep = vi.fn();
 const activeBackend = vi.fn();
 const notesCanEdit = vi.fn(() => false);
@@ -137,6 +138,7 @@ beforeEach(() => {
     renameMeeting: (...a: unknown[]) => renameMeeting(...a),
     getMeetingAudio: (...a: [MeetingListItem, string?]) => getMeetingAudio(...a),
     deleteMeetingClip: (...a: [MeetingListItem, string]) => deleteMeetingClip(...a),
+    deleteMeeting: (...a: [MeetingListItem]) => deleteMeeting(...a),
     getMeetingPrep: (prepId: number) => getMeetingPrep(prepId),
   });
   notesCanEdit.mockReturnValue(false);
@@ -162,6 +164,7 @@ beforeEach(() => {
   copyRecordingFile.mockResolvedValue(undefined);
   retryTranscription.mockResolvedValue({ backend: 'local', id: '7', title: 'T', status: 'done' });
   retryNotes.mockResolvedValue(undefined);
+  deleteMeeting.mockResolvedValue(undefined);
   getMeetingPrep.mockResolvedValue(null);
   apiRequest.mockReset();
   apiRequest.mockResolvedValue({ status: 200, data: {} });
@@ -1281,6 +1284,118 @@ describe('MeetingDetailView per-clip delete', () => {
     // c2 stays active/showing, rather than snapping back to the (now sole) first clip.
     expect(wrapper.text()).toContain('from clip two');
     expect(wrapper.text()).not.toContain('from clip one');
+  });
+});
+
+describe('MeetingDetailView whole-note delete', () => {
+  const localDetail = (over: Partial<MeetingDetail> = {}): MeetingDetail =>
+    detail({ isLocal: true, hasTranscript: true, note: '# notes', ...over });
+
+  it('offers no delete action for an Ariso meeting', async () => {
+    const wrapper = await mountWith(detail());
+    expect(wrapper.find('.note-del-btn').exists()).toBe(false);
+  });
+
+  it('deletes the note on confirm and tells the parent', async () => {
+    const wrapper = await mountWith(localDetail());
+
+    await wrapper.find('.note-del-btn').trigger('click');
+    // Nothing happens until the confirmation is accepted.
+    expect(deleteMeeting).not.toHaveBeenCalled();
+
+    await wrapper.find('.danger-btn').trigger('click');
+    await flushPromises();
+
+    expect(deleteMeeting).toHaveBeenCalledWith(item);
+    expect(wrapper.emitted('deleted')).toEqual([[{ id: '7' }]]);
+  });
+
+  it('names the note in the confirmation so the right one is deleted', async () => {
+    const wrapper = await mountWith(localDetail({ title: 'Budget review' }));
+    await wrapper.find('.note-del-btn').trigger('click');
+
+    const dialog = wrapper.find('[role="dialog"]');
+    expect(dialog.text()).toContain('Budget review');
+    // The vault note and audio go too — the copy has to say so.
+    expect(dialog.text()).toMatch(/Obsidian vault/i);
+  });
+
+  it('leaves the note alone when the confirmation is canceled', async () => {
+    const wrapper = await mountWith(localDetail());
+
+    await wrapper.find('.note-del-btn').trigger('click');
+    await wrapper.find('.secondary-btn').trigger('click');
+    await flushPromises();
+
+    expect(deleteMeeting).not.toHaveBeenCalled();
+    expect(wrapper.emitted('deleted')).toBeUndefined();
+    expect(wrapper.find('.note-del-btn').exists()).toBe(true);
+  });
+
+  it('disables delete while the recording is still being captured', async () => {
+    recordingStatus.mockResolvedValue({
+      status: 'recording',
+      hasTranscript: false,
+      hasNote: false,
+      notesStatus: 'pending',
+    });
+    const wrapper = await mountWith(localDetail({ hasTranscript: false, note: undefined }));
+
+    expect(wrapper.find('.note-del-btn').attributes('disabled')).toBeDefined();
+  });
+
+  it('disables delete while AI notes are still generating', async () => {
+    recordingStatus.mockResolvedValue({
+      status: 'done',
+      hasTranscript: true,
+      hasNote: false,
+      notesStatus: 'pending',
+    });
+    const wrapper = await mountWith(localDetail({ note: undefined }));
+
+    expect(wrapper.find('.note-del-btn').attributes('disabled')).toBeDefined();
+  });
+
+  it('allows delete for a recording whose transcription failed', async () => {
+    recordingStatus.mockResolvedValue({
+      status: 'failed',
+      hasTranscript: false,
+      hasNote: false,
+      notesStatus: 'failed',
+    });
+    const wrapper = await mountWith(localDetail({ hasTranscript: false, note: undefined }));
+
+    expect(wrapper.find('.note-del-btn').attributes('disabled')).toBeUndefined();
+  });
+
+  it('keeps the note and shows an error when the delete fails', async () => {
+    deleteMeeting.mockRejectedValue(new Error('disk on fire'));
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    const wrapper = await mountWith(localDetail());
+
+    await wrapper.find('.note-del-btn').trigger('click');
+    await wrapper.find('.danger-btn').trigger('click');
+    await flushPromises();
+
+    expect(wrapper.emitted('deleted')).toBeUndefined();
+    expect(wrapper.find('.note-del-btn').exists()).toBe(true);
+    expect(wrapper.find('.note-delete-error').text()).toContain('Could not delete this note');
+  });
+
+  it('stops autosaving notes into a deleted recording', async () => {
+    notesCanEdit.mockReturnValue(true);
+    loadNote.mockResolvedValue({ content: 'draft', title: 'T' });
+    const wrapper = await mountWith(localDetail());
+
+    await wrapper.find('.note-del-btn').trigger('click');
+    await wrapper.find('.danger-btn').trigger('click');
+    await flushPromises();
+
+    // The parent calls this while clearing its selection; the recording's
+    // folder is gone, so the save must not be attempted.
+    saveNote.mockClear();
+    await (wrapper.vm as unknown as { saveNotesNow: () => Promise<void> }).saveNotesNow();
+    expect(saveNote).not.toHaveBeenCalled();
   });
 });
 

--- a/src/views/MeetingDetailView.vue
+++ b/src/views/MeetingDetailView.vue
@@ -716,6 +716,9 @@ let reqId = 0;
 let noteReqId = 0;
 let saveReqId = 0;
 let saveTimer: ReturnType<typeof setTimeout> | null = null;
+// Tracks a save currently awaiting `notesPersistence.save()`, so a whole-note
+// delete can wait it out instead of racing the folder removal.
+let activeSave: Promise<void> | null = null;
 let suppressAutoSave = false;
 let noteDirty = false;
 let loadedNoteItem: MeetingListItem | null = null;
@@ -1075,11 +1078,29 @@ async function confirmDeleteNote(): Promise<void> {
   const backend = detailBackend;
   showNoteDeleteConfirm.value = false;
   if (!item || !backend || deletingNote.value) return;
+  // The dialog can sit open long enough for AI notes to start generating or a
+  // retry to kick off — recheck eligibility rather than trusting the state
+  // from when it was opened. Checked before `deletingNote` flips below, since
+  // `canDeleteNote` treats an in-flight delete as ineligible too.
+  if (!canDeleteNote.value) {
+    noteDeleteError.value = deleteDisabledReason.value ?? 'This note can no longer be deleted right now.';
+    return;
+  }
   // Guarded by reqId like onDownloadTranscriptClick: the delete outlives a
   // meeting switch, so a late failure must not blame the newly-opened note.
   const my = reqId;
   deletingNote.value = true;
+  let failed = false;
   try {
+    // Cancel the pending debounce and wait out a save already in flight —
+    // otherwise it can recreate `user-note.md` after (or racing) the removal.
+    // `scheduleNoteAutoSave`/`saveNotesNow` are gated on `deletingNote` above
+    // so nothing new gets scheduled in the meantime.
+    if (saveTimer) {
+      clearTimeout(saveTimer);
+      saveTimer = null;
+    }
+    if (activeSave) await activeSave;
     await backend.deleteMeeting(item);
     if (my !== reqId) return;
     // Stop the status poller before announcing: its folder is gone, so the next
@@ -1093,9 +1114,14 @@ async function confirmDeleteNote(): Promise<void> {
     noteDeleteError.value = `Could not delete this note: ${
       e instanceof Error ? e.message : String(e)
     }`;
+    failed = true;
   } finally {
     if (my === reqId) deletingNote.value = false;
   }
+  // Deletion failed — the folder is still there, so restore autosave for
+  // whatever the cancelled timer would otherwise have written. Deferred until
+  // here since scheduleNoteAutoSave is itself gated on `deletingNote`.
+  if (failed && noteDirty) scheduleNoteAutoSave();
 }
 
 function askDeleteClip(clip: MeetingAudioClip): void {
@@ -1475,9 +1501,9 @@ async function loadIndividualNote(): Promise<void> {
 // parent calls this before changing selection, and the editor calls it on blur.
 async function saveNotesNow(): Promise<void> {
   const item = loadedNoteItem ?? props.item;
-  // The recording's folder no longer exists — saving would either fail or
-  // re-create the artifact the user just deleted.
-  if (noteDeleted.value) return;
+  // The recording's folder no longer exists (or is being removed right now) —
+  // saving would either fail or re-create the artifact a delete just removed.
+  if (noteDeleted.value || deletingNote.value) return;
   if (!item || loadingIndividualNote.value || !individualNoteLoaded.value || !notesPersistence.canEdit(item)) return;
   const my = ++saveReqId;
   const markdown = notesMarkdown.value;
@@ -1487,21 +1513,29 @@ async function saveNotesNow(): Promise<void> {
     saveTimer = null;
   }
   saveState.value = 'saving';
-  try {
-    await notesPersistence.save(item, { content: markdown, title });
-    const stillViewingSavedItem = props.item?.id === item.id;
-    if (my === saveReqId) noteDirty = false;
-    if (my !== saveReqId || !stillViewingSavedItem) return;
-    if (detail.value) {
-      detail.value.hasIndividualNote = markdown.trim().length > 0;
+  const run = (async () => {
+    try {
+      await notesPersistence.save(item, { content: markdown, title });
+      const stillViewingSavedItem = props.item?.id === item.id;
+      if (my === saveReqId) noteDirty = false;
+      if (my !== saveReqId || !stillViewingSavedItem) return;
+      if (detail.value) {
+        detail.value.hasIndividualNote = markdown.trim().length > 0;
+      }
+      individualNote.value = { content: markdown, title };
+      individualNoteLoaded.value = true;
+      saveState.value = 'saved';
+    } catch (e) {
+      if (my !== saveReqId || props.item?.id !== item.id) return;
+      console.error('Failed to save individual note', e);
+      saveState.value = 'error';
     }
-    individualNote.value = { content: markdown, title };
-    individualNoteLoaded.value = true;
-    saveState.value = 'saved';
-  } catch (e) {
-    if (my !== saveReqId || props.item?.id !== item.id) return;
-    console.error('Failed to save individual note', e);
-    saveState.value = 'error';
+  })();
+  activeSave = run;
+  try {
+    await run;
+  } finally {
+    if (activeSave === run) activeSave = null;
   }
 }
 
@@ -1526,6 +1560,7 @@ watch(activeTab, (t) => {
 function scheduleNoteAutoSave(): void {
   if (
     suppressAutoSave ||
+    deletingNote.value ||
     loadingIndividualNote.value ||
     !individualNoteLoaded.value ||
     !props.item ||

--- a/src/views/MeetingDetailView.vue
+++ b/src/views/MeetingDetailView.vue
@@ -49,11 +49,26 @@
             <svg viewBox="0 0 24 24" class="ic"><path d="M4 12v7a1 1 0 0 0 1 1h14a1 1 0 0 0 1-1v-7" /><path d="M16 6l-4-4-4 4" /><path d="M12 2v13" /></svg>
             Share
           </button>
+          <!-- Local notes only: Ariso meetings are deleted server-side, and
+               `ArisoBackend.deleteMeeting` refuses. -->
+          <button
+            v-if="detail.isLocal"
+            class="note-del-btn"
+            type="button"
+            :disabled="!canDeleteNote"
+            :title="deleteDisabledReason ?? 'Delete this note'"
+            @click="askDeleteNote"
+          >
+            <svg viewBox="0 0 24 24" class="ic"><path d="M4 7h16M10 11v6M14 11v6M6 7l1 13h10l1-13M9 7V4h6v3" /></svg>
+            Delete
+          </button>
           <button class="btn-icon btn-close" type="button" aria-label="Close" title="Close" @click="emit('close')">
             <svg viewBox="0 0 24 24" class="ic"><path d="M6 6l12 12M18 6L6 18" /></svg>
           </button>
         </div>
       </header>
+
+      <p v-if="noteDeleteError" class="note-delete-error" role="alert">⚠ {{ noteDeleteError }}</p>
 
       <ShareMeetingPopover
         v-if="showShare && detail && !detail.isLocal"
@@ -403,6 +418,14 @@
         @confirm="confirmDeleteClip"
         @cancel="cancelDeleteClip"
       />
+
+      <RecordingDeleteConfirmDialog
+        :open="showNoteDeleteConfirm"
+        title="Delete this note?"
+        :body="noteDeleteBody"
+        @confirm="confirmDeleteNote"
+        @cancel="cancelDeleteNote"
+      />
     </template>
   </div>
 </template>
@@ -449,6 +472,10 @@ const emit = defineEmits<{
    *  panel was open. The Library reloads its list so the row drops its
    *  "Processing…" sub-line and picks up the finished content. */
   contentReady: [payload: { id: string }];
+  /** The open local note was permanently deleted. The Library drops its row and
+   *  clears the selection — without the usual notes autosave, since there is no
+   *  longer anywhere on disk to save into. */
+  deleted: [payload: { id: string }];
 }>();
 
 const loading = ref(false);
@@ -1003,6 +1030,74 @@ async function onDownloadTranscriptClick(): Promise<void> {
   }
 }
 
+// Whole-note delete (local recordings only). Blocked while the pipeline is
+// still in flight: both the finalize/STT task and the notes task write into the
+// recording's folder AND the vault, and `write_note` targets the vault root,
+// which survives the delete — so a mid-flight delete could leave an orphaned
+// note in the user's Obsidian vault with no library row pointing at it. The
+// Rust command refuses the recording/transcribing cases too (defense in depth);
+// `notes-pending` is gated here, where the poller already knows about it.
+const showNoteDeleteConfirm = ref(false);
+const deletingNote = ref(false);
+const noteDeleteError = ref<string | null>(null);
+// Set once a delete succeeds, so the parent's `saveNotesNow()` on selection
+// change doesn't write `user-note.md` back into the folder we just removed.
+const noteDeleted = ref(false);
+
+const deleteDisabledReason = computed<string | null>(() => {
+  if (progress.stage.value === 'transcribing')
+    return 'Wait until this recording finishes processing';
+  if (progress.stage.value === 'notes-pending') return 'Wait until AI notes finish generating';
+  if (progress.retrying.value) return 'Wait until the retry finishes';
+  return null;
+});
+const canDeleteNote = computed(
+  () => !!detail.value?.isLocal && !deletingNote.value && deleteDisabledReason.value === null
+);
+const noteDeleteBody = computed(
+  () =>
+    `This permanently deletes “${detail.value?.title ?? 'this note'}” — its transcript, AI notes, ` +
+    `audio, and the note file in your Obsidian vault. This can't be undone.`
+);
+
+function askDeleteNote(): void {
+  if (!canDeleteNote.value) return;
+  noteDeleteError.value = null;
+  showNoteDeleteConfirm.value = true;
+}
+
+function cancelDeleteNote(): void {
+  showNoteDeleteConfirm.value = false;
+}
+
+async function confirmDeleteNote(): Promise<void> {
+  const item = props.item;
+  const backend = detailBackend;
+  showNoteDeleteConfirm.value = false;
+  if (!item || !backend || deletingNote.value) return;
+  // Guarded by reqId like onDownloadTranscriptClick: the delete outlives a
+  // meeting switch, so a late failure must not blame the newly-opened note.
+  const my = reqId;
+  deletingNote.value = true;
+  try {
+    await backend.deleteMeeting(item);
+    if (my !== reqId) return;
+    // Stop the status poller before announcing: its folder is gone, so the next
+    // poll would only log a read-meta failure.
+    progress.stop();
+    noteDeleted.value = true;
+    emit('deleted', { id: item.id });
+  } catch (e) {
+    console.error('Failed to delete local note', e);
+    if (my !== reqId) return;
+    noteDeleteError.value = `Could not delete this note: ${
+      e instanceof Error ? e.message : String(e)
+    }`;
+  } finally {
+    if (my === reqId) deletingNote.value = false;
+  }
+}
+
 function askDeleteClip(clip: MeetingAudioClip): void {
   clipDeleteError.value = null;
   clipPendingDelete.value = clip;
@@ -1062,7 +1157,13 @@ async function load(item: MeetingListItem | null): Promise<void> {
   clipDeleteError.value = null;
   transcriptDownloadError.value = null;
   downloadingTranscript.value = false;
+  showNoteDeleteConfirm.value = false;
+  noteDeleteError.value = null;
+  deletingNote.value = false;
+  // Deliberately before the reset below: the flush must still see `noteDeleted`
+  // so a pending draft isn't written back into the folder we just removed.
   await flushPendingNoteBeforeReset();
+  noteDeleted.value = false;
   // Bump the token first so any in-flight load for the previous selection
   // (including one cleared by item=null) is treated as stale on resolve.
   const my = ++reqId;
@@ -1374,6 +1475,9 @@ async function loadIndividualNote(): Promise<void> {
 // parent calls this before changing selection, and the editor calls it on blur.
 async function saveNotesNow(): Promise<void> {
   const item = loadedNoteItem ?? props.item;
+  // The recording's folder no longer exists — saving would either fail or
+  // re-create the artifact the user just deleted.
+  if (noteDeleted.value) return;
   if (!item || loadingIndividualNote.value || !individualNoteLoaded.value || !notesPersistence.canEdit(item)) return;
   const my = ++saveReqId;
   const markdown = notesMarkdown.value;
@@ -1632,6 +1736,18 @@ const durationLabel = computed<string | null>(() => {
   font-family: inherit; font-size: 14px; font-weight: 600; color: #1a1a1a; cursor: pointer;
 }
 .btn-share:hover { background: #fbfbfb; }
+/* Same shape as .btn-share, but it reads destructive only on hover — this sits
+   next to Close and must not shout at the user on every local note. */
+.note-del-btn {
+  display: flex; align-items: center; gap: 6px;
+  height: 32px; padding: 0 12px;
+  background: #fff; border: 1px solid #d6d6d6; border-radius: 8px;
+  box-shadow: 2px 2px 0 #e7e5e2;
+  font-family: inherit; font-size: 14px; font-weight: 600; color: #6f6f6f; cursor: pointer;
+}
+.note-del-btn:hover:not(:disabled) { background: #fef2f2; border-color: #fca5a5; color: #dc2626; }
+.note-del-btn:disabled { opacity: 0.5; cursor: default; }
+.note-delete-error { margin: 0; padding: 8px 24px 0; font-size: 12px; color: #dc2626; }
 .btn-icon {
   width: 32px; height: 32px; display: flex; align-items: center; justify-content: center;
   background: #fff; border: 1px solid #d6d6d6; border-radius: 8px; box-shadow: 2px 2px 0 #e7e5e2;

--- a/src/views/RecordingDeleteConfirmDialog.vue
+++ b/src/views/RecordingDeleteConfirmDialog.vue
@@ -8,11 +8,8 @@
     @click.self="$emit('cancel')"
   >
     <div class="rec-del__card">
-      <h2 id="rec-del-title" class="rec-del__title">Delete this recording?</h2>
-      <p class="rec-del__body">
-        This removes the selected recording and its transcript from the meeting.
-        The meeting's other recordings and notes are kept. This can't be undone.
-      </p>
+      <h2 id="rec-del-title" class="rec-del__title">{{ title }}</h2>
+      <p class="rec-del__body">{{ body }}</p>
       <div class="rec-del__actions">
         <button class="secondary-btn" @click="$emit('cancel')">Cancel</button>
         <button class="danger-btn" @click="$emit('confirm')">Delete</button>
@@ -22,7 +19,14 @@
 </template>
 
 <script setup lang="ts">
-defineProps<{ open: boolean }>();
+// Shared by the per-clip delete (the defaults) and the whole-note delete, which
+// passes its own copy — same modal, same danger styling, different stakes.
+withDefaults(defineProps<{ open: boolean; title?: string; body?: string }>(), {
+  title: 'Delete this recording?',
+  body:
+    "This removes the selected recording and its transcript from the meeting. " +
+    "The meeting's other recordings and notes are kept. This can't be undone.",
+});
 defineEmits<{ (e: 'confirm'): void; (e: 'cancel'): void }>();
 </script>
 


### PR DESCRIPTION
## What does this PR do?

Adds a Delete action for meeting notes recorded by the local backend. Closes #360.

Local notes previously had no way to be removed — the only delete affordance was the **per-clip** one, which removes a single recording session from a meeting rather than the meeting itself (`MeetingDetailView.vue` even said so in a comment: *"oats has no whole-recording delete"*).

**Backend** — new `delete_local_recording(id)` command: validates the id, refuses while the recording is `Recording`/`Transcribing`, removes the vault note + audio attachment, then `remove_dir_all`s `~/.ariso/recordings/<id>/`.

Vault artifacts go first on purpose. A partial failure leaves the library row in place as an idempotent retry handle; the reverse order could orphan a note in the user's Obsidian vault with no UI path back to it.

**Frontend** — a Delete button in the detail header, local notes only. `RecordingDeleteConfirmDialog` gained optional `title`/`body` props (defaulting to the existing clip copy) so one modal serves both flows. The whole-note copy names the note and says plainly that the Obsidian file and audio go too, since that reaches outside oats' own storage. On success the Library drops the row and clears the selection *without* the usual notes autosave — the folder is gone — then re-syncs from disk. On failure the note is preserved and an inline error appears.

**Why delete is blocked mid-flight:** the finalize/STT and notes tasks run detached and write into the vault root, which survives the delete. Deleting while they're in flight could resurrect the note as an orphan `.md` in Obsidian with no library row pointing at it. The Rust command refuses the recording/transcribing cases; the UI also disables the button while AI notes are generating, where the poller already knows. A failed recording *is* deletable — that's the case users most want.

**Ariso meetings are unchanged.** The button is `v-if="detail.isLocal"`, and `ArisoBackend.deleteMeeting` throws.

Two supporting changes beyond the feature:
- `loadMeetings` gains a `silent` flag — the post-delete re-sync was blanking the sidebar to "Loading…", undoing the immediate row removal.
- `recording_dir` now rejects a bare `"."`, which resolved to the recordings root. Harmless for a read; not for a `remove_dir_all`. Came out of the security review below.

## Type of change

- [x] `feat:` — new feature

## How was this tested?

TDD throughout — every test was written first and watched fail.

- **Rust** (5 new): removes dir + vault note + attachment; legacy recording without `audio_file`; refuses while `Recording`/`Transcribing`; missing recording; traversal ids. Plus `"."` added to the existing `recording_dir` traversal test.
- **Frontend** (17 new): `LocalBackend.deleteMeeting` forwards and propagates failures / `ArisoBackend` rejects; no button for cloud; deletes on confirm and emits; the confirmation names the note and mentions the vault; cancel is a no-op; disabled while capturing and while notes generate; enabled after a failed transcription; failure shows an error and does not emit; autosave suppressed after delete; Library drops the row, clears selection, re-syncs, drops the row without waiting on the reload, and skips the autosave.

Suites: **877/877 frontend**, **318 Rust** (`--test-threads=1`), clippy clean, `vite build` clean.

A security pass on the diff (path traversal / arbitrary file deletion, symlink following in `remove_dir_all`, offline-mode invariant, capability surface, data in logs) returned **no findings at any severity**. The `"."` guard above was the one residual edge it surfaced, now closed.

## Screenshots / recordings

None — **not exercised in the running app.** The `oats-desktop` MCP server failed to connect in this session, so this is test-verified only. Worth a manual pass with the Local backend before merge: delete a finished note, cancel one, and confirm the Obsidian note + `Attachments/*.mp3` disappear.

## Checklist

- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I ran `npm test` and the suite passes
- [x] I tested the change in the app — see above, not done

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added permanent deletion for local recordings and their associated files.
  * Added confirmation prompts with customizable titles and messages.
  * Meeting lists now update immediately after deletion without disruptive loading states.
* **Bug Fixes**
  * Prevented deletion while recording or transcription is still in progress.
  * Prevented deletion when completed recordings have pending AI notes.
  * Prevented note autosaves from racing with or occurring after deletion.
  * Clarified that whole-meeting deletion is unavailable for Ariso meetings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->