### PR TITLE
feat: Microphone gates meeting detection; auto-record sets the prompt's default

### DIFF
--- a/src-tauri/src/meeting_notifications.rs
+++ b/src-tauri/src/meeting_notifications.rs
@@ -546,7 +546,8 @@ fn open_prep_from_notification(app: &AppHandle, prep_id: i64) {
 // notes / Dismiss with a countdown bar), which reports the user's choice back
 // through the `resolve_meeting_prompt` command into the `oneshot` below. The
 // user has 10 seconds to choose; if they don't, the caller's mode default
-// applies (record when auto-record is on, skip when it's off). The
+// applies (record when auto-record is on, skip when it's off). The default is
+// also the window's primary button: Take notes when on, Dismiss when off. The
 // UNUserNotificationCenter delegate in `macos_un` no longer carries the
 // auto-record decision — it now handles only meeting-prep deep-link clicks and
 // the silence-stop prompt's Keep / Stop buttons.
@@ -572,13 +573,18 @@ const MEETING_PROMPT_H_EXPANDED: f64 = 102.0;
 /// The route the meeting-start notification window loads. `seconds` drives the
 /// countdown bar so it always matches `AUTO_RECORD_PROMPT_TIMEOUT`; `subtitle`,
 /// when present, shows the live meeting's title (the view falls back to its own
-/// default subtitle when it's absent). Values are URL-encoded so titles with
+/// default subtitle when it's absent). `default_record` is what the timeout
+/// does: when false (auto-record off) `default=dismiss` makes the view lead with
+/// Dismiss instead of Take notes. Values are URL-encoded so titles with
 /// spaces/`&`/`#` survive the hash route.
-fn meeting_prompt_url(seconds: u64, subtitle: Option<&str>) -> String {
+fn meeting_prompt_url(seconds: u64, subtitle: Option<&str>, default_record: bool) -> String {
     let mut ser = url::form_urlencoded::Serializer::new(String::new());
     ser.append_pair("seconds", &seconds.to_string());
     if let Some(s) = subtitle.filter(|s| !s.is_empty()) {
         ser.append_pair("subtitle", s);
+    }
+    if !default_record {
+        ser.append_pair("default", "dismiss");
     }
     format!("/#/meeting-prompt?{}", ser.finish())
 }
@@ -586,7 +592,11 @@ fn meeting_prompt_url(seconds: u64, subtitle: Option<&str>) -> String {
 /// Build (or focus) the borderless top-right notification window. Mirrors the
 /// waveform pill: no decorations, transparent, always-on-top, never focused so
 /// it can't interrupt the live meeting. Must run on the main thread.
-fn open_meeting_prompt_window(app: &AppHandle, subtitle: Option<&str>) -> Result<(), String> {
+fn open_meeting_prompt_window(
+    app: &AppHandle,
+    subtitle: Option<&str>,
+    default_record: bool,
+) -> Result<(), String> {
     use tauri::{WebviewUrl, WebviewWindowBuilder};
 
     // Only one prompt is live per meeting; replace any stale window.
@@ -597,7 +607,7 @@ fn open_meeting_prompt_window(app: &AppHandle, subtitle: Option<&str>) -> Result
     let win = WebviewWindowBuilder::new(
         app,
         "meeting-prompt",
-        WebviewUrl::App(meeting_prompt_url(seconds, subtitle).into()),
+        WebviewUrl::App(meeting_prompt_url(seconds, subtitle, default_record).into()),
     )
     .title("")
     .inner_size(MEETING_PROMPT_W, MEETING_PROMPT_H)
@@ -826,7 +836,7 @@ pub async fn prompt_auto_record(app: &AppHandle, default_record: bool) -> bool {
     let subtitle = current_meeting_title(app).await;
     let (tx, rx) = oneshot::channel();
     *prompt_slot().lock().unwrap() = Some(tx);
-    show_auto_record_prompt(app, subtitle);
+    show_auto_record_prompt(app, subtitle, default_record);
     let record = match tokio::time::timeout(AUTO_RECORD_PROMPT_TIMEOUT, rx).await {
         Ok(Ok(record)) => record,
         // Timed out, or the sender was dropped/replaced — apply the mode
@@ -844,10 +854,11 @@ pub async fn prompt_auto_record(app: &AppHandle, default_record: bool) -> bool {
 
 /// Open the meeting-start notification window. Window creation must happen on
 /// the main thread (like `open_waveform_window`), so dispatch there.
-fn show_auto_record_prompt(app: &AppHandle, subtitle: Option<String>) {
+fn show_auto_record_prompt(app: &AppHandle, subtitle: Option<String>, default_record: bool) {
     let app_main = app.clone();
     let _ = app.run_on_main_thread(move || {
-        if let Err(e) = open_meeting_prompt_window(&app_main, subtitle.as_deref()) {
+        if let Err(e) = open_meeting_prompt_window(&app_main, subtitle.as_deref(), default_record)
+        {
             eprintln!("meeting-prompt: failed to open notification window: {e}");
         }
     });
@@ -1374,23 +1385,37 @@ mod tests {
 
     #[test]
     fn meeting_prompt_url_carries_the_timeout_seconds() {
-        assert_eq!(super::meeting_prompt_url(10, None), "/#/meeting-prompt?seconds=10");
-        assert_eq!(super::meeting_prompt_url(7, None), "/#/meeting-prompt?seconds=7");
+        assert_eq!(super::meeting_prompt_url(10, None, true), "/#/meeting-prompt?seconds=10");
+        assert_eq!(super::meeting_prompt_url(7, None, true), "/#/meeting-prompt?seconds=7");
     }
 
     #[test]
     fn meeting_prompt_url_encodes_the_subtitle() {
         assert_eq!(
-            super::meeting_prompt_url(10, Some("Standup")),
+            super::meeting_prompt_url(10, Some("Standup"), true),
             "/#/meeting-prompt?seconds=10&subtitle=Standup"
         );
         // Spaces and reserved chars must survive the hash route.
         assert_eq!(
-            super::meeting_prompt_url(10, Some("Q3 Plan & Review")),
+            super::meeting_prompt_url(10, Some("Q3 Plan & Review"), true),
             "/#/meeting-prompt?seconds=10&subtitle=Q3+Plan+%26+Review"
         );
         // Empty subtitle is omitted entirely.
-        assert_eq!(super::meeting_prompt_url(10, Some("")), "/#/meeting-prompt?seconds=10");
+        assert_eq!(super::meeting_prompt_url(10, Some(""), true), "/#/meeting-prompt?seconds=10");
+    }
+
+    #[test]
+    fn meeting_prompt_url_marks_dismiss_as_the_default_when_auto_record_is_off() {
+        // Auto-record off: the countdown ends in a no-op, so the view leads with
+        // Dismiss. On (the default) adds nothing, keeping Take notes primary.
+        assert_eq!(
+            super::meeting_prompt_url(10, None, false),
+            "/#/meeting-prompt?seconds=10&default=dismiss"
+        );
+        assert_eq!(
+            super::meeting_prompt_url(10, Some("Standup"), false),
+            "/#/meeting-prompt?seconds=10&subtitle=Standup&default=dismiss"
+        );
     }
 
     #[test]

--- a/src-tauri/src/mic_monitor.rs
+++ b/src-tauri/src/mic_monitor.rs
@@ -418,8 +418,12 @@ async fn run_loop(app: AppHandle) {
                             crate::meeting_notifications::prompt_auto_record(&app2, default_record)
                                 .await;
                         // A manual recording may have started during the prompt;
-                        // don't stack a second recorder on top of it.
+                        // don't stack a second recorder on top of it. Also bail if
+                        // Settings → Microphone was disabled while the prompt was
+                        // showing — this detached task outlives run_loop, which is
+                        // what `sync` aborts on toggle-off.
                         if record
+                            && monitor_desired(is_supported(), mic_setting(&app2).as_ref())
                             && !app2
                                 .state::<crate::recording_state::RecordingState>()
                                 .is_active()

--- a/src-tauri/src/mic_monitor.rs
+++ b/src-tauri/src/mic_monitor.rs
@@ -178,6 +178,19 @@ mod tests {
     }
 
     #[test]
+    fn monitor_runs_only_when_supported_and_the_microphone_is_enabled() {
+        use serde_json::Value;
+        // Mic on (explicitly, or the unset first-run default) → detect.
+        assert!(monitor_desired(true, Some(&Value::Bool(true))));
+        assert!(monitor_desired(true, None));
+        // Mic toggled off in Settings → no detection, so no prompt.
+        assert!(!monitor_desired(true, Some(&Value::Bool(false))));
+        // Unsupported OS never runs, whatever the setting.
+        assert!(!monitor_desired(false, Some(&Value::Bool(true))));
+        assert!(!monitor_desired(false, None));
+    }
+
+    #[test]
     fn brief_blip_does_not_start() {
         let mut m = Machine::new();
         assert_eq!(m.tick(0, &pids(&[42]), false), None); // -> Arming
@@ -280,6 +293,8 @@ pub fn is_supported() -> bool {
 const POLL_INTERVAL: Duration = Duration::from_secs(1);
 const SETTINGS_PATH: &str = "settings.json";
 const ENABLED_KEY: &str = "autoRecordEnabled";
+/// Settings → Microphone. Shared with the frontend's recording-source toggles.
+const MIC_KEY: &str = "recordMicEnabled";
 
 /// Holds the running monitor task (if any) plus a re-arm request flag. The flag
 /// is set by `request_mic_monitor_rearm` and consumed by `run_loop` to reset the
@@ -298,11 +313,11 @@ impl MicMonitorManager {
     }
 }
 
-/// Whether auto-record is enabled (defaults to true). The monitor now runs
-/// regardless — on detection it always prompts — so this only decides the
-/// no-response default: enabled → start recording when the prompt times out;
-/// disabled → skip. Read fresh per detection so a settings toggle takes effect
-/// without restarting the monitor.
+/// Whether auto-record is enabled (defaults to true). It doesn't gate the
+/// monitor — on detection it always prompts — so this only decides the
+/// no-response default (and the prompt's primary button): enabled → start
+/// recording when the prompt times out; disabled → skip. Read fresh per
+/// detection so a settings toggle takes effect without restarting the monitor.
 fn enabled(app: &AppHandle) -> bool {
     use tauri_plugin_store::StoreExt;
     match app.store(SETTINGS_PATH) {
@@ -311,12 +326,26 @@ fn enabled(app: &AppHandle) -> bool {
     }
 }
 
-/// Start the monitor if the OS supports per-process input detection; otherwise
-/// stop it. The enabled setting no longer gates the monitor (it only sets the
-/// prompt's timeout default), so the prompt fires in both modes. Safe to call
-/// repeatedly (startup, settings toggle).
+/// Whether the monitor should run: the OS must support per-process input
+/// detection and Settings → Microphone must be on. An unset value counts as on,
+/// matching the frontend's first-run default. Pure so it's unit-tested.
+fn monitor_desired(supported: bool, mic_setting: Option<&serde_json::Value>) -> bool {
+    supported && !matches!(mic_setting, Some(serde_json::Value::Bool(false)))
+}
+
+/// The raw Settings → Microphone value, or `None` if unset / the store is
+/// unreadable (both treated as on).
+fn mic_setting(app: &AppHandle) -> Option<serde_json::Value> {
+    use tauri_plugin_store::StoreExt;
+    app.store(SETTINGS_PATH).ok().and_then(|store| store.get(MIC_KEY))
+}
+
+/// Start the monitor when `monitor_desired` holds; otherwise stop it. The
+/// Microphone toggle gates detection (mic off → no prompt); the auto-record
+/// setting only sets the prompt's timeout default. Safe to call repeatedly
+/// (startup, settings toggle).
 pub async fn sync(app: &AppHandle) {
-    let desired = is_supported();
+    let desired = monitor_desired(is_supported(), mic_setting(app).as_ref());
     let mgr = app.state::<MicMonitorManager>();
     let mut guard = mgr.handle.lock().unwrap();
     if !desired {

--- a/src/composables/useRecordingPermissions.test.ts
+++ b/src/composables/useRecordingPermissions.test.ts
@@ -6,6 +6,7 @@ const mocks = vi.hoisted(() => ({
   loadPlatformCapabilities: vi.fn(),
   requestMicrophonePermission: vi.fn(),
   checkMicrophonePermission: vi.fn(),
+  emit: vi.fn(),
 }));
 
 vi.mock('@tauri-apps/plugin-store', () => ({
@@ -15,6 +16,9 @@ vi.mock('@tauri-apps/plugin-store', () => ({
   }),
 }));
 vi.mock('@tauri-apps/plugin-opener', () => ({ openUrl: vi.fn() }));
+vi.mock('@tauri-apps/api/event', () => ({
+  emit: (...a: unknown[]) => mocks.emit(...a),
+}));
 vi.mock('./usePlatformCapabilities', () => ({
   loadPlatformCapabilities: () => mocks.loadPlatformCapabilities(),
 }));
@@ -27,7 +31,9 @@ import {
   checkMicPermission,
   ensureMicPermission,
   loadRecordingEnabled,
+  setMicEnabled,
 } from './useRecordingPermissions';
+import { AUTO_RECORD_SYNC_EVENT } from './useAutoRecord';
 
 beforeEach(() => {
   mocks.values.clear();
@@ -38,6 +44,7 @@ beforeEach(() => {
   mocks.loadPlatformCapabilities.mockReset();
   mocks.requestMicrophonePermission.mockReset();
   mocks.checkMicrophonePermission.mockReset();
+  mocks.emit.mockReset();
 });
 
 describe('microphone permissions', () => {
@@ -72,6 +79,25 @@ describe('microphone permissions', () => {
     expect(stop).toHaveBeenCalledOnce();
     expect(query).toHaveBeenCalledWith({ name: 'microphone' });
     expect(mocks.requestMicrophonePermission).not.toHaveBeenCalled();
+  });
+});
+
+describe('setMicEnabled', () => {
+  it('persists the flag and then syncs the mic monitor so detection follows it', async () => {
+    const order: string[] = [];
+    mocks.set.mockImplementation(async (key: string, value: unknown) => {
+      mocks.values.set(key, value);
+      order.push('set');
+    });
+    mocks.emit.mockImplementation(async () => {
+      order.push('emit');
+    });
+
+    await setMicEnabled(false);
+
+    expect(mocks.set).toHaveBeenCalledWith('recordMicEnabled', false);
+    expect(mocks.emit).toHaveBeenCalledWith(AUTO_RECORD_SYNC_EVENT);
+    expect(order).toEqual(['set', 'emit']);
   });
 });
 

--- a/src/composables/useRecordingPermissions.ts
+++ b/src/composables/useRecordingPermissions.ts
@@ -1,11 +1,13 @@
 import { invoke } from '@tauri-apps/api/core';
 import { openUrl } from '@tauri-apps/plugin-opener';
 import { load } from '@tauri-apps/plugin-store';
+import { emit } from '@tauri-apps/api/event';
 import {
   deriveEnabledFromLegacy,
   type RecordingEnabled,
 } from '../views/recordingSettings';
 import { loadPlatformCapabilities } from './usePlatformCapabilities';
+import { AUTO_RECORD_SYNC_EVENT } from './useAutoRecord';
 import {
   requestMicrophonePermission,
   checkMicrophonePermission,
@@ -60,9 +62,12 @@ export async function loadRecordingEnabled(): Promise<RecordingEnabled> {
   return persisted;
 }
 
+/** Persist the mic flag, then sync the native mic monitor: meeting detection
+ *  (the "Meeting started" prompt) only runs while the microphone is enabled. */
 export async function setMicEnabled(enabled: boolean): Promise<void> {
   const store = await load(SETTINGS_PATH, { autoSave: true });
   await store.set(MIC_KEY, enabled);
+  await emit(AUTO_RECORD_SYNC_EVENT);
 }
 
 export async function setSystemAudioEnabled(enabled: boolean): Promise<void> {

--- a/src/views/MeetingPromptView.test.ts
+++ b/src/views/MeetingPromptView.test.ts
@@ -51,28 +51,55 @@ describe('MeetingPromptView', () => {
 
   it('toggles the more-options menu and grows/shrinks the window', async () => {
     const wrapper = mount(MeetingPromptView);
-    expect(wrapper.find('[data-test="menu-dismiss"]').exists()).toBe(false);
+    expect(wrapper.find('[data-test="menu-item"]').exists()).toBe(false);
 
     await wrapper.find('[data-test="more-options"]').trigger('click');
     expect(invoke).toHaveBeenCalledWith('resize_meeting_prompt', { expanded: true });
-    expect(wrapper.find('[data-test="menu-dismiss"]').exists()).toBe(true);
+    expect(wrapper.find('[data-test="menu-item"]').exists()).toBe(true);
 
     await wrapper.find('[data-test="more-options"]').trigger('click');
     expect(invoke).toHaveBeenCalledWith('resize_meeting_prompt', { expanded: false });
-    expect(wrapper.find('[data-test="menu-dismiss"]').exists()).toBe(false);
+    expect(wrapper.find('[data-test="menu-item"]').exists()).toBe(false);
   });
 
   it('resolves with record=false from the menu Dismiss item', async () => {
     const wrapper = mount(MeetingPromptView);
     await wrapper.find('[data-test="more-options"]').trigger('click');
-    await wrapper.find('[data-test="menu-dismiss"]').trigger('click');
+    await wrapper.find('[data-test="menu-item"]').trigger('click');
     expect(invoke).toHaveBeenCalledWith('resolve_meeting_prompt', { record: false });
+  });
+
+  it('makes Take notes the primary action by default (auto-record on)', () => {
+    const wrapper = mount(MeetingPromptView);
+    expect(wrapper.find('.split-main').text()).toBe('Take notes');
   });
 
   it('labels the menu item Dismiss in start mode', async () => {
     const wrapper = mount(MeetingPromptView);
     await wrapper.find('[data-test="more-options"]').trigger('click');
-    expect(wrapper.find('[data-test="menu-dismiss"]').text()).toBe('Dismiss');
+    expect(wrapper.find('[data-test="menu-item"]').text()).toBe('Dismiss');
+  });
+});
+
+describe('MeetingPromptView with auto-record off (default=dismiss)', () => {
+  beforeEach(() => {
+    window.location.hash = '#/meeting-prompt?seconds=10&default=dismiss';
+  });
+
+  it('makes Dismiss the primary action', async () => {
+    const wrapper = mount(MeetingPromptView);
+    expect(wrapper.find('.split-main').text()).toBe('Dismiss');
+    await wrapper.find('.split-main').trigger('click');
+    expect(invoke).toHaveBeenCalledWith('resolve_meeting_prompt', { record: false });
+  });
+
+  it('offers Take notes behind the chevron', async () => {
+    const wrapper = mount(MeetingPromptView);
+    await wrapper.find('[data-test="more-options"]').trigger('click');
+    const item = wrapper.find('[data-test="menu-item"]');
+    expect(item.text()).toBe('Take notes');
+    await item.trigger('click');
+    expect(invoke).toHaveBeenCalledWith('resolve_meeting_prompt', { record: true });
   });
 });
 
@@ -103,7 +130,7 @@ describe('MeetingPromptView switch mode', () => {
     const wrapper = mount(MeetingPromptView);
     await wrapper.find('[data-test="more-options"]').trigger('click');
     expect(invoke).toHaveBeenCalledWith('resize_meeting_switch_prompt', { expanded: true });
-    const keep = wrapper.find('[data-test="menu-dismiss"]');
+    const keep = wrapper.find('[data-test="menu-item"]');
     expect(keep.text()).toBe('Keep recording');
     await keep.trigger('click');
     expect(invoke).toHaveBeenCalledWith('resolve_meeting_switch_prompt', { switch: false });

--- a/src/views/MeetingPromptView.vue
+++ b/src/views/MeetingPromptView.vue
@@ -11,16 +11,21 @@ import oatsLogo from '../assets/oats-light.svg';
 const search = window.location.hash.includes('?')
   ? window.location.hash.slice(window.location.hash.indexOf('?'))
   : '';
-const { seconds, title, subtitle, mode } = parsePromptParams(search);
+const { seconds, title, subtitle, mode, defaultAction } = parsePromptParams(search);
 // Switch mode = the next calendar meeting started while we were already
 // recording: same card, but the choice is "switch to it" vs "keep recording",
 // and it is resolved by the recorder window's own prompt window/commands.
 const isSwitch = mode === 'switch';
+// With auto-record off the countdown ends in a no-op, so the primary button is
+// Dismiss and Take notes moves behind the chevron. Switch mode never swaps.
+const dismissFirst = !isSwitch && defaultAction === 'dismiss';
+const primaryLabel = dismissFirst ? 'Dismiss' : 'Take notes';
+const menuLabel = isSwitch ? 'Keep recording' : dismissFirst ? 'Take notes' : 'Dismiss';
 
-// Whether the "more options" menu below the Take notes button is open. Rust
+// Whether the "more options" menu below the primary button is open. Rust
 // grows the (fixed-size, overflow-hidden) window so the menu has room to show.
 const menuOpen = ref(false);
-// The split button, measured so the Dismiss button can match its width.
+// The split button, measured so the menu item can match its width.
 const splitEl = ref<HTMLElement | null>(null);
 const menuWidth = ref('auto');
 
@@ -77,9 +82,11 @@ async function resolve(yes: boolean) {
           <div v-if="subtitle" data-test="subtitle" class="subtitle">{{ subtitle }}</div>
         </div>
 
-        <!-- Split button: Take notes + a chevron that reveals more options. -->
+        <!-- Split button: the default action + a chevron that reveals the other. -->
         <div ref="splitEl" class="split">
-          <button class="primary-btn split-main" @click="resolve(true)">Take notes</button>
+          <button class="primary-btn split-main" @click="resolve(!dismissFirst)">
+            {{ primaryLabel }}
+          </button>
           <button
             data-test="more-options"
             class="primary-btn split-chevron"
@@ -96,16 +103,16 @@ async function resolve(yes: boolean) {
       </div>
     </div>
 
-    <!-- Dismiss, revealed under the Take notes button by the chevron. Same
-         shape/size as Take notes, secondary styling. -->
+    <!-- The non-default action, revealed under the primary button by the
+         chevron. Same shape/size as the primary, secondary styling. -->
     <button
       v-if="menuOpen"
-      data-test="menu-dismiss"
+      data-test="menu-item"
       class="secondary-btn"
       :style="{ width: menuWidth }"
-      @click="resolve(false)"
+      @click="resolve(dismissFirst)"
     >
-      {{ isSwitch ? 'Keep recording' : 'Dismiss' }}
+      {{ menuLabel }}
     </button>
   </div>
 </template>

--- a/src/views/SettingsView.test.ts
+++ b/src/views/SettingsView.test.ts
@@ -86,11 +86,13 @@ vi.mock('../tauri', () => ({
     downloadLlm: () => downloadLlm(),
   },
 }));
+const loadRecordingEnabled = vi.fn(() => Promise.resolve({ mic: false, systemAudio: false }));
+const ensureMicPermission = vi.fn(() => Promise.resolve(true));
 vi.mock('../composables/useRecordingPermissions', () => ({
-  loadRecordingEnabled: () => Promise.resolve({ mic: false, systemAudio: false }),
+  loadRecordingEnabled: () => loadRecordingEnabled(),
   setMicEnabled: vi.fn(),
   setSystemAudioEnabled: vi.fn(),
-  ensureMicPermission: vi.fn(),
+  ensureMicPermission: () => ensureMicPermission(),
   ensureSystemAudioPermission: vi.fn(),
   checkSystemAudioPermission: vi.fn(() => Promise.resolve(true)),
   openMicSettings: vi.fn(),
@@ -172,6 +174,8 @@ beforeEach(() => {
     checkSession.mockResolvedValue(null);
     return Promise.resolve();
   });
+  loadRecordingEnabled.mockResolvedValue({ mic: false, systemAudio: false });
+  ensureMicPermission.mockResolvedValue(true);
 });
 
 function storeSession(): Promise<SignInResult> {
@@ -1070,5 +1074,47 @@ describe('SettingsView meeting stop reminder toggle', () => {
     await input.trigger('change');
     await flushPromises();
     expect(setMeetingEndReminderEnabled).toHaveBeenCalledWith(false);
+  });
+});
+
+describe('SettingsView auto-record depends on the microphone', () => {
+  function autoRecordToggle(wrapper: ReturnType<typeof mount>) {
+    const row = wrapper
+      .findAll('.setting-row')
+      .find((r) => r.find('.setting-label').text() === 'Auto-record meetings');
+    expect(row, 'Auto-record meetings row').toBeDefined();
+    return row!.find('input.toggle-input');
+  }
+
+  function micToggle(wrapper: ReturnType<typeof mount>) {
+    const row = wrapper
+      .findAll('.setting-row')
+      .find((r) => r.find('.setting-label').text() === 'Microphone');
+    return row!.find('input.toggle-input');
+  }
+
+  it('disables auto-record with a hint while the microphone is off', async () => {
+    const wrapper = mount(SettingsView);
+    await flushPromises();
+    expect(autoRecordToggle(wrapper).attributes('disabled')).toBeDefined();
+    expect(wrapper.text()).toContain('Turn on Microphone to detect meetings.');
+  });
+
+  it('enables auto-record when the microphone is on', async () => {
+    loadRecordingEnabled.mockResolvedValue({ mic: true, systemAudio: false });
+    const wrapper = mount(SettingsView);
+    await flushPromises();
+    expect(autoRecordToggle(wrapper).attributes('disabled')).toBeUndefined();
+    expect(wrapper.text()).not.toContain('Turn on Microphone to detect meetings.');
+  });
+
+  it('re-enables auto-record as soon as the microphone is toggled on', async () => {
+    const wrapper = mount(SettingsView);
+    await flushPromises();
+    const mic = micToggle(wrapper);
+    (mic.element as HTMLInputElement).checked = true;
+    await mic.trigger('change');
+    await flushPromises();
+    expect(autoRecordToggle(wrapper).attributes('disabled')).toBeUndefined();
   });
 });

--- a/src/views/SettingsView.vue
+++ b/src/views/SettingsView.vue
@@ -280,7 +280,7 @@
               type="checkbox"
               class="toggle-input"
               :checked="autoRecordEnabled"
-              :disabled="!autoRecordSupported"
+              :disabled="!autoRecordSupported || !micEnabled"
               @change="onToggleAutoRecord"
             />
             <span class="toggle-track">
@@ -290,6 +290,11 @@
         </div>
         <p v-if="!autoRecordSupported" class="notif-status notif-status--err">
           Auto-record is not available on this platform.
+        </p>
+        <!-- Meeting detection (the prompt this setting configures) only runs
+             while the microphone is enabled. -->
+        <p v-else-if="!micEnabled" class="setting-hint">
+          Turn on Microphone to detect meetings.
         </p>
 
         <div class="setting-row" style="margin-top: 16px">
@@ -1650,6 +1655,15 @@ async function refreshCalendarAccess() {
 .toggle-input:focus-visible + .toggle-track {
   outline: 2px solid #1c1c1c;
   outline-offset: 2px;
+}
+
+/* Greyed out when unavailable (e.g. Auto-record while Microphone is off). */
+.toggle:has(.toggle-input:disabled) {
+  cursor: not-allowed;
+}
+
+.toggle-input:disabled + .toggle-track {
+  opacity: 0.5;
 }
 
 .download-confirm {

--- a/src/views/meetingPromptParams.test.ts
+++ b/src/views/meetingPromptParams.test.ts
@@ -8,6 +8,7 @@ describe('parsePromptParams', () => {
       title: 'Meeting started',
       subtitle: 'oats can take notes for you.',
       mode: 'start',
+      defaultAction: 'record',
     });
   });
 
@@ -37,6 +38,7 @@ describe('parsePromptParams mode', () => {
       title: 'Meeting started',
       subtitle: 'oats can take notes for you.',
       mode: 'start',
+      defaultAction: 'record',
     });
   });
 
@@ -46,6 +48,7 @@ describe('parsePromptParams mode', () => {
       title: 'Meeting started',
       subtitle: '',
       mode: 'switch',
+      defaultAction: 'record',
     });
   });
 
@@ -55,11 +58,23 @@ describe('parsePromptParams mode', () => {
       title: 'Meeting started',
       subtitle: 'Weekly sync',
       mode: 'switch',
+      defaultAction: 'record',
     });
   });
 
   it('treats an unknown mode as start', () => {
     expect(parsePromptParams('?mode=bogus').mode).toBe('start');
+  });
+});
+
+describe('parsePromptParams defaultAction', () => {
+  it('defaults to record when the query does not say otherwise', () => {
+    expect(parsePromptParams('?seconds=10').defaultAction).toBe('record');
+    expect(parsePromptParams('?default=bogus').defaultAction).toBe('record');
+  });
+
+  it('reads default=dismiss (auto-record off)', () => {
+    expect(parsePromptParams('?seconds=10&default=dismiss').defaultAction).toBe('dismiss');
   });
 });
 

--- a/src/views/meetingPromptParams.ts
+++ b/src/views/meetingPromptParams.ts
@@ -2,11 +2,16 @@
  *  (`start`), or the next calendar meeting started mid-recording (`switch`). */
 export type PromptMode = 'start' | 'switch';
 
+/** What happens if the countdown runs out with no answer, which also decides the
+ *  primary button: `record` (auto-record on) or `dismiss` (auto-record off). */
+export type PromptDefaultAction = 'record' | 'dismiss';
+
 export interface PromptParams {
   seconds: number;
   title: string;
   subtitle: string;
   mode: PromptMode;
+  defaultAction: PromptDefaultAction;
 }
 
 /** Both modes show the same heading; only Rust's countdown and the subtitle
@@ -28,6 +33,7 @@ export function parsePromptParams(search: string): PromptParams {
     title: params.get('title') || DEFAULT_TITLE,
     subtitle: params.get('subtitle') || (mode === 'switch' ? '' : START_DEFAULT_SUBTITLE),
     mode,
+    defaultAction: params.get('default') === 'dismiss' ? 'dismiss' : 'record',
   };
 }
 


### PR DESCRIPTION
## What does this PR do?

Changes how two Recording settings work: **Microphone** now turns meeting detection on and off, and **Auto-record meetings** now sets which button the "Meeting started" prompt leads with.

### 1. Microphone turns meeting detection on and off
Until now the mic monitor ran whenever the OS supported it, whatever the settings said.

- **`mic_monitor.rs`:** `sync()` runs the monitor only while `recordMicEnabled` isn't `false`. If the value was never set it counts as on, the same default the frontend uses on first run. So Microphone off means no prompt at all.
- **`useRecordingPermissions.ts`:** `setMicEnabled` now emits `auto-record-sync`, so the monitor starts or stops right away without a restart.
- **`SettingsView.vue`:** "Auto-record meetings" is greyed out while the mic is off, with the hint *"Turn on Microphone to detect meetings."* Its saved value is kept.
- Settings switches had no disabled styling before, so a disabled switch looked the same as an enabled one. Disabled switches now show at half opacity with a not-allowed cursor.

### 2. Auto-record sets the prompt's default button
Auto-record already decided what happens when the countdown ends (record, or nothing). The prompt now shows that choice.

| Auto-record | Primary button | Behind the chevron | When the countdown ends |
| --- | --- | --- | --- |
| On (default) | Take notes | Dismiss | starts recording (**unchanged**) |
| Off | **Dismiss** | **Take notes** | nothing happens |

- **`meeting_notifications.rs`:** adds `default=dismiss` to the prompt URL when auto-record is off. With it on, the URL is unchanged.
- **`meetingPromptParams.ts` / `MeetingPromptView.vue`:** read the new `defaultAction` and swap the split button when it's `dismiss`. The mid-recording switch prompt never swaps.
- The menu item's `data-test` is renamed from `menu-dismiss` to `menu-item`, since it can now hold Take notes.

### Known edge case
An auto-started recording also stops when the meeting app releases the mic, and that signal comes from the mic monitor. If the user turns Microphone off during such a recording, that automatic stop won't fire. Silence detection and the meeting-end reminder still apply. The recording itself keeps the capture mode it started with.

## Type of change

- [ ] `fix:` — bug fix
- [x] `feat:` — new feature
- [ ] `feat!:` / `BREAKING CHANGE:` — breaking change
- [ ] `docs:` / `chore:` / `refactor:` — no user-facing release

## How was this tested?

- **Frontend (`npm test`):** 997 passing. New tests cover parsing `default=dismiss`, the swapped buttons, `setMicEnabled` emitting the sync after it saves, and Settings greying out auto-record while the mic is off and re-enabling it when the mic is turned on.
- **Rust (`cargo test -- --test-threads=1`):** 375 passing. New tests cover `meeting_prompt_url` with `default=dismiss` and `monitor_desired` (whether the OS is supported × the mic setting).
- **In the app:** `tauri:dev:debug` on the Ariso backend, macOS on Apple Silicon, driven through the `oats-desktop` MCP server. ffmpeg held the built-in mic to trigger real detection:
  - Microphone off: no prompt appeared (ffmpeg held the mic the whole time).
  - Microphone on, auto-record off: the prompt URL had `default=dismiss` and Dismiss was the main button. The countdown ended and no recorder opened.
  - Microphone on, auto-record on: Take notes was the main button and Dismiss was in the chevron menu. Clicking Dismiss meant nothing recorded.

## Screenshots / recordings

None attached yet. To see it: turn Microphone off in Settings; Auto-record meetings dims with the hint underneath. For the prompt, turn auto-record off and hold the mic with another app for about 3s.

## Checklist

- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I ran `npm test` and the suite passes
- [x] I tested the change in the app (note which backend above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Meeting prompts now default to “Take notes” when auto-record is enabled and “Dismiss” when it is disabled.
  - Microphone monitoring follows platform support and the Microphone setting.
  - Microphone recording changes now synchronize automatically across related recording controls.

- **Bug Fixes**
  - Auto-record is disabled when microphone recording is turned off, with guidance to re-enable the microphone.
  - Meeting prompt actions and secondary menus now consistently reflect the selected default action.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->