### PR TITLE
feat(library): Meetings backend indicator (#370 part 3)

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -213,20 +213,31 @@ pub async fn is_session_valid(app: &tauri::AppHandle) -> bool {
     false
 }
 
-// Both writers redraw the tray: its idle menu offers sign-in only while no
-// session is stored, and the token also changes from native code (a server
-// rejection clears it) that no window hears about.
+/// Broadcast to every window whenever the stored session changes. Carries no
+/// payload: the token stays scoped to the webview that signed in, so listeners
+/// re-read state through `check_session`.
+pub(crate) const AUTH_CHANGED_EVENT: &str = "auth://changed";
+
+// Both writers go through here. The tray's idle menu offers sign-in only while
+// no session is stored, and every window's account UI follows the session too.
+// The token also changes from native code (a server rejection clears it) that
+// no window hears about otherwise.
+fn on_session_changed(app: &tauri::AppHandle) {
+    crate::tray::refresh(app, true);
+    let _ = app.emit(AUTH_CHANGED_EVENT, ());
+}
+
 fn set_session_token(app: &tauri::AppHandle, token: &str) -> Result<(), String> {
     let store = app.store(STORE_PATH).map_err(|e| e.to_string())?;
     store.set(SESSION_KEY, serde_json::json!(token));
-    crate::tray::refresh(app, true);
+    on_session_changed(app);
     store.save().map_err(|e| e.to_string())
 }
 
 pub(crate) fn clear_session_token(app: &tauri::AppHandle) -> Result<(), String> {
     let store = app.store(STORE_PATH).map_err(|e| e.to_string())?;
     store.delete(SESSION_KEY);
-    crate::tray::refresh(app, true);
+    on_session_changed(app);
     store.save().map_err(|e| e.to_string())
 }
 
@@ -346,17 +357,22 @@ fn attach_sign_in_handle(id: u64, handle: tauri::async_runtime::JoinHandle<()>) 
     }
 }
 
-/// Cancel whatever browser attempt is pending, if any. Returns the flow that
-/// was cancelled so the caller emits on the event its waiter is listening to —
-/// cancelling a calendar connect with an `oauth-result` would leave the
-/// frontend promise hanging until the timeout — and the owner, so the cancel
-/// reaches the window that is waiting rather than the one that asked.
-fn abort_pending_sign_in() -> Option<(BrowserFlow, String)> {
-    let p = PENDING_SIGN_IN.lock().unwrap().take()?;
+/// Cancel the pending browser attempt if the webview labeled `owner` started
+/// it. Another window's attempt is left alone: a stale Cancel click, or a
+/// window cleaning up after itself, must not abort a flow someone else is
+/// waiting on. Returns the flow that was cancelled so the caller emits on the
+/// event its waiter is listening to — cancelling a calendar connect with an
+/// `oauth-result` would leave the frontend promise hanging until the timeout.
+fn abort_pending_sign_in(owner: &str) -> Option<BrowserFlow> {
+    let mut slot = PENDING_SIGN_IN.lock().unwrap();
+    if !matches!(slot.as_ref(), Some(p) if p.owner == owner) {
+        return None;
+    }
+    let p = slot.take()?;
     if let Some(handle) = p.handle {
         abort_pending_handle(handle);
     }
-    Some((p.flow, p.owner))
+    Some(p.flow)
 }
 
 /// Atomically retire attempt `id` — clear the slot only if it still holds
@@ -824,14 +840,15 @@ pub async fn microsoft_sign_in(window: tauri::WebviewWindow) -> Result<SignInRes
     browser_oauth_sign_in(window, SignInProvider::Microsoft).await
 }
 
-/// Abort a pending browser flow (the user gave up waiting): a sign-in with
-/// either provider, or the Calendar connect hop. Resolves the pending wait
-/// with the silent-cancel error, in the window that started the attempt
-/// (which need not be the one invoking cancel).
+/// Abort the calling window's pending browser flow (the user gave up
+/// waiting): a sign-in with either provider, or the Calendar connect hop.
+/// Resolves that window's pending wait with the silent-cancel error. A flow
+/// another window started is not this window's to cancel, so it keeps running.
 #[tauri::command]
 pub async fn cancel_sign_in(window: tauri::WebviewWindow) -> Result<(), String> {
-    if let Some((flow, owner)) = abort_pending_sign_in() {
-        emit_flow_canceled(&window, &owner, flow);
+    let owner = window.label();
+    if let Some(flow) = abort_pending_sign_in(owner) {
+        emit_flow_canceled(&window, owner, flow);
     }
     Ok(())
 }
@@ -2519,6 +2536,11 @@ pub fn share_text_native(_text: String, _anchor: ShareAnchor) -> Result<(), Stri
 mod tests {
     use super::*;
 
+    /// Empty the process-wide sign-in slot, whoever owns the attempt in it.
+    fn clear_sign_in_slot() {
+        PENDING_SIGN_IN.lock().unwrap().take();
+    }
+
     // A recording requested while the pill still holds the window slot is
     // dropped after the yield timeout. What the user is told about it must match
     // the state the pill is actually in (#320).
@@ -2606,11 +2628,11 @@ mod tests {
         // Cancel arrives before the loopback listener task exists (still
         // awaiting prepare-state) — it must still find something to cancel
         // instead of silently no-oping.
-        assert!(abort_pending_sign_in().is_some());
+        assert!(abort_pending_sign_in("settings").is_some());
         assert!(!sign_in_attempt_active(id));
 
         // A cancel with nothing pending is a no-op, not an error.
-        assert!(abort_pending_sign_in().is_none());
+        assert!(abort_pending_sign_in("settings").is_none());
     }
 
     #[test]
@@ -2619,15 +2641,12 @@ mod tests {
         // flows listen on different events, so emitting an oauth-result over a
         // pending calendar connect would hang the frontend until the timeout.
         begin_sign_in_attempt(BrowserFlow::SignIn, "settings");
-        assert_eq!(
-            abort_pending_sign_in(),
-            Some((BrowserFlow::SignIn, "settings".to_string()))
-        );
+        assert_eq!(abort_pending_sign_in("settings"), Some(BrowserFlow::SignIn));
 
         begin_sign_in_attempt(BrowserFlow::CalendarConnect, "settings");
         assert_eq!(
-            abort_pending_sign_in(),
-            Some((BrowserFlow::CalendarConnect, "settings".to_string()))
+            abort_pending_sign_in("settings"),
+            Some(BrowserFlow::CalendarConnect)
         );
 
         assert_eq!(BrowserFlow::SignIn.result_event(), "oauth-result");
@@ -2669,7 +2688,7 @@ mod tests {
             id // guard drops here, as it would on an early `?` return
         };
         assert!(!sign_in_attempt_active(id));
-        assert!(abort_pending_sign_in().is_none());
+        assert!(abort_pending_sign_in("settings").is_none());
     }
 
     #[test]
@@ -2681,10 +2700,7 @@ mod tests {
             attempt.release()
         };
         assert!(sign_in_attempt_active(id));
-        assert_eq!(
-            abort_pending_sign_in(),
-            Some((BrowserFlow::SignIn, "onboarding".to_string()))
-        );
+        assert_eq!(abort_pending_sign_in("onboarding"), Some(BrowserFlow::SignIn));
     }
 
     #[test]
@@ -2700,7 +2716,7 @@ mod tests {
     #[test]
     fn begin_sign_in_attempt_reports_the_attempt_it_supersedes() {
         // Start from an empty slot: the slot is process-wide.
-        abort_pending_sign_in();
+        clear_sign_in_slot();
 
         let (_, prev) = begin_sign_in_attempt(BrowserFlow::SignIn, "onboarding");
         assert_eq!(prev, None);
@@ -2710,22 +2726,39 @@ mod tests {
         let (_, prev) = begin_sign_in_attempt(BrowserFlow::SignIn, "settings");
         assert_eq!(prev, Some((BrowserFlow::SignIn, "onboarding".to_string())));
 
-        let (attempt, prev) = SignInAttemptGuard::begin(BrowserFlow::CalendarConnect, "onboarding");
+        // The Meetings window's popover can supersede Settings the same way.
+        let (_, prev) = begin_sign_in_attempt(BrowserFlow::SignIn, "library");
         assert_eq!(prev, Some((BrowserFlow::SignIn, "settings".to_string())));
+
+        let (attempt, prev) = SignInAttemptGuard::begin(BrowserFlow::CalendarConnect, "onboarding");
+        assert_eq!(prev, Some((BrowserFlow::SignIn, "library".to_string())));
         drop(attempt);
-        assert_eq!(abort_pending_sign_in(), None);
+        assert_eq!(abort_pending_sign_in("onboarding"), None);
     }
 
     #[test]
-    fn abort_pending_sign_in_reports_the_owner_of_the_attempt() {
-        // Cancel resolves the owner's waiter, not the window that invoked it.
-        abort_pending_sign_in();
-        begin_sign_in_attempt(BrowserFlow::CalendarConnect, "onboarding");
+    fn abort_pending_sign_in_cancels_the_owners_attempt() {
+        clear_sign_in_slot();
+        let (id, _) = begin_sign_in_attempt(BrowserFlow::CalendarConnect, "settings");
         assert_eq!(
-            abort_pending_sign_in(),
-            Some((BrowserFlow::CalendarConnect, "onboarding".to_string()))
+            abort_pending_sign_in("settings"),
+            Some(BrowserFlow::CalendarConnect)
         );
-        assert_eq!(abort_pending_sign_in(), None);
+        assert!(!sign_in_attempt_active(id));
+        assert_eq!(abort_pending_sign_in("settings"), None);
+    }
+
+    #[test]
+    fn abort_pending_sign_in_leaves_another_windows_attempt_running() {
+        // Settings' stale Cancel must not abort the attempt the Meetings
+        // window's popover started after superseding it.
+        clear_sign_in_slot();
+        let (id, _) = begin_sign_in_attempt(BrowserFlow::SignIn, "library");
+        assert_eq!(abort_pending_sign_in("settings"), None);
+        assert!(sign_in_attempt_active(id));
+
+        assert_eq!(abort_pending_sign_in("library"), Some(BrowserFlow::SignIn));
+        assert!(!sign_in_attempt_active(id));
     }
 
     #[test]
@@ -2805,7 +2838,7 @@ mod tests {
         attach_sign_in_handle(second_id, handle);
         assert!(sign_in_attempt_active(second_id));
 
-        assert!(abort_pending_sign_in().is_some());
+        assert!(abort_pending_sign_in("settings").is_some());
         assert!(!sign_in_attempt_active(second_id));
     }
 

--- a/src/composables/useAccountState.test.ts
+++ b/src/composables/useAccountState.test.ts
@@ -1,0 +1,274 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { flushPromises } from '@vue/test-utils';
+
+type SignInResult = { success?: boolean; sessionToken?: string; error?: string };
+const checkSession = vi.fn((): Promise<unknown> => Promise.resolve(null));
+const googleSignIn = vi.fn((): Promise<SignInResult> => Promise.resolve({ success: true }));
+const microsoftSignIn = vi.fn((): Promise<SignInResult> => Promise.resolve({ success: true }));
+const cancelSignIn = vi.fn(() => Promise.resolve());
+const signOut = vi.fn(() => Promise.resolve());
+const apiRequest = vi.fn(
+  (_method: string, _path: string): Promise<{ status: number; data: unknown }> =>
+    Promise.resolve({ status: 200, data: {} })
+);
+const emitNotificationsSync = vi.fn(() => Promise.resolve());
+
+vi.mock('../tauri', () => ({
+  SIGN_IN_CANCELED_ERROR: 'Sign-in canceled',
+  auth: {
+    checkSession: () => checkSession(),
+    googleSignIn: () => googleSignIn(),
+    microsoftSignIn: () => microsoftSignIn(),
+    cancelSignIn: () => cancelSignIn(),
+    signOut: () => signOut(),
+  },
+  api: {
+    request: (method: string, path: string) => apiRequest(method, path),
+  },
+}));
+vi.mock('./useMeetingNotifications', () => ({
+  emitNotificationsSync: () => emitNotificationsSync(),
+}));
+
+import { useAccountState } from './useAccountState';
+
+// The avatar is preloaded through a detached Image; let it load immediately.
+class FakeImage {
+  referrerPolicy = '';
+  onload: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+  set src(_v: string) {
+    queueMicrotask(() => this.onload?.());
+  }
+}
+
+function mockProfile() {
+  apiRequest.mockImplementation((_method: string, path: string) => {
+    if (path === '/auth/me') {
+      return Promise.resolve({
+        status: 200,
+        data: { full_name: 'Ada Lovelace', email: 'ada@example.com' },
+      });
+    }
+    if (path === '/users/google-avatar') {
+      return Promise.resolve({ status: 200, data: { avatar: 'https://example.com/a.png' } });
+    }
+    return Promise.resolve({ status: 200, data: {} });
+  });
+}
+
+function profileFetches(): number {
+  return apiRequest.mock.calls.filter((call) => call[1] === '/auth/me').length;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.stubGlobal('Image', FakeImage);
+  checkSession.mockResolvedValue(null);
+  googleSignIn.mockResolvedValue({ success: true });
+  microsoftSignIn.mockResolvedValue({ success: true });
+  apiRequest.mockResolvedValue({ status: 200, data: {} });
+});
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('useAccountState refresh', () => {
+  it('reflects a signed-in session and loads the profile', async () => {
+    checkSession.mockResolvedValue({ sessionToken: 't' });
+    mockProfile();
+    const account = useAccountState();
+    expect(account.checked.value).toBe(false);
+
+    await account.refresh();
+
+    expect(account.checked.value).toBe(true);
+    expect(account.isSignedIn.value).toBe(true);
+    expect(account.displayName.value).toBe('Ada Lovelace');
+    expect(account.email.value).toBe('ada@example.com');
+    expect(account.avatarUrl.value).toBe('https://example.com/a.png');
+    expect(account.initials.value).toBe('AD');
+  });
+
+  it('reflects a missing session without fetching a profile', async () => {
+    const account = useAccountState();
+    await account.refresh();
+
+    expect(account.checked.value).toBe(true);
+    expect(account.isSignedIn.value).toBe(false);
+    expect(apiRequest).not.toHaveBeenCalled();
+  });
+
+  it('never throws, and treats a failed check as signed out', async () => {
+    checkSession.mockResolvedValue({ sessionToken: 't' });
+    mockProfile();
+    const account = useAccountState();
+    await account.refresh();
+
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    checkSession.mockRejectedValue(new Error('offline'));
+    await expect(account.refresh()).resolves.toBeUndefined();
+
+    expect(account.isSignedIn.value).toBe(false);
+    expect(account.displayName.value).toBe('');
+    expect(account.avatarUrl.value).toBe('');
+  });
+
+  it('shares one in-flight refresh between concurrent calls', async () => {
+    checkSession.mockResolvedValue({ sessionToken: 't' });
+    mockProfile();
+    const account = useAccountState();
+
+    await Promise.all([account.refresh(), account.refresh(), account.refresh()]);
+
+    expect(checkSession).toHaveBeenCalledTimes(1);
+    expect(profileFetches()).toBe(1);
+
+    // Once it settles, the next call reads fresh state again.
+    await account.refresh();
+    expect(checkSession).toHaveBeenCalledTimes(2);
+  });
+
+  it('drops a refresh that started before a sign-out', async () => {
+    let resolveCheck!: (v: unknown) => void;
+    checkSession.mockReturnValueOnce(new Promise((resolve) => (resolveCheck = resolve)));
+    mockProfile();
+    const account = useAccountState();
+    const stale = account.refresh();
+
+    await account.signOut();
+    resolveCheck({ sessionToken: 't' });
+    await stale;
+
+    expect(account.isSignedIn.value).toBe(false);
+    expect(account.displayName.value).toBe('');
+  });
+
+  it('reset forgets the account without asking the backend', async () => {
+    checkSession.mockResolvedValue({ sessionToken: 't' });
+    mockProfile();
+    const account = useAccountState();
+    await account.refresh();
+    checkSession.mockClear();
+
+    account.reset();
+
+    expect(account.isSignedIn.value).toBe(false);
+    expect(account.checked.value).toBe(false);
+    expect(account.email.value).toBe('');
+    expect(checkSession).not.toHaveBeenCalled();
+  });
+});
+
+describe('useAccountState signIn', () => {
+  it.each([
+    ['google', googleSignIn, microsoftSignIn],
+    ['microsoft', microsoftSignIn, googleSignIn],
+  ] as const)('%s runs its own flow, syncs notifications, and loads the account', async (provider, used, unused) => {
+    checkSession.mockResolvedValue({ sessionToken: 't' });
+    mockProfile();
+    const account = useAccountState();
+
+    const result = await account.signIn(provider);
+
+    expect(result).toEqual({ success: true });
+    expect(used).toHaveBeenCalledTimes(1);
+    expect(unused).not.toHaveBeenCalled();
+    expect(emitNotificationsSync).toHaveBeenCalledTimes(1);
+    expect(account.isSignedIn.value).toBe(true);
+    expect(account.email.value).toBe('ada@example.com');
+    expect(account.signingInWith.value).toBeNull();
+  });
+
+  it('marks the pending provider until the flow resolves', async () => {
+    let resolveSignIn!: (r: SignInResult) => void;
+    microsoftSignIn.mockReturnValue(new Promise((resolve) => (resolveSignIn = resolve)));
+    const account = useAccountState();
+
+    const pending = account.signIn('microsoft');
+    expect(account.signingInWith.value).toBe('microsoft');
+
+    resolveSignIn({ error: 'Sign-in canceled' });
+    await pending;
+    expect(account.signingInWith.value).toBeNull();
+  });
+
+  it('stays silent on a cancel', async () => {
+    googleSignIn.mockResolvedValue({ error: 'Sign-in canceled' });
+    const account = useAccountState();
+
+    const result = await account.signIn('google');
+
+    expect(result.error).toBe('Sign-in canceled');
+    expect(account.errorMessage.value).toBe('');
+    expect(account.isSignedIn.value).toBe(false);
+    expect(emitNotificationsSync).not.toHaveBeenCalled();
+    expect(checkSession).not.toHaveBeenCalled();
+  });
+
+  it('surfaces a failure as the error message', async () => {
+    microsoftSignIn.mockResolvedValue({ error: 'API returned 500' });
+    const account = useAccountState();
+
+    await account.signIn('microsoft');
+
+    expect(account.errorMessage.value).toBe('API returned 500');
+    expect(emitNotificationsSync).not.toHaveBeenCalled();
+  });
+
+  it('turns a thrown sign-in into an error result', async () => {
+    googleSignIn.mockRejectedValue(new Error('listener setup failed'));
+    const account = useAccountState();
+
+    const result = await account.signIn('google');
+
+    expect(result).toEqual({ error: 'listener setup failed' });
+    expect(account.errorMessage.value).toBe('listener setup failed');
+    expect(account.signingInWith.value).toBeNull();
+  });
+
+  it('fetches the profile once when the sign-in and its broadcast both refresh', async () => {
+    // The backend broadcasts AUTH_CHANGED_EVENT as it stores the token, just
+    // before the sign-in result reaches this window.
+    let resolveSignIn!: (r: SignInResult) => void;
+    googleSignIn.mockReturnValue(new Promise((resolve) => (resolveSignIn = resolve)));
+    checkSession.mockResolvedValue({ sessionToken: 't' });
+    mockProfile();
+    const account = useAccountState();
+
+    const signingIn = account.signIn('google');
+    const onBroadcast = account.refresh();
+    resolveSignIn({ success: true });
+    await Promise.all([signingIn, onBroadcast]);
+
+    expect(profileFetches()).toBe(1);
+  });
+});
+
+describe('useAccountState signOut and cancel', () => {
+  it('signOut clears the account and syncs notifications', async () => {
+    checkSession.mockResolvedValue({ sessionToken: 't' });
+    mockProfile();
+    const account = useAccountState();
+    await account.refresh();
+
+    await account.signOut();
+
+    expect(signOut).toHaveBeenCalledTimes(1);
+    expect(account.isSignedIn.value).toBe(false);
+    expect(account.displayName.value).toBe('');
+    expect(account.email.value).toBe('');
+    expect(account.avatarUrl.value).toBe('');
+    expect(emitNotificationsSync).toHaveBeenCalledTimes(1);
+  });
+
+  it('cancelSignIn asks the backend and swallows a failure', async () => {
+    cancelSignIn.mockRejectedValue(new Error('nothing pending'));
+    const account = useAccountState();
+
+    await expect(account.cancelSignIn()).resolves.toBeUndefined();
+    await flushPromises();
+    expect(cancelSignIn).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/composables/useAccountState.ts
+++ b/src/composables/useAccountState.ts
@@ -1,0 +1,224 @@
+import { computed, ref } from 'vue';
+import { SIGN_IN_CANCELED_ERROR, api, auth, type SignInResult } from '../tauri';
+import { emitNotificationsSync } from './useMeetingNotifications';
+
+export type SignInProvider = 'google' | 'microsoft';
+
+interface Profile {
+  displayName: string;
+  email: string;
+  avatarUrl: string;
+}
+
+const EMPTY_PROFILE: Profile = { displayName: '', email: '', avatarUrl: '' };
+
+async function fetchUserProfile(): Promise<Profile> {
+  const profile = { ...EMPTY_PROFILE };
+  try {
+    const res = await api.request('GET', '/auth/me');
+    const data = res.data as { full_name?: string; email?: string };
+    profile.displayName = data.full_name || '';
+    profile.email = data.email || '';
+  } catch {
+    // profile fetch failed — leave fields empty
+  }
+  // Avatar is fetched separately and is non-critical: a failure here must not
+  // disturb the name/email above, and the UI falls back to initials.
+  profile.avatarUrl = await fetchAvatar();
+  return profile;
+}
+
+// Which provider the user signed in with isn't recorded, so ask Google first
+// and fall back to Microsoft: an account has no avatar on the other provider.
+async function fetchAvatar(): Promise<string> {
+  for (const path of ['/users/google-avatar', '/users/microsoft-avatar']) {
+    try {
+      const res = await api.request('GET', path);
+      const avatar = (res.data as { avatar?: string | null } | null)?.avatar;
+      // Preload before binding to the <img>: WKWebView drops the very first
+      // request for a freshly-rendered <img> during the post-sign-in churn and
+      // never retries it, leaving a broken "?". Loading it through a detached
+      // Image first (which is not affected) warms the cache, so the bound <img>
+      // resolves instantly. Falls back to initials if it truly can't load.
+      if (avatar) return await preloadAvatar(avatar);
+    } catch {
+      // Try the next provider.
+    }
+  }
+  return '';
+}
+
+// Resolves to `url` once it loads in a detached Image (retrying a few times for
+// transient webview failures), or to '' so the caller falls back to initials.
+function preloadAvatar(url: string): Promise<string> {
+  return new Promise((resolve) => {
+    const MAX_ATTEMPTS = 4;
+    let attempts = 0;
+    const attempt = () => {
+      const img = new Image();
+      img.referrerPolicy = 'no-referrer';
+      img.onload = () => resolve(url);
+      img.onerror = () => {
+        attempts += 1;
+        if (attempts >= MAX_ATTEMPTS) {
+          resolve('');
+        } else {
+          setTimeout(attempt, 300 * attempts);
+        }
+      };
+      img.src = url;
+    };
+    attempt();
+  });
+}
+
+/**
+ * The signed-in Ariso account, as one window sees it. Every Tauri window is its
+ * own webview, so each calls this for its own instance and keeps it current by
+ * calling `refresh()` on AUTH_CHANGED_EVENT. Callers decide when to refresh:
+ * Local mode must never call it, because it hits the network.
+ */
+export function useAccountState() {
+  const isSignedIn = ref(false);
+  // False until the first refresh lands, so a view can tell "signed out" from
+  // "not known yet". Later refreshes keep showing the last known state.
+  const checked = ref(false);
+  const displayName = ref('');
+  const email = ref('');
+  const avatarUrl = ref('');
+  // The provider whose browser flow is pending. Both sign-in buttons disable
+  // while either is pending; only the clicked one reads "Continue in your browser…".
+  const signingInWith = ref<SignInProvider | null>(null);
+  const errorMessage = ref('');
+
+  const initials = computed(() => {
+    const name = displayName.value || email.value || '?';
+    return name.slice(0, 2).toUpperCase();
+  });
+
+  function applyProfile(profile: Profile) {
+    displayName.value = profile.displayName;
+    email.value = profile.email;
+    avatarUrl.value = profile.avatarUrl;
+  }
+
+  // Bumped whenever this window learns the session ended, so a refresh that
+  // started before then can't land its stale signed-in result afterwards.
+  let epoch = 0;
+  let inFlight: { epoch: number; promise: Promise<void> } | null = null;
+
+  async function load(mine: number) {
+    let signedIn = false;
+    let profile = EMPTY_PROFILE;
+    try {
+      signedIn = !!(await auth.checkSession());
+      if (signedIn) profile = await fetchUserProfile();
+    } catch (e) {
+      signedIn = false;
+      console.warn('Failed to refresh signed-in account', e);
+    }
+    if (mine !== epoch) return;
+    isSignedIn.value = signedIn;
+    applyProfile(profile);
+    checked.value = true;
+  }
+
+  /**
+   * Re-read the session and, when signed in, the profile. Never throws: a
+   * failure reads as signed out. Calls made while one is in flight share it,
+   * so a window's own sign-in and the AUTH_CHANGED_EVENT it triggers fetch the
+   * profile once.
+   */
+  function refresh(): Promise<void> {
+    if (inFlight && inFlight.epoch === epoch) return inFlight.promise;
+    const mine = epoch;
+    const promise = load(mine).finally(() => {
+      if (inFlight?.promise === promise) inFlight = null;
+    });
+    inFlight = { epoch: mine, promise };
+    return promise;
+  }
+
+  /** Forget the account without asking the backend, e.g. on a switch to Local. */
+  function reset() {
+    epoch += 1;
+    isSignedIn.value = false;
+    checked.value = false;
+    applyProfile(EMPTY_PROFILE);
+    errorMessage.value = '';
+  }
+
+  /**
+   * Run the provider's browser flow. Returns the result so the view can run
+   * its own follow-ups; a cancel resolves silently with SIGN_IN_CANCELED_ERROR.
+   * Emits no auth event: the backend broadcasts AUTH_CHANGED_EVENT itself.
+   */
+  async function signIn(provider: SignInProvider): Promise<SignInResult> {
+    const startedIn = epoch;
+    signingInWith.value = provider;
+    errorMessage.value = '';
+    try {
+      const result =
+        provider === 'google' ? await auth.googleSignIn() : await auth.microsoftSignIn();
+      if (result.error) {
+        if (result.error !== SIGN_IN_CANCELED_ERROR) {
+          errorMessage.value = result.error;
+        }
+        return result;
+      }
+      // Native orchestrators (tray next-meeting, notifications) restart on the
+      // bootstrap window's sync listener.
+      void emitNotificationsSync().catch((err) => {
+        console.warn('Failed to sync notifications after sign-in', err);
+      });
+      // A flow that completed after this window was reset (it switched to
+      // Local) is no longer this window's to show, and must not refresh.
+      if (startedIn !== epoch) return result;
+      isSignedIn.value = true;
+      await refresh();
+      return result;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Sign in failed';
+      errorMessage.value = message;
+      return { error: message };
+    } finally {
+      signingInWith.value = null;
+    }
+  }
+
+  // Abort this window's pending browser flow. The backend resolves the waiting
+  // sign-in call with the silent-cancel error, which resets the UI.
+  async function cancelSignIn() {
+    try {
+      await auth.cancelSignIn();
+    } catch {
+      /* nothing pending — ignore */
+    }
+  }
+
+  async function signOut() {
+    await auth.signOut();
+    epoch += 1;
+    isSignedIn.value = false;
+    applyProfile(EMPTY_PROFILE);
+    void emitNotificationsSync().catch((err) => {
+      console.warn('Failed to sync notifications after sign-out', err);
+    });
+  }
+
+  return {
+    isSignedIn,
+    checked,
+    displayName,
+    email,
+    avatarUrl,
+    initials,
+    signingInWith,
+    errorMessage,
+    refresh,
+    reset,
+    signIn,
+    cancelSignIn,
+    signOut,
+  };
+}

--- a/src/composables/useAccountState.ts
+++ b/src/composables/useAccountState.ts
@@ -53,12 +53,16 @@ async function fetchAvatar(): Promise<string> {
 function preloadAvatar(url: string): Promise<string> {
   return new Promise((resolve) => {
     const MAX_ATTEMPTS = 4;
+    const ATTEMPT_TIMEOUT_MS = 3000;
     let attempts = 0;
     const attempt = () => {
       const img = new Image();
       img.referrerPolicy = 'no-referrer';
-      img.onload = () => resolve(url);
-      img.onerror = () => {
+      let settled = false;
+      const fail = () => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timeoutId);
         attempts += 1;
         if (attempts >= MAX_ATTEMPTS) {
           resolve('');
@@ -66,6 +70,16 @@ function preloadAvatar(url: string): Promise<string> {
           setTimeout(attempt, 300 * attempts);
         }
       };
+      // Neither `load` nor `error` fires for some webview hangs; bound the
+      // wait so the attempt still settles and the retry sequence continues.
+      const timeoutId = setTimeout(fail, ATTEMPT_TIMEOUT_MS);
+      img.onload = () => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timeoutId);
+        resolve(url);
+      };
+      img.onerror = fail;
       img.src = url;
     };
     attempt();
@@ -105,9 +119,13 @@ export function useAccountState() {
   // Bumped whenever this window learns the session ended, so a refresh that
   // started before then can't land its stale signed-in result afterwards.
   let epoch = 0;
+  // Bumped on every load(), so a superseded in-flight request (e.g. one an
+  // authentication-change refresh raced past) can't land its result after a
+  // fresher one has already started or finished.
+  let requestId = 0;
   let inFlight: { epoch: number; promise: Promise<void> } | null = null;
 
-  async function load(mine: number) {
+  async function load(mine: number, myRequest: number) {
     let signedIn = false;
     let profile = EMPTY_PROFILE;
     try {
@@ -117,7 +135,7 @@ export function useAccountState() {
       signedIn = false;
       console.warn('Failed to refresh signed-in account', e);
     }
-    if (mine !== epoch) return;
+    if (mine !== epoch || myRequest !== requestId) return;
     isSignedIn.value = signedIn;
     applyProfile(profile);
     checked.value = true;
@@ -127,12 +145,15 @@ export function useAccountState() {
    * Re-read the session and, when signed in, the profile. Never throws: a
    * failure reads as signed out. Calls made while one is in flight share it,
    * so a window's own sign-in and the AUTH_CHANGED_EVENT it triggers fetch the
-   * profile once.
+   * profile once. Pass `force` for a refresh that must reflect the latest
+   * session rather than an older request's result — e.g. one triggered by an
+   * AUTH_CHANGED_EVENT that may have fired after another window's sign-out.
    */
-  function refresh(): Promise<void> {
-    if (inFlight && inFlight.epoch === epoch) return inFlight.promise;
+  function refresh(force = false): Promise<void> {
+    if (!force && inFlight && inFlight.epoch === epoch) return inFlight.promise;
     const mine = epoch;
-    const promise = load(mine).finally(() => {
+    const myRequest = ++requestId;
+    const promise = load(mine, myRequest).finally(() => {
       if (inFlight?.promise === promise) inFlight = null;
     });
     inFlight = { epoch: mine, promise };

--- a/src/tauri.ts
+++ b/src/tauri.ts
@@ -3,9 +3,10 @@ import { getCurrentWebviewWindow } from '@tauri-apps/api/webviewWindow';
 import { load } from '@tauri-apps/plugin-store';
 import { open as openDialog, save as saveDialog } from '@tauri-apps/plugin-dialog';
 
-// Broadcast when any window completes desktop auth. Settings is pre-created and
-// can mount before onboarding signs in, so it needs a cross-window refresh cue.
-export const AUTH_SIGNED_IN_EVENT = 'auth://signed-in';
+// Broadcast by the backend to every window whenever the stored session changes:
+// sign-in or sign-out from any window, or a native path clearing a session the
+// server rejected. It carries no payload; listeners re-read via checkSession().
+export const AUTH_CHANGED_EVENT = 'auth://changed';
 
 /** Header carrying the non-binary arguments of a raw-body command. */
 const RAW_META_HEADER = 'x-oats-meta';
@@ -23,7 +24,7 @@ function rawMetaOptions(meta: unknown): { headers: Record<string, string> } {
   return { headers: { [RAW_META_HEADER]: hex } };
 }
 
-interface SignInResult {
+export interface SignInResult {
   success?: boolean;
   sessionToken?: string;
   error?: string;
@@ -102,7 +103,10 @@ export const auth = {
     return browserSignIn('microsoft_sign_in');
   },
 
-  /** Abort whichever browser flow is pending: either sign-in, or Calendar connect. */
+  /**
+   * Abort this window's pending browser flow: either sign-in, or Calendar
+   * connect. A flow another window started is left running.
+   */
   async cancelSignIn(): Promise<void> {
     await invoke('cancel_sign_in');
   },

--- a/src/views/LibraryView.test.ts
+++ b/src/views/LibraryView.test.ts
@@ -2386,7 +2386,7 @@ describe('LibraryView backend indicator', () => {
   }
 
   function pill(wrapper: ReturnType<typeof mount>) {
-    return wrapper.get('.sidebar .account-pill');
+    return wrapper.get('.account-pill-wrap .account-pill');
   }
 
   // Every ariso.ai state carries the same label, so tell them apart by shape.
@@ -2396,13 +2396,24 @@ describe('LibraryView backend indicator', () => {
     return el.classes('account-pill--signed-out') ? 'signed-out' : 'signed-in';
   }
 
-  it('sits at the bottom-left, under the sidebar nav, not in the titlebar', async () => {
+  it('sits in the window corner, outside the titlebar and the sidebar', async () => {
     const wrapper = await mountOn('local');
 
+    const wrap = wrapper.get('.account-pill-wrap').element;
+    expect(wrap.parentElement?.classList.contains('library')).toBe(true);
     expect(wrapper.find('.titlebar .account-pill').exists()).toBe(false);
-    const wrap = wrapper.get('.sidebar .account-pill-wrap').element;
-    expect(wrap.previousElementSibling?.classList.contains('bottom-nav')).toBe(true);
-    expect(wrap.nextElementSibling).toBeNull();
+    expect(wrapper.find('.sidebar .account-pill').exists()).toBe(false);
+    expect(wrapper.find('.detail-wrap--clear-corner').exists()).toBe(false);
+  });
+
+  it('stays visible with the sidebar hidden, and keeps the detail card clear of it', async () => {
+    const wrapper = await mountOn('local');
+
+    await wrapper.get('.panel-toggle').trigger('click');
+
+    expect(wrapper.find('.sidebar').exists()).toBe(false);
+    expect(pill(wrapper).text()).toBe('Local');
+    expect(wrapper.find('.detail-wrap').classes()).toContain('detail-wrap--clear-corner');
   });
 
   it('shows a static Local badge and never checks the session, even on an auth broadcast', async () => {

--- a/src/views/LibraryView.test.ts
+++ b/src/views/LibraryView.test.ts
@@ -2386,8 +2386,24 @@ describe('LibraryView backend indicator', () => {
   }
 
   function pill(wrapper: ReturnType<typeof mount>) {
-    return wrapper.get('.titlebar .account-pill');
+    return wrapper.get('.sidebar .account-pill');
   }
+
+  // Every ariso.ai state carries the same label, so tell them apart by shape.
+  function pillState(wrapper: ReturnType<typeof mount>) {
+    const el = pill(wrapper);
+    if (el.element.tagName === 'SPAN') return el.text() === 'Local' ? 'local' : 'checking';
+    return el.classes('account-pill--signed-out') ? 'signed-out' : 'signed-in';
+  }
+
+  it('sits at the bottom-left, under the sidebar nav, not in the titlebar', async () => {
+    const wrapper = await mountOn('local');
+
+    expect(wrapper.find('.titlebar .account-pill').exists()).toBe(false);
+    const wrap = wrapper.get('.sidebar .account-pill-wrap').element;
+    expect(wrap.previousElementSibling?.classList.contains('bottom-nav')).toBe(true);
+    expect(wrap.nextElementSibling).toBeNull();
+  });
 
   it('shows a static Local badge and never checks the session, even on an auth broadcast', async () => {
     const wrapper = await mountOn('local');
@@ -2410,11 +2426,11 @@ describe('LibraryView backend indicator', () => {
     const wrapper = await mountOn('ariso');
 
     expect(pill(wrapper).element.tagName).toBe('SPAN');
-    expect(pill(wrapper).text()).toBe('Ariso');
+    expect(pill(wrapper).text()).toBe('ariso.ai');
 
     resolveCheck(null);
     await flushPromises();
-    expect(pill(wrapper).text()).toBe('Sign in');
+    expect(pillState(wrapper)).toBe('signed-out');
   });
 
   it('offers both providers from the Sign in pill when signed out', async () => {
@@ -2422,7 +2438,10 @@ describe('LibraryView backend indicator', () => {
 
     const signIn = pill(wrapper);
     expect(signIn.element.tagName).toBe('BUTTON');
-    expect(signIn.text()).toBe('Sign in');
+    // Named after the backend; the dot and the accessible name carry the state.
+    expect(signIn.text()).toBe('ariso.ai');
+    expect(signIn.find('.account-pill-dot').exists()).toBe(true);
+    expect(signIn.attributes('aria-label')).toContain('not signed in');
     expect(signIn.attributes('aria-expanded')).toBe('false');
 
     await signIn.trigger('click');
@@ -2443,7 +2462,8 @@ describe('LibraryView backend indicator', () => {
     const wrapper = await mountOn('ariso');
 
     expect(pill(wrapper).element.tagName).toBe('BUTTON');
-    expect(pill(wrapper).text()).toContain('Ariso');
+    expect(pillState(wrapper)).toBe('signed-in');
+    expect(pill(wrapper).text()).toContain('ariso.ai');
     expect(pill(wrapper).get('.account-pill-avatar').text()).toBe('AD');
     expect(pill(wrapper).attributes('title')).toBe('ada@example.com');
 
@@ -2493,7 +2513,7 @@ describe('LibraryView backend indicator', () => {
     expect(googleSignIn).not.toHaveBeenCalled();
     expect(emitNotificationsSync).toHaveBeenCalled();
     expect(wrapper.find('.sign-in-popover').exists()).toBe(false);
-    expect(pill(wrapper).text()).toContain('Ariso');
+    expect(pillState(wrapper)).toBe('signed-in');
     expect(pill(wrapper).attributes('title')).toBe('ada@example.com');
   });
 
@@ -2555,28 +2575,28 @@ describe('LibraryView backend indicator', () => {
   it('follows an auth broadcast without a remount', async () => {
     const wrapper = await mountOn('ariso');
     await pill(wrapper).trigger('click');
-    expect(pill(wrapper).text()).toBe('Sign in');
+    expect(pillState(wrapper)).toBe('signed-out');
 
     // Signed in from Settings or a tray row.
     checkSession.mockResolvedValue({ sessionToken: 't' });
     mockProfile();
     emitEvent('auth://changed', null);
     await flushPromises();
-    expect(pill(wrapper).text()).toContain('Ariso');
+    expect(pillState(wrapper)).toBe('signed-in');
     expect(wrapper.find('.sign-in-popover').exists()).toBe(false);
 
     // Then signed out elsewhere.
     checkSession.mockResolvedValue(null);
     emitEvent('auth://changed', null);
     await flushPromises();
-    expect(pill(wrapper).text()).toBe('Sign in');
+    expect(pillState(wrapper)).toBe('signed-out');
   });
 
   it('follows a backend switch without a remount, and asks nothing on Local', async () => {
     checkSession.mockResolvedValue({ sessionToken: 't' });
     mockProfile();
     const wrapper = await mountOn('ariso');
-    expect(pill(wrapper).text()).toContain('Ariso');
+    expect(pillState(wrapper)).toBe('signed-in');
 
     backendId.mockReturnValue('local');
     checkSession.mockClear();
@@ -2593,7 +2613,7 @@ describe('LibraryView backend indicator', () => {
     emitEvent('backend://changed', null);
     await flushPromises();
     expect(checkSession).toHaveBeenCalledTimes(1);
-    expect(pill(wrapper).text()).toBe('Sign in');
+    expect(pillState(wrapper)).toBe('signed-out');
   });
 
   it('hides the popover and cancels its pending flow on a switch to Local', async () => {

--- a/src/views/LibraryView.test.ts
+++ b/src/views/LibraryView.test.ts
@@ -2446,9 +2446,9 @@ describe('LibraryView backend indicator', () => {
 
     const signIn = pill(wrapper);
     expect(signIn.element.tagName).toBe('BUTTON');
-    // Named after the backend; the dot and the accessible name carry the state.
+    // Named after the backend; the tooltip and accessible name carry the state.
     expect(signIn.text()).toBe('ariso.ai');
-    expect(signIn.find('.account-pill-dot').exists()).toBe(true);
+    expect(signIn.attributes('title')).toContain('Not signed in');
     expect(signIn.attributes('aria-label')).toContain('not signed in');
     expect(signIn.attributes('aria-expanded')).toBe('false');
 

--- a/src/views/LibraryView.test.ts
+++ b/src/views/LibraryView.test.ts
@@ -27,6 +27,15 @@ const toggleMaximizeWindow = vi.fn(() => Promise.resolve());
 const closeWindow = vi.fn(() => Promise.resolve());
 const isWindowMaximized = vi.fn(() => Promise.resolve(false));
 const onWindowResized = vi.fn(() => Promise.resolve(() => undefined));
+type SignInResult = { success?: boolean; sessionToken?: string; error?: string };
+const checkSession = vi.fn((): Promise<unknown> => Promise.resolve(null));
+const googleSignIn = vi.fn((): Promise<SignInResult> => Promise.resolve({ success: true }));
+const microsoftSignIn = vi.fn((): Promise<SignInResult> => Promise.resolve({ success: true }));
+const cancelSignIn = vi.fn(() => Promise.resolve());
+const apiRequest = vi.fn(
+  (_method: string, _path: string): Promise<{ status: number; data: unknown }> =>
+    Promise.resolve({ status: 200, data: {} })
+);
 
 vi.mock('@tauri-apps/api/core', () => ({ invoke: (...a: unknown[]) => invoke(...a) }));
 vi.mock('@tauri-apps/api/webviewWindow', () => ({
@@ -128,6 +137,18 @@ function resolveProcessing(id: string): void {
 // through ../tauri; keep those mocked so jsdom never touches real IPC.
 // pending.list() is also mocked so the PendingUploads child never calls Tauri IPC.
 vi.mock('../tauri', () => ({
+  AUTH_CHANGED_EVENT: 'auth://changed',
+  SIGN_IN_CANCELED_ERROR: 'Sign-in canceled',
+  auth: {
+    checkSession: () => checkSession(),
+    googleSignIn: () => googleSignIn(),
+    microsoftSignIn: () => microsoftSignIn(),
+    cancelSignIn: () => cancelSignIn(),
+    signOut: () => Promise.resolve(),
+  },
+  api: {
+    request: (method: string, path: string) => apiRequest(method, path),
+  },
   local: {
     openRecordingFile: (id: string, kind: string) => openRecordingFile(id, kind),
     readRecordingAudio: (id: string) => readRecordingAudio(id),
@@ -207,6 +228,11 @@ beforeEach(() => {
   searchMeetings.mockResolvedValue([]);
   processingMock.tracked!.value = new Set();
   processingMock.version!.value = 0;
+  checkSession.mockResolvedValue(null);
+  googleSignIn.mockResolvedValue({ success: true });
+  microsoftSignIn.mockResolvedValue({ success: true });
+  cancelSignIn.mockResolvedValue(undefined);
+  apiRequest.mockResolvedValue({ status: 200, data: {} });
 });
 afterEach(() => {
   // Restore real timers even if a fake-timer test failed before its own
@@ -2337,5 +2363,265 @@ describe('LibraryView Todo tab', () => {
     expect(listActionItems).toHaveBeenCalledTimes(2);
     expect(wrapper.text()).toContain('Ship the RFC');
     expect(wrapper.text()).not.toContain('Send pricing deck');
+  });
+});
+
+describe('LibraryView backend indicator', () => {
+  function mockProfile() {
+    apiRequest.mockImplementation((_method: string, path: string) =>
+      Promise.resolve(
+        path === '/auth/me'
+          ? { status: 200, data: { full_name: 'Ada Lovelace', email: 'ada@example.com' } }
+          : { status: 200, data: {} }
+      )
+    );
+  }
+
+  async function mountOn(backend: 'ariso' | 'local') {
+    backendId.mockReturnValue(backend);
+    listMeetings.mockResolvedValue([]);
+    const wrapper = mount(LibraryView, { attachTo: document.body });
+    await flushPromises();
+    return wrapper;
+  }
+
+  function pill(wrapper: ReturnType<typeof mount>) {
+    return wrapper.get('.titlebar .account-pill');
+  }
+
+  it('shows a static Local badge and never checks the session, even on an auth broadcast', async () => {
+    const wrapper = await mountOn('local');
+
+    expect(pill(wrapper).element.tagName).toBe('SPAN');
+    expect(pill(wrapper).text()).toBe('Local');
+    expect(pill(wrapper).attributes('title')).toContain('Local mode');
+
+    emitEvent('auth://changed', null);
+    await flushPromises();
+
+    expect(checkSession).not.toHaveBeenCalled();
+    expect(apiRequest).not.toHaveBeenCalled();
+    expect(wrapper.find('.sign-in-popover').exists()).toBe(false);
+  });
+
+  it('shows Ariso, not yet clickable, until the first session check lands', async () => {
+    let resolveCheck!: (v: unknown) => void;
+    checkSession.mockReturnValue(new Promise((resolve) => (resolveCheck = resolve)));
+    const wrapper = await mountOn('ariso');
+
+    expect(pill(wrapper).element.tagName).toBe('SPAN');
+    expect(pill(wrapper).text()).toBe('Ariso');
+
+    resolveCheck(null);
+    await flushPromises();
+    expect(pill(wrapper).text()).toBe('Sign in');
+  });
+
+  it('offers both providers from the Sign in pill when signed out', async () => {
+    const wrapper = await mountOn('ariso');
+
+    const signIn = pill(wrapper);
+    expect(signIn.element.tagName).toBe('BUTTON');
+    expect(signIn.text()).toBe('Sign in');
+    expect(signIn.attributes('aria-expanded')).toBe('false');
+
+    await signIn.trigger('click');
+    await flushPromises();
+
+    const popover = wrapper.get('.sign-in-popover');
+    expect(popover.attributes('role')).toBe('dialog');
+    expect(popover.get('.google-btn').text()).toContain('Sign in with Google');
+    expect(popover.get('.microsoft-btn').text()).toContain('Sign in with Microsoft');
+    expect(pill(wrapper).attributes('aria-expanded')).toBe('true');
+    // Focus moves into the popover so the keyboard can pick a provider.
+    expect(document.activeElement).toBe(popover.get('.google-btn').element);
+  });
+
+  it('shows initials when signed in, and opens Settings on click', async () => {
+    checkSession.mockResolvedValue({ sessionToken: 't' });
+    mockProfile();
+    const wrapper = await mountOn('ariso');
+
+    expect(pill(wrapper).element.tagName).toBe('BUTTON');
+    expect(pill(wrapper).text()).toContain('Ariso');
+    expect(pill(wrapper).get('.account-pill-avatar').text()).toBe('AD');
+    expect(pill(wrapper).attributes('title')).toBe('ada@example.com');
+
+    await pill(wrapper).trigger('click');
+    expect(invoke).toHaveBeenCalledWith('create_settings_window', {});
+    expect(wrapper.find('.sign-in-popover').exists()).toBe(false);
+  });
+
+  it('shows the avatar image when the account has one', async () => {
+    class FakeImage {
+      referrerPolicy = '';
+      onload: (() => void) | null = null;
+      onerror: (() => void) | null = null;
+      set src(_v: string) {
+        queueMicrotask(() => this.onload?.());
+      }
+    }
+    vi.stubGlobal('Image', FakeImage);
+    checkSession.mockResolvedValue({ sessionToken: 't' });
+    apiRequest.mockImplementation((_method: string, path: string) =>
+      Promise.resolve(
+        path === '/users/google-avatar'
+          ? { status: 200, data: { avatar: 'https://example.com/a.png' } }
+          : { status: 200, data: { email: 'ada@example.com' } }
+      )
+    );
+    const wrapper = await mountOn('ariso');
+
+    expect(pill(wrapper).get('img.account-pill-avatar').attributes('src')).toBe(
+      'https://example.com/a.png'
+    );
+  });
+
+  it('signs in from the popover and switches to the signed-in pill', async () => {
+    const wrapper = await mountOn('ariso');
+    await pill(wrapper).trigger('click');
+
+    microsoftSignIn.mockImplementation(() => {
+      checkSession.mockResolvedValue({ sessionToken: 't' });
+      return Promise.resolve({ success: true });
+    });
+    mockProfile();
+    await wrapper.get('.sign-in-popover .microsoft-btn').trigger('click');
+    await flushPromises();
+
+    expect(microsoftSignIn).toHaveBeenCalledTimes(1);
+    expect(googleSignIn).not.toHaveBeenCalled();
+    expect(emitNotificationsSync).toHaveBeenCalled();
+    expect(wrapper.find('.sign-in-popover').exists()).toBe(false);
+    expect(pill(wrapper).text()).toContain('Ariso');
+    expect(pill(wrapper).attributes('title')).toBe('ada@example.com');
+  });
+
+  it('shows the pending flow with a Cancel, and a failure inline', async () => {
+    let resolveSignIn!: (r: SignInResult) => void;
+    googleSignIn.mockReturnValue(new Promise((resolve) => (resolveSignIn = resolve)));
+    const wrapper = await mountOn('ariso');
+    await pill(wrapper).trigger('click');
+    await wrapper.get('.sign-in-popover .google-btn').trigger('click');
+    await flushPromises();
+
+    expect(wrapper.get('.sign-in-popover .google-btn').text()).toContain('Continue in your browser…');
+    await wrapper.get('.sign-in-popover .sign-in-cancel').trigger('click');
+    expect(cancelSignIn).toHaveBeenCalledTimes(1);
+
+    resolveSignIn({ error: 'API returned 500' });
+    await flushPromises();
+    expect(wrapper.get('.sign-in-popover .sign-in-error').text()).toBe('API returned 500');
+  });
+
+  it('closes the popover on Escape and returns focus to the pill', async () => {
+    const wrapper = await mountOn('ariso');
+    await pill(wrapper).trigger('click');
+    await flushPromises();
+
+    await wrapper.get('.sign-in-popover .google-btn').trigger('keydown', { key: 'Escape' });
+
+    expect(wrapper.find('.sign-in-popover').exists()).toBe(false);
+    expect(document.activeElement).toBe(pill(wrapper).element);
+  });
+
+  it('closes the popover on an outside click, unless a flow is pending', async () => {
+    const wrapper = await mountOn('ariso');
+    await pill(wrapper).trigger('click');
+    await flushPromises();
+
+    // A click inside keeps it open.
+    wrapper.get('.sign-in-popover').element.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+    await flushPromises();
+    expect(wrapper.find('.sign-in-popover').exists()).toBe(true);
+
+    googleSignIn.mockReturnValue(new Promise(() => {}));
+    await wrapper.get('.sign-in-popover .google-btn').trigger('click');
+    document.body.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+    await flushPromises();
+    expect(wrapper.find('.sign-in-popover').exists()).toBe(true);
+  });
+
+  it('closes the popover on an outside click while idle', async () => {
+    const wrapper = await mountOn('ariso');
+    await pill(wrapper).trigger('click');
+    await flushPromises();
+
+    document.body.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+    await flushPromises();
+    expect(wrapper.find('.sign-in-popover').exists()).toBe(false);
+  });
+
+  it('follows an auth broadcast without a remount', async () => {
+    const wrapper = await mountOn('ariso');
+    await pill(wrapper).trigger('click');
+    expect(pill(wrapper).text()).toBe('Sign in');
+
+    // Signed in from Settings or a tray row.
+    checkSession.mockResolvedValue({ sessionToken: 't' });
+    mockProfile();
+    emitEvent('auth://changed', null);
+    await flushPromises();
+    expect(pill(wrapper).text()).toContain('Ariso');
+    expect(wrapper.find('.sign-in-popover').exists()).toBe(false);
+
+    // Then signed out elsewhere.
+    checkSession.mockResolvedValue(null);
+    emitEvent('auth://changed', null);
+    await flushPromises();
+    expect(pill(wrapper).text()).toBe('Sign in');
+  });
+
+  it('follows a backend switch without a remount, and asks nothing on Local', async () => {
+    checkSession.mockResolvedValue({ sessionToken: 't' });
+    mockProfile();
+    const wrapper = await mountOn('ariso');
+    expect(pill(wrapper).text()).toContain('Ariso');
+
+    backendId.mockReturnValue('local');
+    checkSession.mockClear();
+    apiRequest.mockClear();
+    emitEvent('backend://changed', null);
+    await flushPromises();
+    expect(pill(wrapper).text()).toBe('Local');
+    expect(checkSession).not.toHaveBeenCalled();
+    expect(apiRequest).not.toHaveBeenCalled();
+
+    // Back to Ariso: re-checked, not the stale signed-in state from before.
+    checkSession.mockResolvedValue(null);
+    backendId.mockReturnValue('ariso');
+    emitEvent('backend://changed', null);
+    await flushPromises();
+    expect(checkSession).toHaveBeenCalledTimes(1);
+    expect(pill(wrapper).text()).toBe('Sign in');
+  });
+
+  it('hides the popover and cancels its pending flow on a switch to Local', async () => {
+    googleSignIn.mockReturnValue(new Promise(() => {}));
+    const wrapper = await mountOn('ariso');
+    await pill(wrapper).trigger('click');
+    await wrapper.get('.sign-in-popover .google-btn').trigger('click');
+    await flushPromises();
+
+    backendId.mockReturnValue('local');
+    emitEvent('backend://changed', null);
+    await flushPromises();
+
+    expect(cancelSignIn).toHaveBeenCalledTimes(1);
+    expect(wrapper.find('.sign-in-popover').exists()).toBe(false);
+    expect(pill(wrapper).text()).toBe('Local');
+  });
+
+  it('does not cancel on a switch to Local when this window has no flow pending', async () => {
+    const wrapper = await mountOn('ariso');
+    await pill(wrapper).trigger('click');
+
+    backendId.mockReturnValue('local');
+    emitEvent('backend://changed', null);
+    await flushPromises();
+
+    // Another window's flow is not this window's to cancel.
+    expect(cancelSignIn).not.toHaveBeenCalled();
+    expect(wrapper.find('.sign-in-popover').exists()).toBe(false);
   });
 });

--- a/src/views/LibraryView.test.ts
+++ b/src/views/LibraryView.test.ts
@@ -2467,6 +2467,40 @@ describe('LibraryView backend indicator', () => {
     expect(document.activeElement).toBe(menuItem(wrapper, 'Local').element);
   });
 
+  it('grays the ariso.ai option while not signed in, but keeps it clickable', async () => {
+    const wrapper = await mountOn('ariso');
+    await openMenu(wrapper);
+
+    const ariso = menuItem(wrapper, 'ariso.ai');
+    expect(ariso.classes()).toContain('backend-menu-item--signed-out');
+    expect(ariso.attributes('disabled')).toBeUndefined();
+    expect(ariso.attributes('aria-label')).toBe('ariso.ai, not signed in');
+    expect(menuItem(wrapper, 'Local').classes()).not.toContain('backend-menu-item--signed-out');
+
+    await ariso.trigger('click');
+    await flushPromises();
+    expect(wrapper.find('.sign-in-popover').exists()).toBe(true);
+  });
+
+  it('shows the ariso.ai option normally once signed in', async () => {
+    checkSession.mockResolvedValue({ sessionToken: 't' });
+    mockProfile();
+    const wrapper = await mountOn('ariso');
+    await openMenu(wrapper);
+
+    const ariso = menuItem(wrapper, 'ariso.ai');
+    expect(ariso.classes()).not.toContain('backend-menu-item--signed-out');
+    expect(ariso.attributes('aria-label')).toBeUndefined();
+  });
+
+  it('grays the ariso.ai option on Local, which never checks the session', async () => {
+    const wrapper = await mountOn('local');
+    await openMenu(wrapper);
+
+    expect(menuItem(wrapper, 'ariso.ai').classes()).toContain('backend-menu-item--signed-out');
+    expect(checkSession).not.toHaveBeenCalled();
+  });
+
   it('opening the menu on Local asks nothing of the network', async () => {
     const wrapper = await mountOn('local');
     await openMenu(wrapper);

--- a/src/views/LibraryView.test.ts
+++ b/src/views/LibraryView.test.ts
@@ -2396,24 +2396,21 @@ describe('LibraryView backend indicator', () => {
     return el.classes('account-pill--signed-out') ? 'signed-out' : 'signed-in';
   }
 
-  it('sits in the window corner, outside the titlebar and the sidebar', async () => {
+  it('sits in the titlebar, right after the sidebar toggle', async () => {
     const wrapper = await mountOn('local');
 
-    const wrap = wrapper.get('.account-pill-wrap').element;
-    expect(wrap.parentElement?.classList.contains('library')).toBe(true);
-    expect(wrapper.find('.titlebar .account-pill').exists()).toBe(false);
+    const wrap = wrapper.get('.titlebar .account-pill-wrap').element;
+    expect(wrap.previousElementSibling?.classList.contains('panel-toggle')).toBe(true);
     expect(wrapper.find('.sidebar .account-pill').exists()).toBe(false);
-    expect(wrapper.find('.detail-wrap--clear-corner').exists()).toBe(false);
   });
 
-  it('stays visible with the sidebar hidden, and keeps the detail card clear of it', async () => {
+  it('stays visible with the sidebar hidden', async () => {
     const wrapper = await mountOn('local');
 
     await wrapper.get('.panel-toggle').trigger('click');
 
     expect(wrapper.find('.sidebar').exists()).toBe(false);
     expect(pill(wrapper).text()).toBe('Local');
-    expect(wrapper.find('.detail-wrap').classes()).toContain('detail-wrap--clear-corner');
   });
 
   it('shows a static Local badge and never checks the session, even on an auth broadcast', async () => {

--- a/src/views/LibraryView.test.ts
+++ b/src/views/LibraryView.test.ts
@@ -36,6 +36,10 @@ const apiRequest = vi.fn(
   (_method: string, _path: string): Promise<{ status: number; data: unknown }> =>
     Promise.resolve({ status: 200, data: {} })
 );
+const setBackendSetting = vi.fn((_backend: string) => Promise.resolve());
+const localModelStatus = vi.fn(
+  (): Promise<{ state: string; llmReady?: boolean }> => Promise.resolve({ state: 'ready', llmReady: true })
+);
 
 vi.mock('@tauri-apps/api/core', () => ({ invoke: (...a: unknown[]) => invoke(...a) }));
 vi.mock('@tauri-apps/api/webviewWindow', () => ({
@@ -149,7 +153,9 @@ vi.mock('../tauri', () => ({
   api: {
     request: (method: string, path: string) => apiRequest(method, path),
   },
+  setBackendSetting: (backend: string) => setBackendSetting(backend),
   local: {
+    modelStatus: () => localModelStatus(),
     openRecordingFile: (id: string, kind: string) => openRecordingFile(id, kind),
     readRecordingAudio: (id: string) => readRecordingAudio(id),
     readRecordingNote: (id: string) => readRecordingNote(id),
@@ -233,6 +239,8 @@ beforeEach(() => {
   microsoftSignIn.mockResolvedValue({ success: true });
   cancelSignIn.mockResolvedValue(undefined);
   apiRequest.mockResolvedValue({ status: 200, data: {} });
+  setBackendSetting.mockResolvedValue(undefined);
+  localModelStatus.mockResolvedValue({ state: 'ready', llmReady: true });
 });
 afterEach(() => {
   // Restore real timers even if a fake-timer test failed before its own
@@ -2389,11 +2397,17 @@ describe('LibraryView backend indicator', () => {
     return wrapper.get('.account-pill-wrap .account-pill');
   }
 
-  // Every ariso.ai state carries the same label, so tell them apart by shape.
-  function pillState(wrapper: ReturnType<typeof mount>) {
-    const el = pill(wrapper);
-    if (el.element.tagName === 'SPAN') return el.text() === 'Local' ? 'local' : 'checking';
-    return el.classes('account-pill--signed-out') ? 'signed-out' : 'signed-in';
+  function menuItem(wrapper: ReturnType<typeof mount>, label: string) {
+    const item = wrapper
+      .findAll('.backend-menu [role^="menuitem"]')
+      .find((el) => el.text() === label);
+    expect(item, `menu item "${label}"`).toBeDefined();
+    return item!;
+  }
+
+  async function openMenu(wrapper: ReturnType<typeof mount>) {
+    await pill(wrapper).trigger('click');
+    await flushPromises();
   }
 
   it('sits in the titlebar, right after the sidebar toggle', async () => {
@@ -2413,101 +2427,218 @@ describe('LibraryView backend indicator', () => {
     expect(pill(wrapper).text()).toBe('Local');
   });
 
-  it('shows a static Local badge and never checks the session, even on an auth broadcast', async () => {
+  it('names the backend, with its icon after the name', async () => {
+    const local = await mountOn('local');
+    expect(pill(local).text()).toBe('Local');
+    expect(pill(local).attributes('title')).toContain('Local mode');
+    expect(pill(local).element.lastElementChild?.tagName.toLowerCase()).toBe('svg');
+    local.unmount();
+
+    const ariso = await mountOn('ariso');
+    expect(pill(ariso).text()).toBe('ariso.ai');
+    expect(pill(ariso).attributes('title')).toBe('ariso.ai — not signed in');
+    expect(pill(ariso).element.lastElementChild?.tagName.toLowerCase()).toBe('svg');
+  });
+
+  it('carries the signed-in account in the tooltip', async () => {
+    checkSession.mockResolvedValue({ sessionToken: 't' });
+    mockProfile();
+    const wrapper = await mountOn('ariso');
+
+    expect(pill(wrapper).text()).toBe('ariso.ai');
+    expect(pill(wrapper).attributes('title')).toBe('ariso.ai — ada@example.com');
+  });
+
+  it('opens a menu of ariso.ai, Local, and Settings, each with its icon', async () => {
     const wrapper = await mountOn('local');
+    expect(pill(wrapper).attributes('aria-expanded')).toBe('false');
 
-    expect(pill(wrapper).element.tagName).toBe('SPAN');
-    expect(pill(wrapper).text()).toBe('Local');
-    expect(pill(wrapper).attributes('title')).toContain('Local mode');
+    await openMenu(wrapper);
 
+    const menu = wrapper.get('.backend-menu');
+    expect(menu.attributes('role')).toBe('menu');
+    const items = menu.findAll('[role^="menuitem"]');
+    expect(items.map((el) => el.text())).toEqual(['ariso.ai', 'Local', 'Settings']);
+    for (const el of items) expect(el.find('svg').exists()).toBe(true);
+    expect(pill(wrapper).attributes('aria-expanded')).toBe('true');
+    // The active backend is checked, and focus lands on it.
+    expect(menuItem(wrapper, 'Local').attributes('aria-checked')).toBe('true');
+    expect(menuItem(wrapper, 'ariso.ai').attributes('aria-checked')).toBe('false');
+    expect(document.activeElement).toBe(menuItem(wrapper, 'Local').element);
+  });
+
+  it('opening the menu on Local asks nothing of the network', async () => {
+    const wrapper = await mountOn('local');
+    await openMenu(wrapper);
     emitEvent('auth://changed', null);
     await flushPromises();
 
     expect(checkSession).not.toHaveBeenCalled();
     expect(apiRequest).not.toHaveBeenCalled();
-    expect(wrapper.find('.sign-in-popover').exists()).toBe(false);
   });
 
-  it('shows Ariso, not yet clickable, until the first session check lands', async () => {
-    let resolveCheck!: (v: unknown) => void;
-    checkSession.mockReturnValue(new Promise((resolve) => (resolveCheck = resolve)));
-    const wrapper = await mountOn('ariso');
+  it('moves through the menu with the arrow keys', async () => {
+    const wrapper = await mountOn('local');
+    await openMenu(wrapper);
+    const menu = wrapper.get('.backend-menu');
 
-    expect(pill(wrapper).element.tagName).toBe('SPAN');
-    expect(pill(wrapper).text()).toBe('ariso.ai');
-
-    resolveCheck(null);
-    await flushPromises();
-    expect(pillState(wrapper)).toBe('signed-out');
+    await menu.trigger('keydown', { key: 'ArrowDown' });
+    expect(document.activeElement).toBe(menuItem(wrapper, 'Settings').element);
+    await menu.trigger('keydown', { key: 'ArrowDown' });
+    expect(document.activeElement).toBe(menuItem(wrapper, 'ariso.ai').element);
+    await menu.trigger('keydown', { key: 'ArrowUp' });
+    expect(document.activeElement).toBe(menuItem(wrapper, 'Settings').element);
   });
 
-  it('offers both providers from the Sign in pill when signed out', async () => {
+  it('Settings opens the Settings window', async () => {
     const wrapper = await mountOn('ariso');
+    await openMenu(wrapper);
 
-    const signIn = pill(wrapper);
-    expect(signIn.element.tagName).toBe('BUTTON');
-    // Named after the backend; the tooltip and accessible name carry the state.
-    expect(signIn.text()).toBe('ariso.ai');
-    expect(signIn.attributes('title')).toContain('Not signed in');
-    expect(signIn.attributes('aria-label')).toContain('not signed in');
-    expect(signIn.attributes('aria-expanded')).toBe('false');
-
-    await signIn.trigger('click');
+    await menuItem(wrapper, 'Settings').trigger('click');
     await flushPromises();
 
-    const popover = wrapper.get('.sign-in-popover');
-    expect(popover.attributes('role')).toBe('dialog');
-    expect(popover.get('.google-btn').text()).toContain('Sign in with Google');
-    expect(popover.get('.microsoft-btn').text()).toContain('Sign in with Microsoft');
-    expect(pill(wrapper).attributes('aria-expanded')).toBe('true');
-    // Focus moves into the popover so the keyboard can pick a provider.
-    expect(document.activeElement).toBe(popover.get('.google-btn').element);
+    expect(invoke).toHaveBeenCalledWith('create_settings_window', {});
+    expect(wrapper.find('.backend-popover').exists()).toBe(false);
   });
 
-  it('shows initials when signed in, and opens Settings on click', async () => {
+  it('Local switches the backend and reloads against it', async () => {
+    const wrapper = await mountOn('ariso');
+    await openMenu(wrapper);
+    listMeetings.mockClear();
+    checkSession.mockClear();
+    backendId.mockReturnValue('local');
+
+    await menuItem(wrapper, 'Local').trigger('click');
+    await flushPromises();
+
+    expect(setBackendSetting).toHaveBeenCalledWith('local');
+    expect(emitAppEvent).toHaveBeenCalledWith(
+      'backend://changed',
+      expect.objectContaining({ source: expect.any(String) })
+    );
+    expect(emitNotificationsSync).toHaveBeenCalled();
+    expect(listMeetings).toHaveBeenCalled();
+    expect(pill(wrapper).text()).toBe('Local');
+    expect(checkSession).not.toHaveBeenCalled();
+    expect(wrapper.find('.backend-popover').exists()).toBe(false);
+    // Models are ready, so there's nothing for Settings to show.
+    expect(invoke).not.toHaveBeenCalledWith('create_settings_window', {});
+  });
+
+  it('Local brings up Settings when the on-device models still need downloading', async () => {
+    localModelStatus.mockResolvedValue({ state: 'not_downloaded' });
+    const wrapper = await mountOn('ariso');
+    await openMenu(wrapper);
+    backendId.mockReturnValue('local');
+
+    await menuItem(wrapper, 'Local').trigger('click');
+    await flushPromises();
+
+    expect(setBackendSetting).toHaveBeenCalledWith('local');
+    expect(invoke).toHaveBeenCalledWith('create_settings_window', {});
+  });
+
+  it('Local does nothing when it is already the backend', async () => {
+    const wrapper = await mountOn('local');
+    await openMenu(wrapper);
+
+    await menuItem(wrapper, 'Local').trigger('click');
+    await flushPromises();
+
+    expect(setBackendSetting).not.toHaveBeenCalled();
+    expect(wrapper.find('.backend-popover').exists()).toBe(false);
+  });
+
+  it('ignores its own backend broadcast when it comes back', async () => {
+    const wrapper = await mountOn('ariso');
+    await openMenu(wrapper);
+    backendId.mockReturnValue('local');
+    await menuItem(wrapper, 'Local').trigger('click');
+    await flushPromises();
+    listMeetings.mockClear();
+
+    const [, payload] = emitAppEvent.mock.calls.find((call) => call[0] === 'backend://changed')!;
+    emitEvent('backend://changed', payload);
+    await flushPromises();
+
+    expect(listMeetings).not.toHaveBeenCalled();
+  });
+
+  it('ariso.ai while signed out shows the sign-in box', async () => {
+    const wrapper = await mountOn('ariso');
+    await openMenu(wrapper);
+
+    await menuItem(wrapper, 'ariso.ai').trigger('click');
+    await flushPromises();
+
+    expect(setBackendSetting).not.toHaveBeenCalled();
+    expect(wrapper.find('.backend-menu').exists()).toBe(false);
+    const box = wrapper.get('.sign-in-popover');
+    expect(box.attributes('role')).toBe('dialog');
+    expect(box.text()).toContain('Sign in to ariso.ai');
+    expect(box.get('.google-btn').text()).toContain('Sign in with Google');
+    expect(box.get('.microsoft-btn').text()).toContain('Sign in with Microsoft');
+    expect(document.activeElement).toBe(box.get('.google-btn').element);
+  });
+
+  it('ariso.ai while signed in just closes the menu', async () => {
     checkSession.mockResolvedValue({ sessionToken: 't' });
     mockProfile();
     const wrapper = await mountOn('ariso');
+    await openMenu(wrapper);
 
-    expect(pill(wrapper).element.tagName).toBe('BUTTON');
-    expect(pillState(wrapper)).toBe('signed-in');
-    expect(pill(wrapper).text()).toContain('ariso.ai');
-    expect(pill(wrapper).get('.account-pill-avatar').text()).toBe('AD');
-    expect(pill(wrapper).attributes('title')).toBe('ada@example.com');
+    await menuItem(wrapper, 'ariso.ai').trigger('click');
+    await flushPromises();
 
-    await pill(wrapper).trigger('click');
-    expect(invoke).toHaveBeenCalledWith('create_settings_window', {});
-    expect(wrapper.find('.sign-in-popover').exists()).toBe(false);
+    expect(wrapper.find('.backend-popover').exists()).toBe(false);
+    expect(document.activeElement).toBe(pill(wrapper).element);
   });
 
-  it('shows the avatar image when the account has one', async () => {
-    class FakeImage {
-      referrerPolicy = '';
-      onload: (() => void) | null = null;
-      onerror: (() => void) | null = null;
-      set src(_v: string) {
-        queueMicrotask(() => this.onload?.());
-      }
-    }
-    vi.stubGlobal('Image', FakeImage);
+  it('ariso.ai from Local switches, then offers sign-in when there is no session', async () => {
+    const wrapper = await mountOn('local');
+    await openMenu(wrapper);
+    backendId.mockReturnValue('ariso');
+
+    await menuItem(wrapper, 'ariso.ai').trigger('click');
+    await flushPromises();
+
+    expect(setBackendSetting).toHaveBeenCalledWith('ariso');
+    expect(pill(wrapper).text()).toBe('ariso.ai');
+    expect(checkSession).toHaveBeenCalledTimes(1);
+    expect(wrapper.find('.sign-in-popover').exists()).toBe(true);
+  });
+
+  it('ariso.ai from Local closes the menu when a session already exists', async () => {
     checkSession.mockResolvedValue({ sessionToken: 't' });
-    apiRequest.mockImplementation((_method: string, path: string) =>
-      Promise.resolve(
-        path === '/users/google-avatar'
-          ? { status: 200, data: { avatar: 'https://example.com/a.png' } }
-          : { status: 200, data: { email: 'ada@example.com' } }
-      )
-    );
-    const wrapper = await mountOn('ariso');
+    mockProfile();
+    const wrapper = await mountOn('local');
+    await openMenu(wrapper);
+    backendId.mockReturnValue('ariso');
 
-    expect(pill(wrapper).get('img.account-pill-avatar').attributes('src')).toBe(
-      'https://example.com/a.png'
-    );
+    await menuItem(wrapper, 'ariso.ai').trigger('click');
+    await flushPromises();
+
+    expect(setBackendSetting).toHaveBeenCalledWith('ariso');
+    expect(wrapper.find('.backend-popover').exists()).toBe(false);
+    expect(pill(wrapper).attributes('title')).toBe('ariso.ai — ada@example.com');
   });
 
-  it('signs in from the popover and switches to the signed-in pill', async () => {
+  it('cannot switch backend while recording', async () => {
+    getAllWebviewWindows.mockResolvedValue([{ label: 'waveform' }]);
     const wrapper = await mountOn('ariso');
-    await pill(wrapper).trigger('click');
+    await openMenu(wrapper);
+
+    expect(menuItem(wrapper, 'ariso.ai').attributes('disabled')).toBeDefined();
+    expect(menuItem(wrapper, 'Local').attributes('disabled')).toBeDefined();
+    expect(menuItem(wrapper, 'Settings').attributes('disabled')).toBeUndefined();
+    expect(wrapper.get('.backend-menu').text()).toContain("Backend can't be changed while recording.");
+  });
+
+  it('signs in from the sign-in box and closes it', async () => {
+    const wrapper = await mountOn('ariso');
+    await openMenu(wrapper);
+    await menuItem(wrapper, 'ariso.ai').trigger('click');
+    await flushPromises();
 
     microsoftSignIn.mockImplementation(() => {
       checkSession.mockResolvedValue({ sessionToken: 't' });
@@ -2520,16 +2651,17 @@ describe('LibraryView backend indicator', () => {
     expect(microsoftSignIn).toHaveBeenCalledTimes(1);
     expect(googleSignIn).not.toHaveBeenCalled();
     expect(emitNotificationsSync).toHaveBeenCalled();
-    expect(wrapper.find('.sign-in-popover').exists()).toBe(false);
-    expect(pillState(wrapper)).toBe('signed-in');
-    expect(pill(wrapper).attributes('title')).toBe('ada@example.com');
+    expect(wrapper.find('.backend-popover').exists()).toBe(false);
+    expect(pill(wrapper).attributes('title')).toBe('ariso.ai — ada@example.com');
   });
 
   it('shows the pending flow with a Cancel, and a failure inline', async () => {
     let resolveSignIn!: (r: SignInResult) => void;
     googleSignIn.mockReturnValue(new Promise((resolve) => (resolveSignIn = resolve)));
     const wrapper = await mountOn('ariso');
-    await pill(wrapper).trigger('click');
+    await openMenu(wrapper);
+    await menuItem(wrapper, 'ariso.ai').trigger('click');
+    await flushPromises();
     await wrapper.get('.sign-in-popover .google-btn').trigger('click');
     await flushPromises();
 
@@ -2542,69 +2674,68 @@ describe('LibraryView backend indicator', () => {
     expect(wrapper.get('.sign-in-popover .sign-in-error').text()).toBe('API returned 500');
   });
 
-  it('closes the popover on Escape and returns focus to the pill', async () => {
+  it('closes on Escape and returns focus to the pill', async () => {
     const wrapper = await mountOn('ariso');
-    await pill(wrapper).trigger('click');
-    await flushPromises();
+    await openMenu(wrapper);
 
-    await wrapper.get('.sign-in-popover .google-btn').trigger('keydown', { key: 'Escape' });
+    await menuItem(wrapper, 'Local').trigger('keydown', { key: 'Escape' });
 
-    expect(wrapper.find('.sign-in-popover').exists()).toBe(false);
+    expect(wrapper.find('.backend-popover').exists()).toBe(false);
     expect(document.activeElement).toBe(pill(wrapper).element);
   });
 
-  it('closes the popover on an outside click, unless a flow is pending', async () => {
+  it('closes on an outside click while idle', async () => {
     const wrapper = await mountOn('ariso');
-    await pill(wrapper).trigger('click');
-    await flushPromises();
+    await openMenu(wrapper);
 
-    // A click inside keeps it open.
-    wrapper.get('.sign-in-popover').element.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+    wrapper.get('.backend-menu').element.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
     await flushPromises();
-    expect(wrapper.find('.sign-in-popover').exists()).toBe(true);
+    expect(wrapper.find('.backend-popover').exists()).toBe(true);
 
-    googleSignIn.mockReturnValue(new Promise(() => {}));
-    await wrapper.get('.sign-in-popover .google-btn').trigger('click');
     document.body.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
     await flushPromises();
-    expect(wrapper.find('.sign-in-popover').exists()).toBe(true);
+    expect(wrapper.find('.backend-popover').exists()).toBe(false);
   });
 
-  it('closes the popover on an outside click while idle', async () => {
+  it('keeps the sign-in box open on an outside click while a flow is pending', async () => {
+    googleSignIn.mockReturnValue(new Promise(() => {}));
     const wrapper = await mountOn('ariso');
-    await pill(wrapper).trigger('click');
+    await openMenu(wrapper);
+    await menuItem(wrapper, 'ariso.ai').trigger('click');
     await flushPromises();
+    await wrapper.get('.sign-in-popover .google-btn').trigger('click');
 
     document.body.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
     await flushPromises();
-    expect(wrapper.find('.sign-in-popover').exists()).toBe(false);
+    expect(wrapper.find('.sign-in-popover').exists()).toBe(true);
   });
 
   it('follows an auth broadcast without a remount', async () => {
     const wrapper = await mountOn('ariso');
-    await pill(wrapper).trigger('click');
-    expect(pillState(wrapper)).toBe('signed-out');
+    await openMenu(wrapper);
+    await menuItem(wrapper, 'ariso.ai').trigger('click');
+    await flushPromises();
+    expect(wrapper.find('.sign-in-popover').exists()).toBe(true);
 
     // Signed in from Settings or a tray row.
     checkSession.mockResolvedValue({ sessionToken: 't' });
     mockProfile();
     emitEvent('auth://changed', null);
     await flushPromises();
-    expect(pillState(wrapper)).toBe('signed-in');
+    expect(pill(wrapper).attributes('title')).toBe('ariso.ai — ada@example.com');
     expect(wrapper.find('.sign-in-popover').exists()).toBe(false);
 
     // Then signed out elsewhere.
     checkSession.mockResolvedValue(null);
     emitEvent('auth://changed', null);
     await flushPromises();
-    expect(pillState(wrapper)).toBe('signed-out');
+    expect(pill(wrapper).attributes('title')).toBe('ariso.ai — not signed in');
   });
 
-  it('follows a backend switch without a remount, and asks nothing on Local', async () => {
+  it('follows a backend switch made elsewhere, and asks nothing on Local', async () => {
     checkSession.mockResolvedValue({ sessionToken: 't' });
     mockProfile();
     const wrapper = await mountOn('ariso');
-    expect(pillState(wrapper)).toBe('signed-in');
 
     backendId.mockReturnValue('local');
     checkSession.mockClear();
@@ -2621,13 +2752,15 @@ describe('LibraryView backend indicator', () => {
     emitEvent('backend://changed', null);
     await flushPromises();
     expect(checkSession).toHaveBeenCalledTimes(1);
-    expect(pillState(wrapper)).toBe('signed-out');
+    expect(pill(wrapper).attributes('title')).toBe('ariso.ai — not signed in');
   });
 
-  it('hides the popover and cancels its pending flow on a switch to Local', async () => {
+  it('closes the sign-in box and cancels its pending flow on a switch to Local', async () => {
     googleSignIn.mockReturnValue(new Promise(() => {}));
     const wrapper = await mountOn('ariso');
-    await pill(wrapper).trigger('click');
+    await openMenu(wrapper);
+    await menuItem(wrapper, 'ariso.ai').trigger('click');
+    await flushPromises();
     await wrapper.get('.sign-in-popover .google-btn').trigger('click');
     await flushPromises();
 
@@ -2642,7 +2775,6 @@ describe('LibraryView backend indicator', () => {
 
   it('does not cancel on a switch to Local when this window has no flow pending', async () => {
     const wrapper = await mountOn('ariso');
-    await pill(wrapper).trigger('click');
 
     backendId.mockReturnValue('local');
     emitEvent('backend://changed', null);
@@ -2650,6 +2782,5 @@ describe('LibraryView backend indicator', () => {
 
     // Another window's flow is not this window's to cancel.
     expect(cancelSignIn).not.toHaveBeenCalled();
-    expect(wrapper.find('.sign-in-popover').exists()).toBe(false);
   });
 });

--- a/src/views/LibraryView.vue
+++ b/src/views/LibraryView.vue
@@ -73,6 +73,92 @@
           {{ recordingStarting ? 'Starting recording…' : 'Start recording' }}
         </span>
       </button>
+      <!-- Which backend oats is on, and on Ariso whether it's signed in. Local
+           is a plain badge: it never needs auth, so it offers nothing to click. -->
+      <div
+        v-if="accountPill"
+        ref="accountPillWrap"
+        class="account-pill-wrap"
+        @keydown.escape="closeSignInPopover({ restoreFocus: true })"
+      >
+        <span
+          v-if="accountPill === 'local'"
+          class="account-pill account-pill--static"
+          title="Local mode — recordings stay on this device"
+        >
+          <svg class="account-pill-icon" viewBox="0 0 24 24" aria-hidden="true">
+            <rect x="5" y="11" width="14" height="10" rx="2" />
+            <path d="M8 11V7a4 4 0 0 1 8 0v4" />
+          </svg>
+          <span class="account-pill-label">Local</span>
+        </span>
+        <span
+          v-else-if="accountPill === 'checking'"
+          class="account-pill account-pill--static"
+          title="Ariso"
+        >
+          <svg class="account-pill-icon" viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M18 10h-1.26A8 8 0 1 0 9 20h9a5 5 0 0 0 0-10z" />
+          </svg>
+          <span class="account-pill-label">Ariso</span>
+        </span>
+        <button
+          v-else-if="accountPill === 'signed-in'"
+          type="button"
+          class="account-pill"
+          :title="accountEmail"
+          :aria-label="accountEmail ? `Ariso account ${accountEmail}, open Settings` : 'Ariso account, open Settings'"
+          @click="openSettings"
+        >
+          <img
+            v-if="accountAvatarUrl"
+            class="account-pill-avatar"
+            :src="accountAvatarUrl"
+            alt=""
+            referrerpolicy="no-referrer"
+            @error="accountAvatarUrl = ''"
+          />
+          <span v-else-if="accountDisplayName || accountEmail" class="account-pill-avatar" aria-hidden="true">
+            {{ accountInitials }}
+          </span>
+          <svg v-else class="account-pill-icon" viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M18 10h-1.26A8 8 0 1 0 9 20h9a5 5 0 0 0 0-10z" />
+          </svg>
+          <span class="account-pill-label">Ariso</span>
+        </button>
+        <button
+          v-else
+          ref="signInPill"
+          type="button"
+          class="account-pill account-pill--sign-in"
+          title="Sign in to Ariso"
+          aria-haspopup="dialog"
+          :aria-expanded="signInPopoverOpen"
+          aria-controls="sign-in-popover"
+          @click="toggleSignInPopover"
+        >
+          <svg class="account-pill-icon" viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M18 10h-1.26A8 8 0 1 0 9 20h9a5 5 0 0 0 0-10z" />
+          </svg>
+          <span class="account-pill-label">Sign in</span>
+        </button>
+        <div
+          v-if="signInPopoverOpen && accountPill === 'signed-out'"
+          id="sign-in-popover"
+          class="sign-in-popover"
+          role="dialog"
+          aria-labelledby="sign-in-popover-title"
+        >
+          <p id="sign-in-popover-title" class="sign-in-popover-title">Sign in to Ariso</p>
+          <SignInButtons
+            ref="signInButtons"
+            :signing-in-with="accountSigningInWith"
+            :error-message="accountErrorMessage"
+            @sign-in="account.signIn"
+            @cancel="account.cancelSignIn"
+          />
+        </div>
+      </div>
       <div v-if="isWindows" class="window-controls">
         <button
           class="window-control"
@@ -317,6 +403,9 @@ import {
   recordingBlockedPayload,
   recordingStartErrorMessage,
 } from '../composables/recordingStartError';
+import { useAccountState } from '../composables/useAccountState';
+import { AUTH_CHANGED_EVENT } from '../tauri';
+import SignInButtons from './SignInButtons.vue';
 import oatsLogo from '../assets/oats-dark.svg';
 
 const meetings = ref<MeetingListItem[]>([]);
@@ -538,6 +627,84 @@ watch(
 const emptyListHint = computed(() =>
   activeView.value === 'today' ? 'No meetings today.' : 'No past meetings.'
 );
+
+// Titlebar backend indicator. This window's own account state, kept current by
+// the backend's AUTH_CHANGED_EVENT broadcast. It is only ever refreshed on
+// Ariso: Local mode makes no session or profile request from this window.
+const account = useAccountState();
+const {
+  isSignedIn: accountSignedIn,
+  checked: accountChecked,
+  displayName: accountDisplayName,
+  email: accountEmail,
+  avatarUrl: accountAvatarUrl,
+  initials: accountInitials,
+  signingInWith: accountSigningInWith,
+  errorMessage: accountErrorMessage,
+} = account;
+type AccountPill = 'local' | 'checking' | 'signed-in' | 'signed-out';
+const accountPill = computed<AccountPill | null>(() => {
+  const id = activeBackend.value?.id;
+  if (id === 'local') return 'local';
+  if (id !== 'ariso') return null; // backend not loaded yet
+  if (!accountChecked.value) return 'checking';
+  return accountSignedIn.value ? 'signed-in' : 'signed-out';
+});
+
+const signInPopoverOpen = ref(false);
+const accountPillWrap = ref<HTMLElement | null>(null);
+const signInPill = ref<HTMLButtonElement | null>(null);
+const signInButtons = ref<{ focus: () => void } | null>(null);
+
+async function toggleSignInPopover(): Promise<void> {
+  if (signInPopoverOpen.value) {
+    closeSignInPopover();
+    return;
+  }
+  signInPopoverOpen.value = true;
+  await nextTick();
+  signInButtons.value?.focus();
+}
+
+function closeSignInPopover({ restoreFocus = false } = {}): void {
+  if (!signInPopoverOpen.value) return;
+  signInPopoverOpen.value = false;
+  if (restoreFocus) signInPill.value?.focus();
+}
+
+// A click elsewhere dismisses the popover, except while a browser flow is
+// pending: its Cancel button lives there.
+function onDocumentMousedown(event: MouseEvent): void {
+  if (!signInPopoverOpen.value || accountSigningInWith.value) return;
+  if (accountPillWrap.value?.contains(event.target as Node)) return;
+  closeSignInPopover();
+}
+
+// However the session arrived (the popover, Settings, Onboarding, a tray row),
+// the pill switches to the signed-in state and the popover has nothing to offer.
+watch(accountSignedIn, (signedIn) => {
+  if (signedIn) closeSignInPopover();
+});
+
+// Covers both the first load on mount and every backend switch, since each
+// re-reads the active backend. On Local, forget the account instead of asking,
+// so a later switch back doesn't flash the stale state.
+watch(
+  () => activeBackend.value?.id,
+  (id) => {
+    if (id === 'ariso') {
+      void account.refresh();
+    } else if (id === 'local') {
+      closeSignInPopover();
+      if (accountSigningInWith.value) void account.cancelSignIn();
+      account.reset();
+    }
+  }
+);
+
+function onAuthChanged(): void {
+  if (activeBackend.value?.id === 'ariso') void account.refresh();
+}
 
 // Only the next upcoming meeting (soonest, or the one in progress) carries a
 // relative-time chip; it's the first item of the Today view's UPCOMING section.
@@ -1218,6 +1385,7 @@ let unlistenVaultChanged: UnlistenFn | null = null;
 let unlistenBackendChanged: UnlistenFn | null = null;
 let unlistenPrepOpen: UnlistenFn | null = null;
 let unlistenWindowResized: UnlistenFn | null = null;
+let unlistenAuthChanged: UnlistenFn | null = null;
 
 // Recover the attached meeting for a recording that started before this
 // library window existed. The `recording://started` event is one-shot, so a
@@ -1294,17 +1462,23 @@ onMounted(() => {
   }).then((un) => {
     unlistenPrepOpen = un;
   });
+  // A sign-in or sign-out anywhere, or a rejected session cleared natively.
+  void listen(AUTH_CHANGED_EVENT, onAuthChanged).then((un) => {
+    unlistenAuthChanged = un;
+  });
   clockTimer = window.setInterval(() => {
     now.value = new Date();
   }, 30_000);
   window.addEventListener('focus', onWindowFocus);
   window.addEventListener('keydown', onGlobalKeydown);
+  document.addEventListener('mousedown', onDocumentMousedown);
 });
 
 onUnmounted(() => {
   if (clockTimer !== undefined) clearInterval(clockTimer);
   window.removeEventListener('focus', onWindowFocus);
   window.removeEventListener('keydown', onGlobalKeydown);
+  document.removeEventListener('mousedown', onDocumentMousedown);
   unlistenRecordingStarted?.();
   unlistenRecordingState?.();
   unlistenRecordingStartFailed?.();
@@ -1313,6 +1487,7 @@ onUnmounted(() => {
   unlistenBackendChanged?.();
   unlistenPrepOpen?.();
   unlistenWindowResized?.();
+  unlistenAuthChanged?.();
 });
 </script>
 
@@ -1539,6 +1714,108 @@ onUnmounted(() => {
    to re-dock on), so it must not invite a click it can't honor. */
 .add-btn--static { cursor: default; }
 .add-btn--static:hover { box-shadow: 1px 1px 0 #e7e5e2; transform: none; }
+/* Backend indicator: a compact pill after Start recording. Capped so it can't
+   push Start recording off a narrow window. */
+.account-pill-wrap {
+  position: relative;
+  display: flex;
+  margin-left: 6px;
+}
+.titlebar--windows .account-pill-wrap { margin: 0 9px 0 0; }
+.account-pill {
+  max-width: 120px;
+  height: 22px;
+  padding: 0 9px 0 5px;
+  gap: 5px;
+  border-radius: 11px;
+  background: #ffffff;
+  border: 1px solid #d6d6d6;
+  box-shadow: 1px 1px 0 #e7e5e2;
+  color: #1a1a1a;
+  font-family: inherit;
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+  transition: transform 0.1s, box-shadow 0.1s;
+}
+.titlebar--windows .account-pill { height: 26px; border-radius: 13px; }
+button.account-pill:hover { box-shadow: 0 0 0 #e7e5e2; transform: translate(1px, 1px); }
+.titlebar--windows .account-pill:focus-visible {
+  outline: 2px solid #3b6fc4;
+  outline-offset: -3px;
+}
+/* Local, and Ariso before the first session check: informational only. */
+.account-pill--static {
+  background: transparent;
+  border-color: #e4e2de;
+  box-shadow: none;
+  color: #6f6f6f;
+  cursor: default;
+}
+.account-pill-icon {
+  width: 13px;
+  height: 13px;
+  flex: 0 0 auto;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+.account-pill-avatar {
+  width: 16px;
+  height: 16px;
+  flex: 0 0 auto;
+  border-radius: 50%;
+  background: #1c1c1c;
+  color: #ffffff;
+  font-size: 7px;
+  font-weight: 700;
+  line-height: 16px;
+  text-align: center;
+  object-fit: cover;
+}
+.account-pill-label {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-size: 11px;
+  font-weight: 600;
+  line-height: 1;
+  white-space: nowrap;
+}
+.sign-in-popover {
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+  z-index: 30;
+  width: 260px;
+  box-sizing: border-box;
+  padding: 14px;
+  background: #ffffff;
+  border: 1px solid #e5e6e3;
+  border-radius: 12px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
+}
+.sign-in-popover-title {
+  margin: 0 0 12px;
+  font-size: 13px;
+  font-weight: 600;
+  color: #1c1c1c;
+}
+/* Narrow windows keep only the pill's glyph; the label stays readable to
+   assistive tech, and the title tooltip still names the state. */
+@media (max-width: 520px) {
+  .account-pill { padding: 0 5px; }
+  .account-pill-label {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+    clip: rect(0 0 0 0);
+    white-space: nowrap;
+  }
+}
 /* Mini live waveform: four bars pulsing on a staggered cycle. */
 .rec-wave {
   display: inline-flex;

--- a/src/views/LibraryView.vue
+++ b/src/views/LibraryView.vue
@@ -73,92 +73,6 @@
           {{ recordingStarting ? 'Starting recording…' : 'Start recording' }}
         </span>
       </button>
-      <!-- Which backend oats is on, and on Ariso whether it's signed in. Local
-           is a plain badge: it never needs auth, so it offers nothing to click. -->
-      <div
-        v-if="accountPill"
-        ref="accountPillWrap"
-        class="account-pill-wrap"
-        @keydown.escape="closeSignInPopover({ restoreFocus: true })"
-      >
-        <span
-          v-if="accountPill === 'local'"
-          class="account-pill account-pill--static"
-          title="Local mode — recordings stay on this device"
-        >
-          <svg class="account-pill-icon" viewBox="0 0 24 24" aria-hidden="true">
-            <rect x="5" y="11" width="14" height="10" rx="2" />
-            <path d="M8 11V7a4 4 0 0 1 8 0v4" />
-          </svg>
-          <span class="account-pill-label">Local</span>
-        </span>
-        <span
-          v-else-if="accountPill === 'checking'"
-          class="account-pill account-pill--static"
-          title="Ariso"
-        >
-          <svg class="account-pill-icon" viewBox="0 0 24 24" aria-hidden="true">
-            <path d="M18 10h-1.26A8 8 0 1 0 9 20h9a5 5 0 0 0 0-10z" />
-          </svg>
-          <span class="account-pill-label">Ariso</span>
-        </span>
-        <button
-          v-else-if="accountPill === 'signed-in'"
-          type="button"
-          class="account-pill"
-          :title="accountEmail"
-          :aria-label="accountEmail ? `Ariso account ${accountEmail}, open Settings` : 'Ariso account, open Settings'"
-          @click="openSettings"
-        >
-          <img
-            v-if="accountAvatarUrl"
-            class="account-pill-avatar"
-            :src="accountAvatarUrl"
-            alt=""
-            referrerpolicy="no-referrer"
-            @error="accountAvatarUrl = ''"
-          />
-          <span v-else-if="accountDisplayName || accountEmail" class="account-pill-avatar" aria-hidden="true">
-            {{ accountInitials }}
-          </span>
-          <svg v-else class="account-pill-icon" viewBox="0 0 24 24" aria-hidden="true">
-            <path d="M18 10h-1.26A8 8 0 1 0 9 20h9a5 5 0 0 0 0-10z" />
-          </svg>
-          <span class="account-pill-label">Ariso</span>
-        </button>
-        <button
-          v-else
-          ref="signInPill"
-          type="button"
-          class="account-pill account-pill--sign-in"
-          title="Sign in to Ariso"
-          aria-haspopup="dialog"
-          :aria-expanded="signInPopoverOpen"
-          aria-controls="sign-in-popover"
-          @click="toggleSignInPopover"
-        >
-          <svg class="account-pill-icon" viewBox="0 0 24 24" aria-hidden="true">
-            <path d="M18 10h-1.26A8 8 0 1 0 9 20h9a5 5 0 0 0 0-10z" />
-          </svg>
-          <span class="account-pill-label">Sign in</span>
-        </button>
-        <div
-          v-if="signInPopoverOpen && accountPill === 'signed-out'"
-          id="sign-in-popover"
-          class="sign-in-popover"
-          role="dialog"
-          aria-labelledby="sign-in-popover-title"
-        >
-          <p id="sign-in-popover-title" class="sign-in-popover-title">Sign in to Ariso</p>
-          <SignInButtons
-            ref="signInButtons"
-            :signing-in-with="accountSigningInWith"
-            :error-message="accountErrorMessage"
-            @sign-in="account.signIn"
-            @cancel="account.cancelSignIn"
-          />
-        </div>
-      </div>
       <div v-if="isWindows" class="window-controls">
         <button
           class="window-control"
@@ -306,6 +220,97 @@
           </button>
         </div>
       </nav>
+
+      <!-- Which backend oats is on, named as in Settings. On ariso.ai it also
+           says whether you're signed in, and signs you in when you're not.
+           Local is a plain badge: it never needs auth, so it offers nothing to
+           click. -->
+      <div
+        v-if="accountPill"
+        ref="accountPillWrap"
+        class="account-pill-wrap"
+        @keydown.escape="closeSignInPopover({ restoreFocus: true })"
+      >
+        <span
+          v-if="accountPill === 'local'"
+          class="account-pill account-pill--static"
+          title="Local mode — recordings stay on this device"
+        >
+          <svg class="account-pill-icon" viewBox="0 0 24 24" aria-hidden="true">
+            <rect x="5" y="11" width="14" height="10" rx="2" />
+            <path d="M8 11V7a4 4 0 0 1 8 0v4" />
+          </svg>
+          <span class="account-pill-label">Local</span>
+        </span>
+        <span
+          v-else-if="accountPill === 'checking'"
+          class="account-pill account-pill--static"
+          title="ariso.ai"
+        >
+          <svg class="account-pill-icon" viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M18 10h-1.26A8 8 0 1 0 9 20h9a5 5 0 0 0 0-10z" />
+          </svg>
+          <span class="account-pill-label">ariso.ai</span>
+        </span>
+        <button
+          v-else-if="accountPill === 'signed-in'"
+          type="button"
+          class="account-pill"
+          :title="accountEmail"
+          :aria-label="accountEmail ? `ariso.ai account ${accountEmail}, open Settings` : 'ariso.ai account, open Settings'"
+          @click="openSettings"
+        >
+          <img
+            v-if="accountAvatarUrl"
+            class="account-pill-avatar"
+            :src="accountAvatarUrl"
+            alt=""
+            referrerpolicy="no-referrer"
+            @error="accountAvatarUrl = ''"
+          />
+          <span v-else-if="accountDisplayName || accountEmail" class="account-pill-avatar" aria-hidden="true">
+            {{ accountInitials }}
+          </span>
+          <svg v-else class="account-pill-icon" viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M18 10h-1.26A8 8 0 1 0 9 20h9a5 5 0 0 0 0-10z" />
+          </svg>
+          <span class="account-pill-label">ariso.ai</span>
+        </button>
+        <button
+          v-else
+          ref="signInPill"
+          type="button"
+          class="account-pill account-pill--signed-out"
+          title="Not signed in — click to sign in"
+          aria-label="ariso.ai, not signed in. Sign in"
+          aria-haspopup="dialog"
+          :aria-expanded="signInPopoverOpen"
+          aria-controls="sign-in-popover"
+          @click="toggleSignInPopover"
+        >
+          <svg class="account-pill-icon" viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M18 10h-1.26A8 8 0 1 0 9 20h9a5 5 0 0 0 0-10z" />
+          </svg>
+          <span class="account-pill-label">ariso.ai</span>
+          <span class="account-pill-dot" aria-hidden="true" />
+        </button>
+        <div
+          v-if="signInPopoverOpen && accountPill === 'signed-out'"
+          id="sign-in-popover"
+          class="sign-in-popover"
+          role="dialog"
+          aria-labelledby="sign-in-popover-title"
+        >
+          <p id="sign-in-popover-title" class="sign-in-popover-title">Sign in to ariso.ai</p>
+          <SignInButtons
+            ref="signInButtons"
+            :signing-in-with="accountSigningInWith"
+            :error-message="accountErrorMessage"
+            @sign-in="account.signIn"
+            @cancel="account.cancelSignIn"
+          />
+        </div>
+      </div>
     </aside>
 
     <!-- Floating detail card on the backdrop, with the recorder strip
@@ -628,7 +633,7 @@ const emptyListHint = computed(() =>
   activeView.value === 'today' ? 'No meetings today.' : 'No past meetings.'
 );
 
-// Titlebar backend indicator. This window's own account state, kept current by
+// Bottom-left backend indicator. This window's own account state, kept current by
 // the backend's AUTH_CHANGED_EVENT broadcast. It is only ever refreshed on
 // Ariso: Local mode makes no session or profile request from this window.
 const account = useAccountState();
@@ -1714,20 +1719,21 @@ onUnmounted(() => {
    to re-dock on), so it must not invite a click it can't honor. */
 .add-btn--static { cursor: default; }
 .add-btn--static:hover { box-shadow: 1px 1px 0 #e7e5e2; transform: none; }
-/* Backend indicator: a compact pill after Start recording. Capped so it can't
-   push Start recording off a narrow window. */
+/* Backend indicator: a compact pill under the bottom nav, at the window's
+   bottom-left. Capped so a long label can't stretch the sidebar. */
 .account-pill-wrap {
   position: relative;
+  flex-shrink: 0;
+  align-self: flex-start;
   display: flex;
-  margin-left: 6px;
+  margin-top: 10px;
 }
-.titlebar--windows .account-pill-wrap { margin: 0 9px 0 0; }
 .account-pill {
-  max-width: 120px;
-  height: 22px;
-  padding: 0 9px 0 5px;
-  gap: 5px;
-  border-radius: 11px;
+  max-width: 160px;
+  height: 24px;
+  padding: 0 10px 0 6px;
+  gap: 6px;
+  border-radius: 12px;
   background: #ffffff;
   border: 1px solid #d6d6d6;
   box-shadow: 1px 1px 0 #e7e5e2;
@@ -1738,13 +1744,12 @@ onUnmounted(() => {
   cursor: pointer;
   transition: transform 0.1s, box-shadow 0.1s;
 }
-.titlebar--windows .account-pill { height: 26px; border-radius: 13px; }
 button.account-pill:hover { box-shadow: 0 0 0 #e7e5e2; transform: translate(1px, 1px); }
-.titlebar--windows .account-pill:focus-visible {
+button.account-pill:focus-visible {
   outline: 2px solid #3b6fc4;
-  outline-offset: -3px;
+  outline-offset: 2px;
 }
-/* Local, and Ariso before the first session check: informational only. */
+/* Local, and ariso.ai before the first session check: informational only. */
 .account-pill--static {
   background: transparent;
   border-color: #e4e2de;
@@ -1753,8 +1758,8 @@ button.account-pill:hover { box-shadow: 0 0 0 #e7e5e2; transform: translate(1px,
   cursor: default;
 }
 .account-pill-icon {
-  width: 13px;
-  height: 13px;
+  width: 14px;
+  height: 14px;
   flex: 0 0 auto;
   fill: none;
   stroke: currentColor;
@@ -1779,15 +1784,24 @@ button.account-pill:hover { box-shadow: 0 0 0 #e7e5e2; transform: translate(1px,
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
-  font-size: 11px;
+  font-size: 12px;
   font-weight: 600;
   line-height: 1;
   white-space: nowrap;
 }
+/* Signed out: the label stays the backend's name, so a dot carries the state. */
+.account-pill-dot {
+  width: 6px;
+  height: 6px;
+  flex: 0 0 auto;
+  border-radius: 50%;
+  background: #d97706;
+}
+/* Opens upward: the pill sits at the bottom of the window. */
 .sign-in-popover {
   position: absolute;
-  top: calc(100% + 6px);
-  right: 0;
+  bottom: calc(100% + 6px);
+  left: 0;
   z-index: 30;
   width: 260px;
   box-sizing: border-box;
@@ -1802,19 +1816,6 @@ button.account-pill:hover { box-shadow: 0 0 0 #e7e5e2; transform: translate(1px,
   font-size: 13px;
   font-weight: 600;
   color: #1c1c1c;
-}
-/* Narrow windows keep only the pill's glyph; the label stays readable to
-   assistive tech, and the title tooltip still names the state. */
-@media (max-width: 520px) {
-  .account-pill { padding: 0 5px; }
-  .account-pill-label {
-    position: absolute;
-    width: 1px;
-    height: 1px;
-    overflow: hidden;
-    clip: rect(0 0 0 0);
-    white-space: nowrap;
-  }
 }
 /* Mini live waveform: four bars pulsing on a staggered cycle. */
 .rec-wave {

--- a/src/views/LibraryView.vue
+++ b/src/views/LibraryView.vue
@@ -841,7 +841,7 @@ async function onBackendChanged(): Promise<void> {
 }
 
 function onAuthChanged(): void {
-  if (activeBackend.value?.id === 'ariso') void account.refresh();
+  if (activeBackend.value?.id === 'ariso') void account.refresh(true);
 }
 
 // Only the next upcoming meeting (soonest, or the one in progress) carries a

--- a/src/views/LibraryView.vue
+++ b/src/views/LibraryView.vue
@@ -71,8 +71,13 @@
               type="button"
               role="menuitemradio"
               class="backend-menu-item"
-              :class="{ 'backend-menu-item--active': activeBackend?.id === 'ariso' }"
+              :class="{
+                'backend-menu-item--active': activeBackend?.id === 'ariso',
+                'backend-menu-item--signed-out': !accountSignedIn,
+              }"
               :aria-checked="activeBackend?.id === 'ariso'"
+              :aria-label="accountSignedIn ? undefined : 'ariso.ai, not signed in'"
+              :title="accountSignedIn ? undefined : 'Not signed in — click to sign in'"
               :disabled="recording"
               tabindex="-1"
               @click="chooseAriso"
@@ -1937,6 +1942,16 @@ onUnmounted(() => {
   color: #ffffff;
 }
 .backend-menu-item:disabled { opacity: 0.5; cursor: not-allowed; }
+/* ariso.ai without a session: grayed, but still clickable, since it leads to
+   the sign-in box. Local never checks the session, so it reads as signed out
+   there too. When it's the active backend, a light fill still marks it. */
+.backend-menu-item--signed-out { color: #8a8a86; }
+.backend-menu-item--signed-out.backend-menu-item--active,
+.backend-menu-item--signed-out.backend-menu-item--active:hover:not(:disabled),
+.backend-menu-item--signed-out.backend-menu-item--active:focus-visible {
+  background: #efeeeb;
+  color: #8a8a86;
+}
 .backend-menu-hint {
   margin: 4px 10px;
   font-size: 11px;

--- a/src/views/LibraryView.vue
+++ b/src/views/LibraryView.vue
@@ -220,102 +220,103 @@
           </button>
         </div>
       </nav>
-
-      <!-- Which backend oats is on, named as in Settings. On ariso.ai it also
-           says whether you're signed in, and signs you in when you're not.
-           Local is a plain badge: it never needs auth, so it offers nothing to
-           click. -->
-      <div
-        v-if="accountPill"
-        ref="accountPillWrap"
-        class="account-pill-wrap"
-        @keydown.escape="closeSignInPopover({ restoreFocus: true })"
-      >
-        <span
-          v-if="accountPill === 'local'"
-          class="account-pill account-pill--static"
-          title="Local mode — recordings stay on this device"
-        >
-          <svg class="account-pill-icon" viewBox="0 0 24 24" aria-hidden="true">
-            <rect x="5" y="11" width="14" height="10" rx="2" />
-            <path d="M8 11V7a4 4 0 0 1 8 0v4" />
-          </svg>
-          <span class="account-pill-label">Local</span>
-        </span>
-        <span
-          v-else-if="accountPill === 'checking'"
-          class="account-pill account-pill--static"
-          title="ariso.ai"
-        >
-          <svg class="account-pill-icon" viewBox="0 0 24 24" aria-hidden="true">
-            <path d="M18 10h-1.26A8 8 0 1 0 9 20h9a5 5 0 0 0 0-10z" />
-          </svg>
-          <span class="account-pill-label">ariso.ai</span>
-        </span>
-        <button
-          v-else-if="accountPill === 'signed-in'"
-          type="button"
-          class="account-pill"
-          :title="accountEmail"
-          :aria-label="accountEmail ? `ariso.ai account ${accountEmail}, open Settings` : 'ariso.ai account, open Settings'"
-          @click="openSettings"
-        >
-          <img
-            v-if="accountAvatarUrl"
-            class="account-pill-avatar"
-            :src="accountAvatarUrl"
-            alt=""
-            referrerpolicy="no-referrer"
-            @error="accountAvatarUrl = ''"
-          />
-          <span v-else-if="accountDisplayName || accountEmail" class="account-pill-avatar" aria-hidden="true">
-            {{ accountInitials }}
-          </span>
-          <svg v-else class="account-pill-icon" viewBox="0 0 24 24" aria-hidden="true">
-            <path d="M18 10h-1.26A8 8 0 1 0 9 20h9a5 5 0 0 0 0-10z" />
-          </svg>
-          <span class="account-pill-label">ariso.ai</span>
-        </button>
-        <button
-          v-else
-          ref="signInPill"
-          type="button"
-          class="account-pill account-pill--signed-out"
-          title="Not signed in — click to sign in"
-          aria-label="ariso.ai, not signed in. Sign in"
-          aria-haspopup="dialog"
-          :aria-expanded="signInPopoverOpen"
-          aria-controls="sign-in-popover"
-          @click="toggleSignInPopover"
-        >
-          <svg class="account-pill-icon" viewBox="0 0 24 24" aria-hidden="true">
-            <path d="M18 10h-1.26A8 8 0 1 0 9 20h9a5 5 0 0 0 0-10z" />
-          </svg>
-          <span class="account-pill-label">ariso.ai</span>
-          <span class="account-pill-dot" aria-hidden="true" />
-        </button>
-        <div
-          v-if="signInPopoverOpen && accountPill === 'signed-out'"
-          id="sign-in-popover"
-          class="sign-in-popover"
-          role="dialog"
-          aria-labelledby="sign-in-popover-title"
-        >
-          <p id="sign-in-popover-title" class="sign-in-popover-title">Sign in to ariso.ai</p>
-          <SignInButtons
-            ref="signInButtons"
-            :signing-in-with="accountSigningInWith"
-            :error-message="accountErrorMessage"
-            @sign-in="account.signIn"
-            @cancel="account.cancelSignIn"
-          />
-        </div>
-      </div>
     </aside>
+
+    <!-- Which backend oats is on, named as in Settings, pinned to the window's
+         bottom-left corner the way Start recording sits top-right. On ariso.ai
+         it also says whether you're signed in, and signs you in when you're
+         not. Local is a plain badge: it never needs auth, so it offers
+         nothing to click. -->
+    <div
+      v-if="accountPill"
+      ref="accountPillWrap"
+      class="account-pill-wrap"
+      @keydown.escape="closeSignInPopover({ restoreFocus: true })"
+    >
+      <span
+        v-if="accountPill === 'local'"
+        class="account-pill account-pill--static"
+        title="Local mode — recordings stay on this device"
+      >
+        <svg class="account-pill-icon" viewBox="0 0 24 24" aria-hidden="true">
+          <rect x="5" y="11" width="14" height="10" rx="2" />
+          <path d="M8 11V7a4 4 0 0 1 8 0v4" />
+        </svg>
+        <span class="account-pill-label">Local</span>
+      </span>
+      <span
+        v-else-if="accountPill === 'checking'"
+        class="account-pill account-pill--static"
+        title="ariso.ai"
+      >
+        <svg class="account-pill-icon" viewBox="0 0 24 24" aria-hidden="true">
+          <path d="M18 10h-1.26A8 8 0 1 0 9 20h9a5 5 0 0 0 0-10z" />
+        </svg>
+        <span class="account-pill-label">ariso.ai</span>
+      </span>
+      <button
+        v-else-if="accountPill === 'signed-in'"
+        type="button"
+        class="account-pill"
+        :title="accountEmail"
+        :aria-label="accountEmail ? `ariso.ai account ${accountEmail}, open Settings` : 'ariso.ai account, open Settings'"
+        @click="openSettings"
+      >
+        <img
+          v-if="accountAvatarUrl"
+          class="account-pill-avatar"
+          :src="accountAvatarUrl"
+          alt=""
+          referrerpolicy="no-referrer"
+          @error="accountAvatarUrl = ''"
+        />
+        <span v-else-if="accountDisplayName || accountEmail" class="account-pill-avatar" aria-hidden="true">
+          {{ accountInitials }}
+        </span>
+        <svg v-else class="account-pill-icon" viewBox="0 0 24 24" aria-hidden="true">
+          <path d="M18 10h-1.26A8 8 0 1 0 9 20h9a5 5 0 0 0 0-10z" />
+        </svg>
+        <span class="account-pill-label">ariso.ai</span>
+      </button>
+      <button
+        v-else
+        ref="signInPill"
+        type="button"
+        class="account-pill account-pill--signed-out"
+        title="Not signed in — click to sign in"
+        aria-label="ariso.ai, not signed in. Sign in"
+        aria-haspopup="dialog"
+        :aria-expanded="signInPopoverOpen"
+        aria-controls="sign-in-popover"
+        @click="toggleSignInPopover"
+      >
+        <svg class="account-pill-icon" viewBox="0 0 24 24" aria-hidden="true">
+          <path d="M18 10h-1.26A8 8 0 1 0 9 20h9a5 5 0 0 0 0-10z" />
+        </svg>
+        <span class="account-pill-label">ariso.ai</span>
+        <span class="account-pill-dot" aria-hidden="true" />
+      </button>
+      <div
+        v-if="signInPopoverOpen && accountPill === 'signed-out'"
+        id="sign-in-popover"
+        class="sign-in-popover"
+        role="dialog"
+        aria-labelledby="sign-in-popover-title"
+      >
+        <p id="sign-in-popover-title" class="sign-in-popover-title">Sign in to ariso.ai</p>
+        <SignInButtons
+          ref="signInButtons"
+          :signing-in-with="accountSigningInWith"
+          :error-message="accountErrorMessage"
+          @sign-in="account.signIn"
+          @cancel="account.cancelSignIn"
+        />
+      </div>
+    </div>
 
     <!-- Floating detail card on the backdrop, with the recorder strip
          (mirroring an on-going recording) docked underneath. -->
-    <section class="detail-wrap">
+    <section class="detail-wrap" :class="{ 'detail-wrap--clear-corner': !leftPanelVisible && accountPill }">
       <div class="detail-card">
         <MeetingDetailView
           v-if="selectedItem"
@@ -1650,7 +1651,8 @@ onUnmounted(() => {
 .sidebar {
   width: 300px;
   flex-shrink: 0;
-  padding: 30px 18px 18px;
+  /* Bottom 30px mirrors the top: it leaves the corner to the backend pill. */
+  padding: 30px 18px 30px;
   box-sizing: border-box;
   display: flex;
   flex-direction: column;
@@ -1719,21 +1721,24 @@ onUnmounted(() => {
    to re-dock on), so it must not invite a click it can't honor. */
 .add-btn--static { cursor: default; }
 .add-btn--static:hover { box-shadow: 1px 1px 0 #e7e5e2; transform: none; }
-/* Backend indicator: a compact pill under the bottom nav, at the window's
-   bottom-left. Capped so a long label can't stretch the sidebar. */
+/* Backend indicator, pinned to the bottom-left corner with the same small
+   inset as Start recording at the top-right. The sidebar (and, with it hidden,
+   the detail card) keeps a matching 30px bottom band clear for it, mirroring
+   the titlebar band at the top. Above the recorder strip (z-index 10), below
+   the dialogs (100). */
 .account-pill-wrap {
-  position: relative;
-  flex-shrink: 0;
-  align-self: flex-start;
+  position: absolute;
+  left: 5px;
+  bottom: 5px;
+  z-index: 20;
   display: flex;
-  margin-top: 10px;
 }
 .account-pill {
   max-width: 160px;
-  height: 24px;
-  padding: 0 10px 0 6px;
-  gap: 6px;
-  border-radius: 12px;
+  height: 22px;
+  padding: 0 9px 0 5px;
+  gap: 5px;
+  border-radius: 11px;
   background: #ffffff;
   border: 1px solid #d6d6d6;
   box-shadow: 1px 1px 0 #e7e5e2;
@@ -1758,8 +1763,8 @@ button.account-pill:focus-visible {
   cursor: default;
 }
 .account-pill-icon {
-  width: 14px;
-  height: 14px;
+  width: 13px;
+  height: 13px;
   flex: 0 0 auto;
   fill: none;
   stroke: currentColor;
@@ -1784,7 +1789,7 @@ button.account-pill:focus-visible {
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
-  font-size: 12px;
+  font-size: 11px;
   font-weight: 600;
   line-height: 1;
   white-space: nowrap;
@@ -2059,6 +2064,8 @@ button.account-pill:focus-visible {
   min-height: 0;
 }
 .library--windows .detail-wrap { padding-top: 52px; }
+/* With the sidebar hidden, the card would reach under the corner pill. */
+.detail-wrap--clear-corner { padding-bottom: 30px; }
 .detail-card {
   flex: 1;
   min-height: 0;

--- a/src/views/LibraryView.vue
+++ b/src/views/LibraryView.vue
@@ -29,6 +29,96 @@
           <line x1="6.75" y1="3" x2="6.75" y2="15" stroke="currentColor" stroke-width="1.5" />
         </svg>
       </button>
+      <!-- Which backend oats is on, named as in Settings, next to the sidebar
+           toggle. On ariso.ai it also says whether you're signed in, and signs
+           you in when you're not. Local is a plain badge: it never needs auth,
+           so it offers nothing to click. -->
+      <div
+        v-if="accountPill"
+        ref="accountPillWrap"
+        class="account-pill-wrap"
+        @keydown.escape="closeSignInPopover({ restoreFocus: true })"
+      >
+        <span
+          v-if="accountPill === 'local'"
+          class="account-pill account-pill--static"
+          title="Local mode — recordings stay on this device"
+        >
+          <svg class="account-pill-icon" viewBox="0 0 24 24" aria-hidden="true">
+            <rect x="5" y="11" width="14" height="10" rx="2" />
+            <path d="M8 11V7a4 4 0 0 1 8 0v4" />
+          </svg>
+          <span class="account-pill-label">Local</span>
+        </span>
+        <span
+          v-else-if="accountPill === 'checking'"
+          class="account-pill account-pill--static"
+          title="ariso.ai"
+        >
+          <svg class="account-pill-icon" viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M18 10h-1.26A8 8 0 1 0 9 20h9a5 5 0 0 0 0-10z" />
+          </svg>
+          <span class="account-pill-label">ariso.ai</span>
+        </span>
+        <button
+          v-else-if="accountPill === 'signed-in'"
+          type="button"
+          class="account-pill"
+          :title="accountEmail"
+          :aria-label="accountEmail ? `ariso.ai account ${accountEmail}, open Settings` : 'ariso.ai account, open Settings'"
+          @click="openSettings"
+        >
+          <img
+            v-if="accountAvatarUrl"
+            class="account-pill-avatar"
+            :src="accountAvatarUrl"
+            alt=""
+            referrerpolicy="no-referrer"
+            @error="accountAvatarUrl = ''"
+          />
+          <span v-else-if="accountDisplayName || accountEmail" class="account-pill-avatar" aria-hidden="true">
+            {{ accountInitials }}
+          </span>
+          <svg v-else class="account-pill-icon" viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M18 10h-1.26A8 8 0 1 0 9 20h9a5 5 0 0 0 0-10z" />
+          </svg>
+          <span class="account-pill-label">ariso.ai</span>
+        </button>
+        <button
+          v-else
+          ref="signInPill"
+          type="button"
+          class="account-pill account-pill--signed-out"
+          title="Not signed in — click to sign in"
+          aria-label="ariso.ai, not signed in. Sign in"
+          aria-haspopup="dialog"
+          :aria-expanded="signInPopoverOpen"
+          aria-controls="sign-in-popover"
+          @click="toggleSignInPopover"
+        >
+          <svg class="account-pill-icon" viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M18 10h-1.26A8 8 0 1 0 9 20h9a5 5 0 0 0 0-10z" />
+          </svg>
+          <span class="account-pill-label">ariso.ai</span>
+          <span class="account-pill-dot" aria-hidden="true" />
+        </button>
+        <div
+          v-if="signInPopoverOpen && accountPill === 'signed-out'"
+          id="sign-in-popover"
+          class="sign-in-popover"
+          role="dialog"
+          aria-labelledby="sign-in-popover-title"
+        >
+          <p id="sign-in-popover-title" class="sign-in-popover-title">Sign in to ariso.ai</p>
+          <SignInButtons
+            ref="signInButtons"
+            :signing-in-with="accountSigningInWith"
+            :error-message="accountErrorMessage"
+            @sign-in="account.signIn"
+            @cancel="account.cancelSignIn"
+          />
+        </div>
+      </div>
       <!-- While a recording runs off-screen (its meeting isn't shown), the
            Start button becomes a "Recording" indicator that re-docks the strip
            when clicked. A recording attached to no meeting has nowhere to
@@ -222,101 +312,9 @@
       </nav>
     </aside>
 
-    <!-- Which backend oats is on, named as in Settings, pinned to the window's
-         bottom-left corner the way Start recording sits top-right. On ariso.ai
-         it also says whether you're signed in, and signs you in when you're
-         not. Local is a plain badge: it never needs auth, so it offers
-         nothing to click. -->
-    <div
-      v-if="accountPill"
-      ref="accountPillWrap"
-      class="account-pill-wrap"
-      @keydown.escape="closeSignInPopover({ restoreFocus: true })"
-    >
-      <span
-        v-if="accountPill === 'local'"
-        class="account-pill account-pill--static"
-        title="Local mode — recordings stay on this device"
-      >
-        <svg class="account-pill-icon" viewBox="0 0 24 24" aria-hidden="true">
-          <rect x="5" y="11" width="14" height="10" rx="2" />
-          <path d="M8 11V7a4 4 0 0 1 8 0v4" />
-        </svg>
-        <span class="account-pill-label">Local</span>
-      </span>
-      <span
-        v-else-if="accountPill === 'checking'"
-        class="account-pill account-pill--static"
-        title="ariso.ai"
-      >
-        <svg class="account-pill-icon" viewBox="0 0 24 24" aria-hidden="true">
-          <path d="M18 10h-1.26A8 8 0 1 0 9 20h9a5 5 0 0 0 0-10z" />
-        </svg>
-        <span class="account-pill-label">ariso.ai</span>
-      </span>
-      <button
-        v-else-if="accountPill === 'signed-in'"
-        type="button"
-        class="account-pill"
-        :title="accountEmail"
-        :aria-label="accountEmail ? `ariso.ai account ${accountEmail}, open Settings` : 'ariso.ai account, open Settings'"
-        @click="openSettings"
-      >
-        <img
-          v-if="accountAvatarUrl"
-          class="account-pill-avatar"
-          :src="accountAvatarUrl"
-          alt=""
-          referrerpolicy="no-referrer"
-          @error="accountAvatarUrl = ''"
-        />
-        <span v-else-if="accountDisplayName || accountEmail" class="account-pill-avatar" aria-hidden="true">
-          {{ accountInitials }}
-        </span>
-        <svg v-else class="account-pill-icon" viewBox="0 0 24 24" aria-hidden="true">
-          <path d="M18 10h-1.26A8 8 0 1 0 9 20h9a5 5 0 0 0 0-10z" />
-        </svg>
-        <span class="account-pill-label">ariso.ai</span>
-      </button>
-      <button
-        v-else
-        ref="signInPill"
-        type="button"
-        class="account-pill account-pill--signed-out"
-        title="Not signed in — click to sign in"
-        aria-label="ariso.ai, not signed in. Sign in"
-        aria-haspopup="dialog"
-        :aria-expanded="signInPopoverOpen"
-        aria-controls="sign-in-popover"
-        @click="toggleSignInPopover"
-      >
-        <svg class="account-pill-icon" viewBox="0 0 24 24" aria-hidden="true">
-          <path d="M18 10h-1.26A8 8 0 1 0 9 20h9a5 5 0 0 0 0-10z" />
-        </svg>
-        <span class="account-pill-label">ariso.ai</span>
-        <span class="account-pill-dot" aria-hidden="true" />
-      </button>
-      <div
-        v-if="signInPopoverOpen && accountPill === 'signed-out'"
-        id="sign-in-popover"
-        class="sign-in-popover"
-        role="dialog"
-        aria-labelledby="sign-in-popover-title"
-      >
-        <p id="sign-in-popover-title" class="sign-in-popover-title">Sign in to ariso.ai</p>
-        <SignInButtons
-          ref="signInButtons"
-          :signing-in-with="accountSigningInWith"
-          :error-message="accountErrorMessage"
-          @sign-in="account.signIn"
-          @cancel="account.cancelSignIn"
-        />
-      </div>
-    </div>
-
     <!-- Floating detail card on the backdrop, with the recorder strip
          (mirroring an on-going recording) docked underneath. -->
-    <section class="detail-wrap" :class="{ 'detail-wrap--clear-corner': !leftPanelVisible && accountPill }">
+    <section class="detail-wrap">
       <div class="detail-card">
         <MeetingDetailView
           v-if="selectedItem"
@@ -634,7 +632,7 @@ const emptyListHint = computed(() =>
   activeView.value === 'today' ? 'No meetings today.' : 'No past meetings.'
 );
 
-// Bottom-left backend indicator. This window's own account state, kept current by
+// Titlebar backend indicator. This window's own account state, kept current by
 // the backend's AUTH_CHANGED_EVENT broadcast. It is only ever refreshed on
 // Ariso: Local mode makes no session or profile request from this window.
 const account = useAccountState();
@@ -1651,8 +1649,7 @@ onUnmounted(() => {
 .sidebar {
   width: 300px;
   flex-shrink: 0;
-  /* Bottom 30px mirrors the top: it leaves the corner to the backend pill. */
-  padding: 30px 18px 30px;
+  padding: 30px 18px 18px;
   box-sizing: border-box;
   display: flex;
   flex-direction: column;
@@ -1721,18 +1718,14 @@ onUnmounted(() => {
    to re-dock on), so it must not invite a click it can't honor. */
 .add-btn--static { cursor: default; }
 .add-btn--static:hover { box-shadow: 1px 1px 0 #e7e5e2; transform: none; }
-/* Backend indicator, pinned to the bottom-left corner with the same small
-   inset as Start recording at the top-right. The sidebar (and, with it hidden,
-   the detail card) keeps a matching 30px bottom band clear for it, mirroring
-   the titlebar band at the top. Above the recorder strip (z-index 10), below
-   the dialogs (100). */
+/* Backend indicator: a compact pill beside the sidebar toggle, matching the
+   Start recording pill at the other end of the titlebar. */
 .account-pill-wrap {
-  position: absolute;
-  left: 5px;
-  bottom: 5px;
-  z-index: 20;
+  position: relative;
   display: flex;
+  margin-left: 6px;
 }
+.titlebar--windows .account-pill-wrap { margin-left: 4px; }
 .account-pill {
   max-width: 160px;
   height: 22px;
@@ -1749,6 +1742,7 @@ onUnmounted(() => {
   cursor: pointer;
   transition: transform 0.1s, box-shadow 0.1s;
 }
+.titlebar--windows .account-pill { height: 26px; border-radius: 13px; }
 button.account-pill:hover { box-shadow: 0 0 0 #e7e5e2; transform: translate(1px, 1px); }
 button.account-pill:focus-visible {
   outline: 2px solid #3b6fc4;
@@ -1802,10 +1796,9 @@ button.account-pill:focus-visible {
   border-radius: 50%;
   background: #d97706;
 }
-/* Opens upward: the pill sits at the bottom of the window. */
 .sign-in-popover {
   position: absolute;
-  bottom: calc(100% + 6px);
+  top: calc(100% + 6px);
   left: 0;
   z-index: 30;
   width: 260px;
@@ -2064,8 +2057,6 @@ button.account-pill:focus-visible {
   min-height: 0;
 }
 .library--windows .detail-wrap { padding-top: 52px; }
-/* With the sidebar hidden, the card would reach under the corner pill. */
-.detail-wrap--clear-corner { padding-bottom: 30px; }
 .detail-card {
   flex: 1;
   min-height: 0;

--- a/src/views/LibraryView.vue
+++ b/src/views/LibraryView.vue
@@ -100,7 +100,6 @@
             <path d="M18 10h-1.26A8 8 0 1 0 9 20h9a5 5 0 0 0 0-10z" />
           </svg>
           <span class="account-pill-label">ariso.ai</span>
-          <span class="account-pill-dot" aria-hidden="true" />
         </button>
         <div
           v-if="signInPopoverOpen && accountPill === 'signed-out'"
@@ -1787,14 +1786,6 @@ button.account-pill:focus-visible {
   font-weight: 600;
   line-height: 1;
   white-space: nowrap;
-}
-/* Signed out: the label stays the backend's name, so a dot carries the state. */
-.account-pill-dot {
-  width: 6px;
-  height: 6px;
-  flex: 0 0 auto;
-  border-radius: 50%;
-  background: #d97706;
 }
 .sign-in-popover {
   position: absolute;

--- a/src/views/LibraryView.vue
+++ b/src/views/LibraryView.vue
@@ -30,92 +30,103 @@
         </svg>
       </button>
       <!-- Which backend oats is on, named as in Settings, next to the sidebar
-           toggle. On ariso.ai it also says whether you're signed in, and signs
-           you in when you're not. Local is a plain badge: it never needs auth,
-           so it offers nothing to click. -->
+           toggle. Clicking it opens a menu to switch backend or open Settings;
+           picking ariso.ai while signed out shows the sign-in box instead. -->
       <div
         v-if="accountPill"
         ref="accountPillWrap"
         class="account-pill-wrap"
-        @keydown.escape="closeSignInPopover({ restoreFocus: true })"
+        @keydown.escape="closeBackendPopover({ restoreFocus: true })"
       >
-        <span
-          v-if="accountPill === 'local'"
-          class="account-pill account-pill--static"
-          title="Local mode — recordings stay on this device"
-        >
-          <svg class="account-pill-icon" viewBox="0 0 24 24" aria-hidden="true">
-            <rect x="5" y="11" width="14" height="10" rx="2" />
-            <path d="M8 11V7a4 4 0 0 1 8 0v4" />
-          </svg>
-          <span class="account-pill-label">Local</span>
-        </span>
-        <span
-          v-else-if="accountPill === 'checking'"
-          class="account-pill account-pill--static"
-          title="ariso.ai"
-        >
-          <svg class="account-pill-icon" viewBox="0 0 24 24" aria-hidden="true">
-            <path d="M18 10h-1.26A8 8 0 1 0 9 20h9a5 5 0 0 0 0-10z" />
-          </svg>
-          <span class="account-pill-label">ariso.ai</span>
-        </span>
         <button
-          v-else-if="accountPill === 'signed-in'"
+          ref="backendPillButton"
           type="button"
           class="account-pill"
-          :title="accountEmail"
-          :aria-label="accountEmail ? `ariso.ai account ${accountEmail}, open Settings` : 'ariso.ai account, open Settings'"
-          @click="openSettings"
+          :title="backendPillTitle"
+          aria-haspopup="menu"
+          :aria-expanded="backendPopover !== null"
+          @click="toggleBackendMenu"
+          @keydown.down.prevent="openBackendMenu"
         >
-          <img
-            v-if="accountAvatarUrl"
-            class="account-pill-avatar"
-            :src="accountAvatarUrl"
-            alt=""
-            referrerpolicy="no-referrer"
-            @error="accountAvatarUrl = ''"
-          />
-          <span v-else-if="accountDisplayName || accountEmail" class="account-pill-avatar" aria-hidden="true">
-            {{ accountInitials }}
-          </span>
+          <span class="account-pill-label">{{ accountPill === 'local' ? 'Local' : 'ariso.ai' }}</span>
+          <svg v-if="accountPill === 'local'" class="account-pill-icon" viewBox="0 0 24 24" aria-hidden="true">
+            <rect x="2" y="3" width="20" height="14" rx="2" ry="2" />
+            <line x1="8" y1="21" x2="16" y2="21" />
+            <line x1="12" y1="17" x2="12" y2="21" />
+          </svg>
           <svg v-else class="account-pill-icon" viewBox="0 0 24 24" aria-hidden="true">
             <path d="M18 10h-1.26A8 8 0 1 0 9 20h9a5 5 0 0 0 0-10z" />
           </svg>
-          <span class="account-pill-label">ariso.ai</span>
         </button>
-        <button
-          v-else
-          ref="signInPill"
-          type="button"
-          class="account-pill account-pill--signed-out"
-          title="Not signed in — click to sign in"
-          aria-label="ariso.ai, not signed in. Sign in"
-          aria-haspopup="dialog"
-          :aria-expanded="signInPopoverOpen"
-          aria-controls="sign-in-popover"
-          @click="toggleSignInPopover"
-        >
-          <svg class="account-pill-icon" viewBox="0 0 24 24" aria-hidden="true">
-            <path d="M18 10h-1.26A8 8 0 1 0 9 20h9a5 5 0 0 0 0-10z" />
-          </svg>
-          <span class="account-pill-label">ariso.ai</span>
-        </button>
-        <div
-          v-if="signInPopoverOpen && accountPill === 'signed-out'"
-          id="sign-in-popover"
-          class="sign-in-popover"
-          role="dialog"
-          aria-labelledby="sign-in-popover-title"
-        >
-          <p id="sign-in-popover-title" class="sign-in-popover-title">Sign in to ariso.ai</p>
-          <SignInButtons
-            ref="signInButtons"
-            :signing-in-with="accountSigningInWith"
-            :error-message="accountErrorMessage"
-            @sign-in="account.signIn"
-            @cancel="account.cancelSignIn"
-          />
+        <div v-if="backendPopover" class="backend-popover">
+          <div
+            v-if="backendPopover === 'menu'"
+            ref="backendMenu"
+            class="backend-menu"
+            role="menu"
+            aria-label="Backend"
+            @keydown="onBackendMenuKeydown"
+          >
+            <button
+              type="button"
+              role="menuitemradio"
+              class="backend-menu-item"
+              :class="{ 'backend-menu-item--active': activeBackend?.id === 'ariso' }"
+              :aria-checked="activeBackend?.id === 'ariso'"
+              :disabled="recording"
+              tabindex="-1"
+              @click="chooseAriso"
+            >
+              <span>ariso.ai</span>
+              <svg class="account-pill-icon" viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M18 10h-1.26A8 8 0 1 0 9 20h9a5 5 0 0 0 0-10z" />
+              </svg>
+            </button>
+            <button
+              type="button"
+              role="menuitemradio"
+              class="backend-menu-item"
+              :class="{ 'backend-menu-item--active': activeBackend?.id === 'local' }"
+              :aria-checked="activeBackend?.id === 'local'"
+              :disabled="recording"
+              tabindex="-1"
+              @click="chooseLocal"
+            >
+              <span>Local</span>
+              <svg class="account-pill-icon" viewBox="0 0 24 24" aria-hidden="true">
+                <rect x="2" y="3" width="20" height="14" rx="2" ry="2" />
+                <line x1="8" y1="21" x2="16" y2="21" />
+                <line x1="12" y1="17" x2="12" y2="21" />
+              </svg>
+            </button>
+            <p v-if="recording" class="backend-menu-hint">Backend can't be changed while recording.</p>
+            <div class="backend-menu-sep" role="separator" />
+            <button
+              type="button"
+              role="menuitem"
+              class="backend-menu-item"
+              tabindex="-1"
+              @click="chooseSettings"
+            >
+              <span>Settings</span>
+              <Cog6ToothIcon class="account-pill-icon backend-menu-gear" aria-hidden="true" />
+            </button>
+          </div>
+          <div
+            v-else
+            class="sign-in-popover"
+            role="dialog"
+            aria-labelledby="sign-in-popover-title"
+          >
+            <p id="sign-in-popover-title" class="sign-in-popover-title">Sign in to ariso.ai</p>
+            <SignInButtons
+              ref="signInButtons"
+              :signing-in-with="accountSigningInWith"
+              :error-message="accountErrorMessage"
+              @sign-in="account.signIn"
+              @cancel="account.cancelSignIn"
+            />
+          </div>
         </div>
       </div>
       <!-- While a recording runs off-screen (its meeting isn't shown), the
@@ -407,7 +418,8 @@ import {
   recordingStartErrorMessage,
 } from '../composables/recordingStartError';
 import { useAccountState } from '../composables/useAccountState';
-import { AUTH_CHANGED_EVENT } from '../tauri';
+import { AUTH_CHANGED_EVENT, local, setBackendSetting } from '../tauri';
+import { Cog6ToothIcon } from '@heroicons/vue/24/outline';
 import SignInButtons from './SignInButtons.vue';
 import oatsLogo from '../assets/oats-dark.svg';
 
@@ -638,10 +650,7 @@ const account = useAccountState();
 const {
   isSignedIn: accountSignedIn,
   checked: accountChecked,
-  displayName: accountDisplayName,
   email: accountEmail,
-  avatarUrl: accountAvatarUrl,
-  initials: accountInitials,
   signingInWith: accountSigningInWith,
   errorMessage: accountErrorMessage,
 } = account;
@@ -653,40 +662,148 @@ const accountPill = computed<AccountPill | null>(() => {
   if (!accountChecked.value) return 'checking';
   return accountSignedIn.value ? 'signed-in' : 'signed-out';
 });
-
-const signInPopoverOpen = ref(false);
-const accountPillWrap = ref<HTMLElement | null>(null);
-const signInPill = ref<HTMLButtonElement | null>(null);
-const signInButtons = ref<{ focus: () => void } | null>(null);
-
-async function toggleSignInPopover(): Promise<void> {
-  if (signInPopoverOpen.value) {
-    closeSignInPopover();
-    return;
+const backendPillTitle = computed(() => {
+  switch (accountPill.value) {
+    case 'local':
+      return 'Local mode — recordings stay on this device';
+    case 'signed-in':
+      return accountEmail.value ? `ariso.ai — ${accountEmail.value}` : 'ariso.ai';
+    case 'signed-out':
+      return 'ariso.ai — not signed in';
+    default:
+      return 'ariso.ai';
   }
-  signInPopoverOpen.value = true;
+});
+
+// The pill's popover holds the backend menu, or the sign-in box once ariso.ai
+// is picked without a session.
+const backendPopover = ref<'menu' | 'sign-in' | null>(null);
+const accountPillWrap = ref<HTMLElement | null>(null);
+const backendPillButton = ref<HTMLButtonElement | null>(null);
+const backendMenu = ref<HTMLElement | null>(null);
+const signInButtons = ref<{ focus: () => void } | null>(null);
+let switchingBackend = false;
+
+function backendMenuItems(): HTMLElement[] {
+  return [
+    ...(backendMenu.value?.querySelectorAll<HTMLElement>('[role^="menuitem"]:not(:disabled)') ?? []),
+  ];
+}
+
+function focusBackendMenuItem(idx: number): void {
+  const items = backendMenuItems();
+  if (items.length === 0) return;
+  items[((idx % items.length) + items.length) % items.length].focus();
+}
+
+function onBackendMenuKeydown(event: KeyboardEvent): void {
+  const items = backendMenuItems();
+  const current = items.indexOf(document.activeElement as HTMLElement);
+  const moves: Record<string, number> = {
+    ArrowDown: current + 1,
+    ArrowUp: current - 1,
+    Home: 0,
+    End: items.length - 1,
+  };
+  if (!(event.key in moves)) return;
+  event.preventDefault();
+  focusBackendMenuItem(moves[event.key]);
+}
+
+async function openBackendMenu(): Promise<void> {
+  backendPopover.value = 'menu';
+  await nextTick();
+  // Land on the active backend, as Settings' backend picker does.
+  const items = backendMenuItems();
+  (items.find((el) => el.getAttribute('aria-checked') === 'true') ?? items[0])?.focus();
+}
+
+function toggleBackendMenu(): void {
+  if (backendPopover.value) closeBackendPopover();
+  else void openBackendMenu();
+}
+
+function closeBackendPopover({ restoreFocus = false } = {}): void {
+  if (!backendPopover.value) return;
+  backendPopover.value = null;
+  if (restoreFocus) backendPillButton.value?.focus();
+}
+
+async function showSignInBox(): Promise<void> {
+  backendPopover.value = 'sign-in';
   await nextTick();
   signInButtons.value?.focus();
 }
 
-function closeSignInPopover({ restoreFocus = false } = {}): void {
-  if (!signInPopoverOpen.value) return;
-  signInPopoverOpen.value = false;
-  if (restoreFocus) signInPill.value?.focus();
+// Tags this window's own backend-changed broadcasts, which it has already
+// applied by the time they come back to it.
+const backendSwitchSource = `library-${Math.random().toString(36).slice(2)}`;
+
+// The switch Settings' backend picker makes: persist it, then tell every
+// window and the native orchestrators (tray next-meeting, notifications).
+// Refused while a recording owns the recorder, as in Settings.
+async function switchBackend(next: 'ariso' | 'local'): Promise<boolean> {
+  if (recording.value || switchingBackend) return false;
+  switchingBackend = true;
+  try {
+    await setBackendSetting(next);
+  } catch (e) {
+    console.error('Failed to switch backend', e);
+    return false;
+  } finally {
+    switchingBackend = false;
+  }
+  void emit(BACKEND_CHANGED_EVENT, { source: backendSwitchSource }).catch((err) => {
+    console.warn('Failed to broadcast backend change', err);
+  });
+  void emitNotificationsSync().catch((err) => {
+    console.warn('Failed to broadcast sync after backend change', err);
+  });
+  await onBackendChanged();
+  return true;
+}
+
+// ariso.ai: switch to it if needed, then sign in if there's no session.
+async function chooseAriso(): Promise<void> {
+  if (activeBackend.value?.id !== 'ariso' && !(await switchBackend('ariso'))) return;
+  if (!accountChecked.value) await account.refresh();
+  if (activeBackend.value?.id !== 'ariso') return; // switched away meanwhile
+  if (accountSignedIn.value) closeBackendPopover({ restoreFocus: true });
+  else await showSignInBox();
+}
+
+async function chooseLocal(): Promise<void> {
+  closeBackendPopover({ restoreFocus: true });
+  if (activeBackend.value?.id === 'local' || !(await switchBackend('local'))) return;
+  // Settings owns the on-device models: their first-time download confirmation
+  // and progress. Its backend-changed listener starts that flow; bring it up
+  // when there's something to see.
+  try {
+    const status = await local.modelStatus();
+    if (status.state !== 'ready' || status.llmReady !== true) await openSettings();
+  } catch (e) {
+    console.warn('Failed to read on-device model status', e);
+    await openSettings();
+  }
+}
+
+async function chooseSettings(): Promise<void> {
+  closeBackendPopover();
+  await openSettings();
 }
 
 // A click elsewhere dismisses the popover, except while a browser flow is
 // pending: its Cancel button lives there.
 function onDocumentMousedown(event: MouseEvent): void {
-  if (!signInPopoverOpen.value || accountSigningInWith.value) return;
+  if (!backendPopover.value || accountSigningInWith.value) return;
   if (accountPillWrap.value?.contains(event.target as Node)) return;
-  closeSignInPopover();
+  closeBackendPopover();
 }
 
-// However the session arrived (the popover, Settings, Onboarding, a tray row),
-// the pill switches to the signed-in state and the popover has nothing to offer.
+// However the session arrived (the sign-in box, Settings, Onboarding, a tray
+// row), the sign-in box has nothing left to offer.
 watch(accountSignedIn, (signedIn) => {
-  if (signedIn) closeSignInPopover();
+  if (signedIn && backendPopover.value === 'sign-in') closeBackendPopover();
 });
 
 // Covers both the first load on mount and every backend switch, since each
@@ -698,12 +815,25 @@ watch(
     if (id === 'ariso') {
       void account.refresh();
     } else if (id === 'local') {
-      closeSignInPopover();
+      if (backendPopover.value === 'sign-in') closeBackendPopover();
       if (accountSigningInWith.value) void account.cancelSignIn();
       account.reset();
     }
   }
 );
+
+// Switching backends changes the whole meeting corpus. Close any meeting held
+// open from the previous backend — returning the detail to the neutral Up Next
+// state — and reload against the new backend.
+async function onBackendChanged(): Promise<void> {
+  selectedItem.value = null;
+  userSelectedMeetingId.value = null;
+  pinnedMeetings.value = new Map();
+  // The tracked ids are Ariso's; keeping them alive would keep polling its
+  // API from offline mode and re-show "Processing…" on a later switch back.
+  processingMeetings.reset();
+  await loadMeetings();
+}
 
 function onAuthChanged(): void {
   if (activeBackend.value?.id === 'ariso') void account.refresh();
@@ -1445,17 +1575,11 @@ onMounted(() => {
   }).then((un) => {
     unlistenVaultChanged = un;
   });
-  // Switching backends (in Settings) changes the whole meeting corpus. Close
-  // any meeting held open from the previous backend — returning the detail to
-  // the neutral Up Next state — and reload against the new backend.
-  void listen(BACKEND_CHANGED_EVENT, () => {
-    selectedItem.value = null;
-    userSelectedMeetingId.value = null;
-    pinnedMeetings.value = new Map();
-    // The tracked ids are Ariso's; keeping them alive would keep polling its
-    // API from offline mode and re-show "Processing…" on a later switch back.
-    processingMeetings.reset();
-    void loadMeetings();
+  // A backend switch made in Settings (or another window).
+  void listen(BACKEND_CHANGED_EVENT, (event) => {
+    const source = (event.payload as { source?: unknown } | null)?.source;
+    if (source === backendSwitchSource) return;
+    void onBackendChanged();
   }).then((un) => {
     unlistenBackendChanged = un;
   });
@@ -1718,7 +1842,8 @@ onUnmounted(() => {
 .add-btn--static { cursor: default; }
 .add-btn--static:hover { box-shadow: 1px 1px 0 #e7e5e2; transform: none; }
 /* Backend indicator: a compact pill beside the sidebar toggle, matching the
-   Start recording pill at the other end of the titlebar. */
+   Start recording pill at the other end of the titlebar. Name first, then the
+   backend's icon, as in Settings' backend picker. */
 .account-pill-wrap {
   position: relative;
   display: flex;
@@ -1728,7 +1853,7 @@ onUnmounted(() => {
 .account-pill {
   max-width: 160px;
   height: 22px;
-  padding: 0 9px 0 5px;
+  padding: 0 7px 0 9px;
   gap: 5px;
   border-radius: 11px;
   background: #ffffff;
@@ -1742,18 +1867,10 @@ onUnmounted(() => {
   transition: transform 0.1s, box-shadow 0.1s;
 }
 .titlebar--windows .account-pill { height: 26px; border-radius: 13px; }
-button.account-pill:hover { box-shadow: 0 0 0 #e7e5e2; transform: translate(1px, 1px); }
-button.account-pill:focus-visible {
+.account-pill:hover { box-shadow: 0 0 0 #e7e5e2; transform: translate(1px, 1px); }
+.account-pill:focus-visible {
   outline: 2px solid #3b6fc4;
   outline-offset: 2px;
-}
-/* Local, and ariso.ai before the first session check: informational only. */
-.account-pill--static {
-  background: transparent;
-  border-color: #e4e2de;
-  box-shadow: none;
-  color: #6f6f6f;
-  cursor: default;
 }
 .account-pill-icon {
   width: 13px;
@@ -1765,19 +1882,7 @@ button.account-pill:focus-visible {
   stroke-linecap: round;
   stroke-linejoin: round;
 }
-.account-pill-avatar {
-  width: 16px;
-  height: 16px;
-  flex: 0 0 auto;
-  border-radius: 50%;
-  background: #1c1c1c;
-  color: #ffffff;
-  font-size: 7px;
-  font-weight: 700;
-  line-height: 16px;
-  text-align: center;
-  object-fit: cover;
-}
+.backend-menu-gear { stroke-width: 1.5; }
 .account-pill-label {
   min-width: 0;
   overflow: hidden;
@@ -1787,11 +1892,63 @@ button.account-pill:focus-visible {
   line-height: 1;
   white-space: nowrap;
 }
-.sign-in-popover {
+.backend-popover {
   position: absolute;
   top: calc(100% + 6px);
   left: 0;
   z-index: 30;
+}
+/* Same card and rows as Settings' backend picker. */
+.backend-menu {
+  min-width: 160px;
+  box-sizing: border-box;
+  padding: 4px;
+  background: #ffffff;
+  border: 1px solid #e5e6e3;
+  border-radius: 12px;
+  box-shadow: 2px 2px 0 #e7e5e2;
+}
+.backend-menu-item {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 6px 10px;
+  border: none;
+  border-radius: 999px;
+  background: transparent;
+  color: #1c1c1c;
+  font-family: inherit;
+  font-size: 13px;
+  white-space: nowrap;
+  cursor: pointer;
+}
+.backend-menu-item:hover:not(:disabled) { background: rgba(0, 0, 0, 0.03); }
+.backend-menu-item:focus-visible {
+  background: #f5f5f7;
+  outline: 2px solid #6366f1;
+  outline-offset: -2px;
+}
+.backend-menu-item--active,
+.backend-menu-item--active:hover:not(:disabled),
+.backend-menu-item--active:focus-visible {
+  background: #1c1c1c;
+  color: #ffffff;
+}
+.backend-menu-item:disabled { opacity: 0.5; cursor: not-allowed; }
+.backend-menu-hint {
+  margin: 4px 10px;
+  font-size: 11px;
+  color: #6f6f6f;
+  white-space: nowrap;
+}
+.backend-menu-sep {
+  height: 1px;
+  margin: 4px 6px;
+  background: #e5e6e3;
+}
+.sign-in-popover {
   width: 260px;
   box-sizing: border-box;
   padding: 14px;

--- a/src/views/OnboardingView.test.ts
+++ b/src/views/OnboardingView.test.ts
@@ -9,11 +9,9 @@ const ensureCalendarAccess = vi.fn();
 const setOnboarded = vi.fn();
 const openSettingsWindow = vi.fn();
 const emitNotificationsSync = vi.fn();
-const emit = vi.fn();
 const close = vi.fn();
 
 vi.mock('../tauri', () => ({
-  AUTH_SIGNED_IN_EVENT: 'auth://signed-in',
   SIGN_IN_CANCELED_ERROR: 'Sign-in canceled',
   auth: {
     googleSignIn: () => googleSignIn(),
@@ -27,9 +25,6 @@ vi.mock('../tauri', () => ({
 vi.mock('../composables/useMeetingNotifications', () => ({
   emitNotificationsSync: () => emitNotificationsSync(),
 }));
-vi.mock('@tauri-apps/api/event', () => ({
-  emit: (event: string) => emit(event),
-}));
 vi.mock('@tauri-apps/api/window', () => ({
   getCurrentWindow: () => ({ close: () => close() }),
 }));
@@ -41,7 +36,6 @@ beforeEach(() => {
   setOnboarded.mockResolvedValue(undefined);
   openSettingsWindow.mockResolvedValue(undefined);
   emitNotificationsSync.mockResolvedValue(undefined);
-  emit.mockResolvedValue(undefined);
   ensureCalendarAccess.mockResolvedValue({ connected: true });
 });
 
@@ -109,7 +103,6 @@ describe('OnboardingView', () => {
     await wrapper.find('.google-btn').trigger('click');
     await flushPromises();
     expect(emitNotificationsSync).toHaveBeenCalled();
-    expect(emit).toHaveBeenCalledWith('auth://signed-in');
     expect(setOnboarded).toHaveBeenCalledWith(true);
     expect(openSettingsWindow).toHaveBeenCalled();
     expect(close).toHaveBeenCalled();
@@ -131,7 +124,7 @@ describe('OnboardingView', () => {
     expect(wrapper.get('.microsoft-btn').text()).toContain('Sign in with Microsoft');
   });
 
-  it('Microsoft sign-in broadcasts, skips the calendar hop, and finishes onboarding', async () => {
+  it('Microsoft sign-in syncs notifications, skips the calendar hop, and finishes onboarding', async () => {
     microsoftSignIn.mockResolvedValue({ success: true, sessionToken: 't' });
     const wrapper = mount(OnboardingView);
     await wrapper.get('.microsoft-btn').trigger('click');
@@ -139,7 +132,6 @@ describe('OnboardingView', () => {
 
     expect(googleSignIn).not.toHaveBeenCalled();
     expect(emitNotificationsSync).toHaveBeenCalled();
-    expect(emit).toHaveBeenCalledWith('auth://signed-in');
     // ensureCalendarAccess opens Google's Workspace consent page.
     expect(ensureCalendarAccess).not.toHaveBeenCalled();
     expect(setOnboarded).toHaveBeenCalledWith(true);

--- a/src/views/OnboardingView.vue
+++ b/src/views/OnboardingView.vue
@@ -63,8 +63,7 @@
 <script setup lang="ts">
 import { ref, computed } from 'vue';
 import { getCurrentWindow } from '@tauri-apps/api/window';
-import { emit } from '@tauri-apps/api/event';
-import { AUTH_SIGNED_IN_EVENT, SIGN_IN_CANCELED_ERROR, auth, openSettingsWindow, setOnboarded } from '../tauri';
+import { SIGN_IN_CANCELED_ERROR, auth, openSettingsWindow, setOnboarded } from '../tauri';
 import { emitNotificationsSync } from '../composables/useMeetingNotifications';
 import { ONBOARDING_STEPS, nextStepIndex } from './onboarding';
 
@@ -124,9 +123,6 @@ async function handleSignIn(provider: SignInProvider) {
     }
     void emitNotificationsSync().catch((err) => {
       console.warn('Failed to sync notifications after sign-in', err);
-    });
-    void emit(AUTH_SIGNED_IN_EVENT).catch((err) => {
-      console.warn('Failed to broadcast desktop sign-in', err);
     });
     // Calendar comes from Google only: ensureCalendarAccess opens Google's
     // Workspace consent page, which a Microsoft user must never land on.

--- a/src/views/SettingsView.test.ts
+++ b/src/views/SettingsView.test.ts
@@ -48,7 +48,7 @@ vi.mock('@tauri-apps/api/event', () => ({
   emit: (...args: unknown[]) => emit(...args),
 }));
 vi.mock('../tauri', () => ({
-  AUTH_SIGNED_IN_EVENT: 'auth://signed-in',
+  AUTH_CHANGED_EVENT: 'auth://changed',
   SIGN_IN_CANCELED_ERROR: 'Sign-in canceled',
   auth: {
     checkSession: () => checkSession(),
@@ -162,12 +162,28 @@ beforeEach(() => {
   getVaultDir.mockResolvedValue('/Users/x/.ariso/vault');
   setVaultDir.mockResolvedValue(undefined);
   pickVaultFolder.mockResolvedValue(null);
-  googleSignIn.mockResolvedValue({ success: true, sessionToken: 't' });
-  microsoftSignIn.mockResolvedValue({ success: true, sessionToken: 't' });
+  // Sign-in stores a session and sign-out clears it, as the backend does, so
+  // the account refresh that follows each one reads the new state.
+  googleSignIn.mockImplementation(storeSession);
+  microsoftSignIn.mockImplementation(storeSession);
   cancelSignIn.mockResolvedValue(undefined);
   ensureCalendarAccess.mockResolvedValue({ connected: true });
-  signOut.mockResolvedValue(undefined);
+  signOut.mockImplementation(() => {
+    checkSession.mockResolvedValue(null);
+    return Promise.resolve();
+  });
 });
+
+function storeSession(): Promise<SignInResult> {
+  checkSession.mockResolvedValue({ sessionToken: 't' });
+  return Promise.resolve({ success: true, sessionToken: 't' });
+}
+
+function fireAuthChanged() {
+  const cb = listeners.get('auth://changed');
+  expect(cb).toBeDefined();
+  cb!({ payload: null });
+}
 
 function fireRecordingState(active: boolean) {
   const cb = listeners.get('recording://state');
@@ -533,7 +549,7 @@ describe('SettingsView sign-in providers', () => {
     expect(google.text()).toContain('Sign in with Google');
 
     // One Cancel covers both providers.
-    await wrapper.get('.sign-in-container .sign-out-btn').trigger('click');
+    await wrapper.get('.sign-in-cancel').trigger('click');
     expect(cancelSignIn).toHaveBeenCalledTimes(1);
   });
 
@@ -543,7 +559,7 @@ describe('SettingsView sign-in providers', () => {
     await wrapper.get('.microsoft-btn').trigger('click');
     await flushPromises();
 
-    expect(wrapper.find('.sign-in-container .error').exists()).toBe(false);
+    expect(wrapper.find('.sign-in-error').exists()).toBe(false);
     expect(wrapper.get('.google-btn').attributes('disabled')).toBeUndefined();
     expect(wrapper.get('.microsoft-btn').attributes('disabled')).toBeUndefined();
     expect(wrapper.get('.microsoft-btn').text()).toContain('Sign in with Microsoft');
@@ -555,7 +571,7 @@ describe('SettingsView sign-in providers', () => {
     await wrapper.get('.microsoft-btn').trigger('click');
     await flushPromises();
 
-    expect(wrapper.get('.sign-in-container .error').text()).toBe('API returned 500');
+    expect(wrapper.get('.sign-in-error').text()).toBe('API returned 500');
   });
 
   it('never shows a Microsoft user the Google calendar nudge left over from a Google session', async () => {
@@ -589,13 +605,61 @@ describe('SettingsView sign-in providers', () => {
     // A Microsoft sign-in completed in Onboarding: this window only hears the
     // broadcast and refreshes, so handleSignIn's reset never runs here.
     checkSession.mockResolvedValue({ token: 'session' });
-    const onSignedIn = listeners.get('auth://signed-in');
-    expect(onSignedIn).toBeDefined();
-    onSignedIn!({ payload: null });
+    fireAuthChanged();
     await flushPromises();
 
     expect(wrapper.text()).toContain('Sign Out');
     expect(wrapper.find('.calendar-connect').exists()).toBe(false);
+  });
+});
+
+describe('SettingsView auth broadcast', () => {
+  it('clears the account card when the session ends elsewhere', async () => {
+    checkSession.mockResolvedValue({ sessionToken: 'session' });
+    const wrapper = mount(SettingsView);
+    await flushPromises();
+    expect(wrapper.text()).toContain('Sign Out');
+
+    // Signed out from another window, or a rejected session cleared natively.
+    checkSession.mockResolvedValue(null);
+    fireAuthChanged();
+    await flushPromises();
+
+    expect(wrapper.text()).not.toContain('Sign Out');
+    expect(wrapper.get('.google-btn').text()).toContain('Sign in with Google');
+  });
+
+  it('shows a sign-in from another window without a remount', async () => {
+    const wrapper = mount(SettingsView);
+    await flushPromises();
+    expect(wrapper.find('.sign-in-container').exists()).toBe(true);
+
+    checkSession.mockResolvedValue({ sessionToken: 'session' });
+    fireAuthChanged();
+    await flushPromises();
+
+    expect(wrapper.text()).toContain('Sign Out');
+    // The broadcast only prompts a re-read; this window starts no flow.
+    expect(googleSignIn).not.toHaveBeenCalled();
+    expect(microsoftSignIn).not.toHaveBeenCalled();
+  });
+
+  it('keeps the recording sign-in banner until a session actually exists', async () => {
+    const wrapper = mount(SettingsView);
+    await flushPromises();
+    listeners.get('tray://show-sign-in-prompt')!({ payload: null });
+    await flushPromises();
+    expect(wrapper.text()).toContain('Please sign in to start recording.');
+
+    // A sign-out elsewhere is also a change, but leaves the user signed out.
+    fireAuthChanged();
+    await flushPromises();
+    expect(wrapper.text()).toContain('Please sign in to start recording.');
+
+    checkSession.mockResolvedValue({ sessionToken: 'session' });
+    fireAuthChanged();
+    await flushPromises();
+    expect(wrapper.text()).not.toContain('Please sign in to start recording.');
   });
 });
 
@@ -634,7 +698,7 @@ describe('SettingsView tray sign-in', () => {
     await flushPromises();
 
     expect(wrapper.get('.google-btn').text()).toContain('Continue in your browser…');
-    expect(wrapper.find('.sign-in-container .sign-out-btn').exists()).toBe(true);
+    expect(wrapper.find('.sign-in-cancel').exists()).toBe(true);
   });
 
   it('ignores a request while a flow is already pending', async () => {

--- a/src/views/SettingsView.test.ts
+++ b/src/views/SettingsView.test.ts
@@ -613,6 +613,79 @@ describe('SettingsView sign-in providers', () => {
   });
 });
 
+describe('SettingsView backend switched elsewhere', () => {
+  function fireBackendChanged() {
+    const cb = listeners.get('backend://changed');
+    expect(cb).toBeDefined();
+    cb!({ payload: { source: 'library-x' } });
+  }
+
+  it('follows a switch to Local and asks before the first model download', async () => {
+    hasPromptedLocalModels.mockResolvedValue(false);
+    const wrapper = mount(SettingsView);
+    await flushPromises();
+    expect(wrapper.get('.backend-trigger').text()).toContain('ariso.ai');
+
+    getBackendSetting.mockResolvedValue('local' as never);
+    fireBackendChanged();
+    await flushPromises();
+
+    expect(wrapper.get('.backend-trigger').text()).toContain('Local');
+    expect(wrapper.find('.download-confirm').exists()).toBe(true);
+    expect(downloadStt).not.toHaveBeenCalled();
+    // Following a switch doesn't make one of its own.
+    expect(setBackendSetting).not.toHaveBeenCalled();
+    expect(emit).not.toHaveBeenCalledWith('backend://changed');
+  });
+
+  it('starts missing downloads right away when already prompted once', async () => {
+    hasPromptedLocalModels.mockResolvedValue(true);
+    const wrapper = mount(SettingsView);
+    await flushPromises();
+
+    getBackendSetting.mockResolvedValue('local' as never);
+    fireBackendChanged();
+    await flushPromises();
+
+    expect(wrapper.find('.download-confirm').exists()).toBe(false);
+    expect(downloadStt).toHaveBeenCalledTimes(1);
+    expect(downloadLlm).toHaveBeenCalledTimes(1);
+  });
+
+  it('treats its own switch coming back as already applied', async () => {
+    hasPromptedLocalModels.mockResolvedValue(true);
+    const wrapper = mount(SettingsView);
+    await flushPromises();
+    await wrapper.get('.backend-trigger').trigger('click');
+    await wrapper.findAll('.backend-option')[1].trigger('mousedown');
+    await flushPromises();
+    expect(downloadStt).toHaveBeenCalledTimes(1);
+
+    getBackendSetting.mockResolvedValue('local' as never);
+    fireBackendChanged();
+    await flushPromises();
+
+    expect(downloadStt).toHaveBeenCalledTimes(1);
+  });
+
+  it('drops the download confirmation when switched back to ariso.ai elsewhere', async () => {
+    hasPromptedLocalModels.mockResolvedValue(false);
+    const wrapper = mount(SettingsView);
+    await flushPromises();
+    getBackendSetting.mockResolvedValue('local' as never);
+    fireBackendChanged();
+    await flushPromises();
+    expect(wrapper.find('.download-confirm').exists()).toBe(true);
+
+    getBackendSetting.mockResolvedValue('ariso');
+    fireBackendChanged();
+    await flushPromises();
+
+    expect(wrapper.find('.download-confirm').exists()).toBe(false);
+    expect(wrapper.get('.backend-trigger').text()).toContain('ariso.ai');
+  });
+});
+
 describe('SettingsView auth broadcast', () => {
   it('clears the account card when the session ends elsewhere', async () => {
     checkSession.mockResolvedValue({ sessionToken: 'session' });

--- a/src/views/SettingsView.vue
+++ b/src/views/SettingsView.vue
@@ -679,18 +679,43 @@ async function selectBackend(next: 'ariso' | 'local') {
   void emitNotificationsSync().catch((err) => {
     console.warn('Failed to broadcast sync after backend change', err);
   });
+  if (next === 'local') await afterSwitchToLocal();
+}
+
+async function afterSwitchToLocal() {
+  await refreshModelStatus();
+  // First time only: ask before fetching the (large) on-device models.
+  const prompted = await hasPromptedLocalModels().catch(() => true);
+  if (shouldPromptDownload('local', prompted, modelStatus.value.state)) {
+    showDownloadConfirm.value = true;
+  } else {
+    // Already confirmed once before (or STT already installed): skip the
+    // modal and start any still-missing downloads right away, so the models
+    // are ready by the time the user records.
+    startMissingDownloads();
+  }
+}
+
+// Another window (the Meetings window's backend menu) switched the backend.
+// This window is pre-created and outlives that, so follow it, and treat a
+// switch to Local the way a switch made here is treated. Its own switches
+// come back here too, already applied, so an unchanged backend is a no-op.
+async function onBackendChangedElsewhere() {
+  let next: 'ariso' | 'local';
+  try {
+    next = await getBackendSetting();
+  } catch (e) {
+    console.warn('Failed to re-read backend setting', e);
+    return;
+  }
+  if (next === backend.value) return;
+  backend.value = next;
+  backendOpen.value = false;
   if (next === 'local') {
-    await refreshModelStatus();
-    // First time only: ask before fetching the (large) on-device models.
-    const prompted = await hasPromptedLocalModels().catch(() => true);
-    if (shouldPromptDownload(next, prompted, modelStatus.value.state)) {
-      showDownloadConfirm.value = true;
-    } else {
-      // Already confirmed once before (or STT already installed): skip the
-      // modal and start any still-missing downloads right away, so the models
-      // are ready by the time the user records.
-      startMissingDownloads();
-    }
+    await afterSwitchToLocal();
+  } else {
+    // Nothing left to confirm: the switch the modal was about is undone.
+    showDownloadConfirm.value = false;
   }
 }
 
@@ -1073,6 +1098,9 @@ onMounted(async () => {
   const unLlmProgress = await listen<number>('model://llm/progress', (e) => {
     llmProgress.value = e.payload >= 0 ? e.payload : null;
   });
+  const unBackendChanged = await listen(BACKEND_CHANGED_EVENT, () => {
+    void onBackendChangedElsewhere();
+  });
   const unModelPrompt = await listen('tray://show-model-prompt', async () => {
     modelPrompt.value = true;
     // The recording gate fired because a model isn't ready — auto-start the
@@ -1080,7 +1108,7 @@ onMounted(async () => {
     await refreshModelStatus();
     startMissingDownloads();
   });
-  unlistenUpdates.push(unSttProgress, unLlmProgress, unModelPrompt);
+  unlistenUpdates.push(unSttProgress, unLlmProgress, unModelPrompt, unBackendChanged);
 });
 
 // Registered as its own hook so a failure in the main bootstrap above can't

--- a/src/views/SettingsView.vue
+++ b/src/views/SettingsView.vue
@@ -1059,7 +1059,7 @@ onMounted(async () => {
   // elsewhere (Onboarding, the Meetings popover, a rejected session cleared
   // natively), so follow the backend's broadcast rather than its own mount.
   const unAuthChanged = await listen(AUTH_CHANGED_EVENT, async () => {
-    await refreshSignedInAccount();
+    await refreshSignedInAccount(true);
     if (isSignedIn.value) signInPrompt.value = false;
   });
 

--- a/src/views/SettingsView.vue
+++ b/src/views/SettingsView.vue
@@ -196,7 +196,7 @@
             <span class="account-name">{{ displayName }}</span>
             <span class="account-email">{{ email }}</span>
           </div>
-          <button class="sign-out-btn" @click="handleSignOut">Sign Out</button>
+          <button class="sign-out-btn" @click="signOut">Sign Out</button>
         </div>
         <div v-if="calendarConnected === false" class="calendar-connect">
           <p class="calendar-connect-text">
@@ -212,42 +212,12 @@
         </div>
         </template>
         <div v-else class="sign-in-container">
-          <button
-            :disabled="isSigningIn"
-            class="google-btn"
-            @click="handleSignIn('google')"
-          >
-            <svg class="google-icon" viewBox="0 0 24 24" aria-hidden="true">
-              <path fill="#4285F4" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z" />
-              <path fill="#34A853" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" />
-              <path fill="#FBBC05" d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" />
-              <path fill="#EA4335" d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" />
-            </svg>
-            <span v-if="signingInWith === 'google'">Continue in your browser…</span>
-            <span v-else>Sign in with Google</span>
-          </button>
-          <button
-            :disabled="isSigningIn"
-            class="microsoft-btn"
-            @click="handleSignIn('microsoft')"
-          >
-            <svg class="microsoft-icon" viewBox="0 0 21 21" aria-hidden="true">
-              <path fill="#F25022" d="M0 0h10v10H0z" />
-              <path fill="#7FBA00" d="M11 0h10v10H11z" />
-              <path fill="#00A4EF" d="M0 11h10v10H0z" />
-              <path fill="#FFB900" d="M11 11h10v10H11z" />
-            </svg>
-            <span v-if="signingInWith === 'microsoft'">Continue in your browser…</span>
-            <span v-else>Sign in with Microsoft</span>
-          </button>
-          <button
-            v-if="isSigningIn"
-            class="sign-out-btn"
-            @click="handleCancelSignIn"
-          >
-            Cancel
-          </button>
-          <p v-if="errorMessage" class="error">{{ errorMessage }}</p>
+          <SignInButtons
+            :signing-in-with="signingInWith"
+            :error-message="errorMessage"
+            @sign-in="handleSignIn"
+            @cancel="cancelSignIn"
+          />
         </div>
       </div>
     </section>
@@ -468,7 +438,7 @@ import { ref, computed, watch, nextTick, onMounted, onUnmounted } from 'vue';
 import { emit, listen, type UnlistenFn } from '@tauri-apps/api/event';
 import { BACKEND_CHANGED_EVENT } from '../composables/useBackend';
 import { getAllWebviewWindows } from '@tauri-apps/api/webviewWindow';
-import { AUTH_SIGNED_IN_EVENT, SIGN_IN_CANCELED_ERROR, auth, api, updater, getBackendSetting, setBackendSetting, hasPromptedLocalModels, setPromptedLocalModels, local, getVaultDir, setVaultDir, pickVaultFolder, type ModelStatus } from '../tauri';
+import { AUTH_CHANGED_EVENT, auth, updater, getBackendSetting, setBackendSetting, hasPromptedLocalModels, setPromptedLocalModels, local, getVaultDir, setVaultDir, pickVaultFolder, type ModelStatus } from '../tauri';
 import { shouldPromptDownload, rowStatusText, pendingInstalls, modelBannerVisible, type Busy } from './settingsDownload';
 import { defaultPlatformCapabilities, loadPlatformCapabilities } from '../composables/usePlatformCapabilities';
 import { applyToggle, type PermissionStatus } from './recordingSettings';
@@ -502,20 +472,34 @@ import {
   isMeetingEndReminderEnabled,
   setMeetingEndReminderEnabled,
 } from '../composables/useMeetingEndReminder';
+import { useAccountState, type SignInProvider } from '../composables/useAccountState';
+import SignInButtons from './SignInButtons.vue';
 
-const isSignedIn = ref(false);
-type SignInProvider = 'google' | 'microsoft';
-// The provider whose browser flow is pending. Both buttons disable while
-// either is pending; only the clicked one reads "Continue in your browser…".
-const signingInWith = ref<SignInProvider | null>(null);
+const {
+  isSignedIn,
+  displayName,
+  email,
+  avatarUrl,
+  initials,
+  signingInWith,
+  // Also carries the platform-capabilities failure below, shown in the same spot.
+  errorMessage,
+  refresh: refreshSignedInAccount,
+  signIn,
+  cancelSignIn,
+  signOut,
+} = useAccountState();
 const isSigningIn = computed(() => signingInWith.value !== null);
 const isConnectingCalendar = ref(false);
 // null = not checked this session; false = checked and missing.
 const calendarConnected = ref<boolean | null>(null);
-const errorMessage = ref('');
-const displayName = ref('');
-const email = ref('');
-const avatarUrl = ref('');
+// The Calendar verdict belongs to the session that just ended, however it
+// ended: a sign-out here, or one that reached this window as a broadcast. The
+// next session may be a Microsoft sign-in finished in another window, which
+// reaches this window only through the refresh, and that keeps the verdict.
+watch(isSignedIn, (signedIn) => {
+  if (!signedIn) calendarConnected.value = null;
+});
 const micEnabled = ref(true);
 const systemAudioEnabled = ref(true);
 const autoRecordEnabled = ref(true);
@@ -916,11 +900,6 @@ async function onToggleMeetingNotifications(e: Event) {
   }
 }
 
-const initials = computed(() => {
-  const name = displayName.value || email.value || '?';
-  return name.slice(0, 2).toUpperCase();
-});
-
 async function onToggleMic(e: Event) {
   if (recordingToggleBusy.value) return;
   micToggling.value = true;
@@ -1003,93 +982,8 @@ async function onToggleSystemAudio(e: Event) {
   }
 }
 
-async function fetchUserProfile() {
-  try {
-    const res = await api.request('GET', '/auth/me');
-    const data = res.data as { full_name?: string; email?: string };
-    displayName.value = data.full_name || '';
-    email.value = data.email || '';
-  } catch {
-    // profile fetch failed — leave fields empty
-  }
-  // Avatar is fetched separately and is non-critical: a failure here must not
-  // disturb the name/email above, and the UI falls back to initials.
-  avatarUrl.value = await fetchAvatar();
-}
-
-// Which provider the user signed in with isn't recorded, so ask Google first
-// and fall back to Microsoft: an account has no avatar on the other provider.
-async function fetchAvatar(): Promise<string> {
-  for (const path of ['/users/google-avatar', '/users/microsoft-avatar']) {
-    try {
-      const res = await api.request('GET', path);
-      const avatar = (res.data as { avatar?: string | null } | null)?.avatar;
-      // Preload before binding to the <img>: WKWebView drops the very first
-      // request for a freshly-rendered <img> during the post-sign-in churn and
-      // never retries it, leaving a broken "?". Loading it through a detached
-      // Image first (which is not affected) warms the cache, so the bound <img>
-      // resolves instantly. Falls back to initials if it truly can't load.
-      if (avatar) return await preloadAvatar(avatar);
-    } catch {
-      // Try the next provider.
-    }
-  }
-  return '';
-}
-
-// Resolves to `url` once it loads in a detached Image (retrying a few times for
-// transient webview failures), or to '' so the caller falls back to initials.
-function preloadAvatar(url: string): Promise<string> {
-  return new Promise((resolve) => {
-    const MAX_ATTEMPTS = 4;
-    let attempts = 0;
-    const attempt = () => {
-      const img = new Image();
-      img.referrerPolicy = 'no-referrer';
-      img.onload = () => resolve(url);
-      img.onerror = () => {
-        attempts += 1;
-        if (attempts >= MAX_ATTEMPTS) {
-          resolve('');
-        } else {
-          setTimeout(attempt, 300 * attempts);
-        }
-      };
-      img.src = url;
-    };
-    attempt();
-  });
-}
-
 let unlistenSignInPrompt: UnlistenFn | null = null;
 const unlistenUpdates: UnlistenFn[] = [];
-
-// Refresh account UI from persisted native session state. The settings window is
-// hidden/pre-created at app startup, so it cannot rely only on its first mount.
-// Never throws: a checkSession failure in onMounted would otherwise abort the
-// rest of initialization (update listeners, recording bootstrap, etc.), and a
-// failure inside the AUTH_SIGNED_IN_EVENT callback would reject the listener.
-async function refreshSignedInAccount() {
-  try {
-    const session = await auth.checkSession();
-    isSignedIn.value = !!session;
-    if (isSignedIn.value) {
-      await fetchUserProfile();
-    } else {
-      displayName.value = '';
-      email.value = '';
-      avatarUrl.value = '';
-      calendarConnected.value = null;
-    }
-  } catch (e) {
-    isSignedIn.value = false;
-    displayName.value = '';
-    email.value = '';
-    avatarUrl.value = '';
-    calendarConnected.value = null;
-    console.warn('Failed to refresh signed-in account', e);
-  }
-}
 
 onMounted(async () => {
   // Native capabilities are authoritative. Keep the conservative initial state
@@ -1136,9 +1030,12 @@ onMounted(async () => {
   const unTraySignIn = await listen<unknown>('tray://sign-in', (e) => {
     void handleTraySignIn(e.payload);
   });
-  const unSignedIn = await listen(AUTH_SIGNED_IN_EVENT, async () => {
+  // This window is pre-created hidden and outlives sign-ins and sign-outs made
+  // elsewhere (Onboarding, the Meetings popover, a rejected session cleared
+  // natively), so follow the backend's broadcast rather than its own mount.
+  const unAuthChanged = await listen(AUTH_CHANGED_EVENT, async () => {
     await refreshSignedInAccount();
-    signInPrompt.value = false;
+    if (isSignedIn.value) signInPrompt.value = false;
   });
 
   await loadUpdateState();
@@ -1158,7 +1055,7 @@ onMounted(async () => {
     checking.value = false;
   });
 
-  unlistenUpdates.push(unTraySignIn, unSignedIn, unAvail, unNone, unChecking, unError);
+  unlistenUpdates.push(unTraySignIn, unAuthChanged, unAvail, unNone, unChecking, unError);
 
   try {
     backend.value = await getBackendSetting();
@@ -1204,37 +1101,18 @@ onUnmounted(() => {
 });
 
 async function handleSignIn(provider: SignInProvider) {
-  signingInWith.value = provider;
-  errorMessage.value = '';
-  try {
-    const result =
-      provider === 'google' ? await auth.googleSignIn() : await auth.microsoftSignIn();
-    if (result.error) {
-      if (result.error !== SIGN_IN_CANCELED_ERROR) {
-        errorMessage.value = result.error;
-      }
-      return;
-    }
-    isSignedIn.value = true;
-    signInPrompt.value = false;
-    await fetchUserProfile();
-    void emitNotificationsSync().catch((err) => {
-      console.warn('Failed to sync notifications after sign-in', err);
-    });
-    if (provider === 'google') {
-      // Sign-in may not carry Calendar — a user who already granted Google
-      // Workspace keeps their broader grant, which might not cover it.
-      await refreshCalendarAccess();
-    } else {
-      // Calendar comes from Google only, and the Connect Calendar nudge opens
-      // Google's consent page. Clear any verdict left by an earlier Google
-      // session in this window so the nudge stays hidden.
-      calendarConnected.value = null;
-    }
-  } catch (error) {
-    errorMessage.value = error instanceof Error ? error.message : 'Sign in failed';
-  } finally {
-    signingInWith.value = null;
+  const result = await signIn(provider);
+  if (result.error) return;
+  signInPrompt.value = false;
+  if (provider === 'google') {
+    // Sign-in may not carry Calendar — a user who already granted Google
+    // Workspace keeps their broader grant, which might not cover it.
+    await refreshCalendarAccess();
+  } else {
+    // Calendar comes from Google only, and the Connect Calendar nudge opens
+    // Google's consent page. Clear any verdict left by an earlier Google
+    // session in this window so the nudge stays hidden.
+    calendarConnected.value = null;
   }
 }
 
@@ -1274,31 +1152,6 @@ async function refreshCalendarAccess() {
   } finally {
     isConnectingCalendar.value = false;
   }
-}
-
-// Abort a pending browser sign-in. The backend resolves the waiting
-// sign-in call with the silent-cancel error, which resets the UI.
-async function handleCancelSignIn() {
-  try {
-    await auth.cancelSignIn();
-  } catch {
-    /* nothing pending — ignore */
-  }
-}
-
-async function handleSignOut() {
-  await auth.signOut();
-  isSignedIn.value = false;
-  displayName.value = '';
-  email.value = '';
-  avatarUrl.value = '';
-  // The Calendar verdict belongs to the session that just ended. The next one
-  // may be a Microsoft sign-in finished in another window, which reaches this
-  // window only through the signed-in refresh, and that keeps the verdict.
-  calendarConnected.value = null;
-  void emitNotificationsSync().catch((err) => {
-    console.warn('Failed to sync notifications after sign-out', err);
-  });
 }
 </script>
 
@@ -1449,52 +1302,6 @@ async function handleSignOut() {
      white card, where #9ca3af managed only 2.5:1 — under the WCAG AA floor. */
   color: #6f6f6f;
   margin: 0;
-}
-
-.sign-in-container {
-  text-align: center;
-}
-
-.google-btn,
-.microsoft-btn {
-  width: 100%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 12px;
-  padding: 10px 16px;
-  background: #ffffff;
-  border: 1px solid #d6d6d6;
-  border-radius: 999px;
-  box-shadow: 2px 2px 0 #e7e5e2;
-  font-size: 14px;
-  font-weight: 500;
-  color: #1c1c1c;
-  cursor: pointer;
-  transition: transform 0.1s, box-shadow 0.1s;
-}
-
-.microsoft-btn {
-  margin-top: 8px;
-}
-
-.google-btn:hover:not(:disabled),
-.microsoft-btn:hover:not(:disabled) {
-  box-shadow: 1px 1px 0 #e7e5e2;
-  transform: translate(1px, 1px);
-}
-
-.google-btn:disabled,
-.microsoft-btn:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-}
-
-.google-icon,
-.microsoft-icon {
-  width: 20px;
-  height: 20px;
-  flex-shrink: 0;
 }
 
 .error {

--- a/src/views/SignInButtons.test.ts
+++ b/src/views/SignInButtons.test.ts
@@ -1,0 +1,39 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import SignInButtons from './SignInButtons.vue';
+
+describe('SignInButtons', () => {
+  it('emits the clicked provider', async () => {
+    const wrapper = mount(SignInButtons, { props: { signingInWith: null } });
+
+    await wrapper.get('.google-btn').trigger('click');
+    await wrapper.get('.microsoft-btn').trigger('click');
+
+    expect(wrapper.emitted('sign-in')).toEqual([['google'], ['microsoft']]);
+    expect(wrapper.find('.sign-in-cancel').exists()).toBe(false);
+    expect(wrapper.find('.sign-in-error').exists()).toBe(false);
+  });
+
+  it('disables both providers while one is pending and offers Cancel', async () => {
+    const wrapper = mount(SignInButtons, { props: { signingInWith: 'microsoft' } });
+
+    expect(wrapper.get('.google-btn').attributes('disabled')).toBeDefined();
+    expect(wrapper.get('.microsoft-btn').attributes('disabled')).toBeDefined();
+    expect(wrapper.get('.microsoft-btn').text()).toContain('Continue in your browser…');
+    expect(wrapper.get('.google-btn').text()).toContain('Sign in with Google');
+
+    await wrapper.get('.sign-in-cancel').trigger('click');
+    expect(wrapper.emitted('cancel')).toHaveLength(1);
+  });
+
+  it('shows the error inline', () => {
+    const wrapper = mount(SignInButtons, {
+      props: { signingInWith: null, errorMessage: 'API returned 500' },
+    });
+
+    const error = wrapper.get('.sign-in-error');
+    expect(error.text()).toBe('API returned 500');
+    expect(error.attributes('role')).toBe('alert');
+  });
+});

--- a/src/views/SignInButtons.vue
+++ b/src/views/SignInButtons.vue
@@ -1,0 +1,135 @@
+<template>
+  <div class="sign-in-buttons">
+    <button
+      ref="googleBtn"
+      type="button"
+      :disabled="pending"
+      class="google-btn"
+      @click="emit('sign-in', 'google')"
+    >
+      <svg class="google-icon" viewBox="0 0 24 24" aria-hidden="true">
+        <path fill="#4285F4" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z" />
+        <path fill="#34A853" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" />
+        <path fill="#FBBC05" d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" />
+        <path fill="#EA4335" d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" />
+      </svg>
+      <span v-if="signingInWith === 'google'">Continue in your browser…</span>
+      <span v-else>Sign in with Google</span>
+    </button>
+    <button
+      type="button"
+      :disabled="pending"
+      class="microsoft-btn"
+      @click="emit('sign-in', 'microsoft')"
+    >
+      <svg class="microsoft-icon" viewBox="0 0 21 21" aria-hidden="true">
+        <path fill="#F25022" d="M0 0h10v10H0z" />
+        <path fill="#7FBA00" d="M11 0h10v10H11z" />
+        <path fill="#00A4EF" d="M0 11h10v10H0z" />
+        <path fill="#FFB900" d="M11 11h10v10H11z" />
+      </svg>
+      <span v-if="signingInWith === 'microsoft'">Continue in your browser…</span>
+      <span v-else>Sign in with Microsoft</span>
+    </button>
+    <button v-if="pending" type="button" class="sign-in-cancel" @click="emit('cancel')">
+      Cancel
+    </button>
+    <p v-if="errorMessage" class="sign-in-error" role="alert">{{ errorMessage }}</p>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue';
+import type { SignInProvider } from '../composables/useAccountState';
+
+// The Google/Microsoft sign-in buttons, with the pending state, Cancel, and the
+// inline error. Shared by the Settings Account card and the Meetings window's
+// sign-in popover so the two can't drift apart.
+const props = defineProps<{
+  signingInWith: SignInProvider | null;
+  errorMessage?: string;
+}>();
+const emit = defineEmits<{
+  'sign-in': [provider: SignInProvider];
+  cancel: [];
+}>();
+
+const pending = computed(() => props.signingInWith !== null);
+
+const googleBtn = ref<HTMLButtonElement | null>(null);
+defineExpose({
+  /** Move focus to the first provider button, e.g. when a popover opens. */
+  focus: () => googleBtn.value?.focus(),
+});
+</script>
+
+<style scoped>
+.sign-in-buttons {
+  text-align: center;
+}
+
+.google-btn,
+.microsoft-btn {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  padding: 10px 16px;
+  background: #ffffff;
+  border: 1px solid #d6d6d6;
+  border-radius: 999px;
+  box-shadow: 2px 2px 0 #e7e5e2;
+  font-family: inherit;
+  font-size: 14px;
+  font-weight: 500;
+  color: #1c1c1c;
+  white-space: nowrap;
+  cursor: pointer;
+  transition: transform 0.1s, box-shadow 0.1s;
+}
+
+.microsoft-btn {
+  margin-top: 8px;
+}
+
+.google-btn:hover:not(:disabled),
+.microsoft-btn:hover:not(:disabled) {
+  box-shadow: 1px 1px 0 #e7e5e2;
+  transform: translate(1px, 1px);
+}
+
+.google-btn:disabled,
+.microsoft-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.google-icon,
+.microsoft-icon {
+  width: 20px;
+  height: 20px;
+  flex-shrink: 0;
+}
+
+.sign-in-cancel {
+  margin-top: 8px;
+  font-family: inherit;
+  font-size: 13px;
+  color: #f87171;
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-weight: 500;
+}
+
+.sign-in-cancel:hover {
+  text-decoration: underline;
+}
+
+.sign-in-error {
+  margin: 8px 0 0;
+  font-size: 12px;
+  color: #f87171;
+}
+</style>


### PR DESCRIPTION
## What does this PR do?

Implements the part 3 spec from #381 (`docs/superpowers/specs/2026-09-10-meetings-backend-indicator-design.md`) for #370.

**Stacked on #385. Merge that first.** Microsoft sign-in (#382, on main) and the tray sign-in rows (#385) are not part of this PR.

### Meetings titlebar pill (`LibraryView.vue`)
The pill sits after Start recording. Its states:

| State | Shows | Click |
| --- | --- | --- |
| backend not loaded yet | nothing | — |
| Local | static badge with a lock and "Local" | none (a `<span>`) |
| Ariso, first check pending | "Ariso", not clickable | — |
| Ariso, signed in | avatar or initials, "Ariso", email as tooltip | opens Settings |
| Ariso, signed out | "Sign in" | opens a Google/Microsoft popover |

- The popover shows the same busy label, Cancel, and inline error as Settings.
- It closes on Escape (focus returns to the pill), on an outside click unless a flow is pending, and once a session exists.
- Switching to Local hides the popover, cancels this window's pending flow, and resets the account state.
- **Local mode makes no `check_session` or profile request from this window, including on `auth://changed`.** A test covers this, and a mutation check confirmed it fails without the guard.

### Cross-window sync from Rust (`commands.rs`)
- The session hook from #385 (`on_session_changed`) now also emits a payload-free `auth://changed`.
- `auth://changed` replaces the frontend-emitted `auth://signed-in`. Onboarding no longer emits it by hand.
- Settings now also follows sign-outs and natively cleared sessions.

### `useAccountState` composable
- Account state, profile, and avatar loading moved here out of `SettingsView`.
- Concurrent `refresh()` calls share one request, so a window's own sign-in and the broadcast it triggers fetch `/auth/me` once.
- A sign-out or reset discards a refresh that was already in flight.
- A sign-in that completes after the window switched to Local doesn't refresh.

### `SignInButtons.vue`
The provider buttons, Cancel, and error now live in one component, used by the Settings Account card and the popover.

### Window-aware sign-in attempts (§5)
Most of §5 already shipped in #382: attempts record their window, and a superseded window gets its silent cancel. The remaining piece is here: **`cancel_sign_in` now only cancels an attempt the calling window started.**

### Deviations from the spec
- **Tooltip copy:** the Local tooltip says "this device" instead of "this Mac", because the Local backend also ships on Windows.
- **Narrow windows:** the spec says the pill collapses "where `.add-btn-label` collapses", but that label never collapses. Below 520px the pill label is visually hidden instead: it stays readable to assistive tech, and the `title` tooltip stays.
- **No Calendar hop from the popover**, as the spec says. The follow-up hop stays in Settings and Onboarding. As a result, a Google user whose existing grant lacks Calendar and who signs in from the popover isn't sent through the connect hop. Settings still offers Connect Calendar once the grant has been checked there.

## Type of change

- [x] `feat:` — new feature

## How was this tested?

- `npm test`: 942 passed. New tests:
  - `useAccountState.test.ts` (15)
  - `SignInButtons.test.ts` (3)
  - `LibraryView` backend indicator (14)
  - `SettingsView` auth broadcast (3)
- `cargo test -- --test-threads=1`: 355 passed. New tests cover a stale cancel from another window leaving the attempt running, and the owner's cancel aborting it.
- `npm run vite:build` succeeds.
- **Not yet verified in the running app.** The `oats-desktop` MCP server was unavailable in this session, so the spec's manual checks still need a pass on the Ariso backend:
  - [ ] Sign out in Settings with Meetings open: the pill flips to "Sign in".
  - [ ] Sign in with Google from the popover, then repeat with Microsoft.
  - [ ] Start a sign-in in Settings, then one from the popover: Settings resets to idle.
  - [ ] Switch to Local: the pill turns into a static badge, and devtools shows no network requests from Meetings.

## Checklist

- [x] My commit messages follow Conventional Commits
- [x] I ran `npm test` and the suite passes
- [ ] I tested the change in the app (see above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added accessible Google and Microsoft sign-in controls with progress, cancellation, and inline errors.
  - Added account indicators for Local, signed-in, signed-out, and loading states.
  - Added automatic account and backend updates across windows.

- **Bug Fixes**
  - Improved account refresh reliability after sign-in, sign-out, rejected sessions, and mode changes.
  - Restricted sign-in and calendar-flow cancellation to the window that started the flow.
  - Prevented stale account data from replacing newer results.

- **Tests**
  - Expanded coverage for account state, authentication flows, cross-window updates, cancellation, errors, and account indicators.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->