### PR TITLE
feat(library): discard an individual pending upload

### DIFF
--- a/src/views/PendingUploads.test.ts
+++ b/src/views/PendingUploads.test.ts
@@ -5,6 +5,7 @@ import { mount, flushPromises } from '@vue/test-utils';
 const list = vi.fn();
 const combine = vi.fn();
 const reveal = vi.fn();
+const discardAudio = vi.fn();
 const bufferPath = vi.fn();
 const checkSession = vi.fn();
 const combineAndUpload = vi.fn();
@@ -17,6 +18,7 @@ vi.mock('../tauri', () => ({
     list: (...a: unknown[]) => list(...a),
     combine: (...a: unknown[]) => combine(...a),
     reveal: (...a: unknown[]) => reveal(...a),
+    discardAudio: (...a: unknown[]) => discardAudio(...a),
     bufferPath: (...a: unknown[]) => bufferPath(...a),
   },
 }));
@@ -274,6 +276,93 @@ describe('PendingUploads', () => {
     // A subsequent click only re-arms — it must not discard.
     await wrapper.find('.discard').trigger('click');
     expect(discardAll).not.toHaveBeenCalled();
+  });
+
+  // With a single recording, "Discard all" already discards exactly that one.
+  it('shows no per-recording Discard when only one recording is pending', async () => {
+    list.mockResolvedValue([items[0]]);
+    const wrapper = mount(PendingUploads);
+    await flushPromises();
+    expect(wrapper.find('.pi-discard').exists()).toBe(false);
+  });
+
+  it('per-recording Discard confirms then discards only that recording', async () => {
+    list.mockResolvedValueOnce(items).mockResolvedValueOnce([items[0]]);
+    discardAudio.mockResolvedValue(undefined);
+    const wrapper = mount(PendingUploads);
+    await flushPromises();
+
+    const buttons = wrapper.findAll('.pi-discard');
+    expect(buttons).toHaveLength(2);
+    await buttons[1].trigger('click'); // first click → confirm
+    expect(wrapper.findAll('.pi-discard')[1].text()).toBe('Confirm');
+    expect(wrapper.findAll('.pi-discard')[0].text()).toBe('Discard');
+    expect(discardAudio).not.toHaveBeenCalled();
+    await wrapper.findAll('.pi-discard')[1].trigger('click'); // second click → run
+    await flushPromises();
+
+    expect(discardAudio).toHaveBeenCalledTimes(1);
+    expect(discardAudio).toHaveBeenCalledWith('2026-06-12T11:00:00Z');
+    expect(discardAll).not.toHaveBeenCalled();
+    expect(wrapper.findAll('.pending-item')).toHaveLength(1);
+  });
+
+  it('arming one recording\'s Discard does not let another recording\'s click discard', async () => {
+    list.mockResolvedValue(items);
+    const wrapper = mount(PendingUploads);
+    await flushPromises();
+
+    await wrapper.findAll('.pi-discard')[0].trigger('click'); // arm the first
+    await wrapper.findAll('.pi-discard')[1].trigger('click'); // only arms the second
+
+    expect(discardAudio).not.toHaveBeenCalled();
+    expect(wrapper.findAll('.pi-discard')[0].text()).toBe('Discard');
+    expect(wrapper.findAll('.pi-discard')[1].text()).toBe('Confirm');
+  });
+
+  it('cancels a per-recording discard confirmation when the pointer leaves its row', async () => {
+    list.mockResolvedValue(items);
+    const wrapper = mount(PendingUploads);
+    await flushPromises();
+
+    await wrapper.findAll('.pi-discard')[0].trigger('click'); // arm confirm
+    await wrapper.findAll('.pi-controls')[0].trigger('mouseleave'); // move away
+    expect(wrapper.findAll('.pi-discard')[0].text()).toBe('Discard');
+
+    await wrapper.findAll('.pi-discard')[0].trigger('click'); // only re-arms
+    expect(discardAudio).not.toHaveBeenCalled();
+  });
+
+  it('shows an error and keeps the recording when a per-recording discard fails', async () => {
+    list.mockResolvedValue(items);
+    discardAudio.mockRejectedValue(new Error('permission denied'));
+    const wrapper = mount(PendingUploads);
+    await flushPromises();
+
+    await wrapper.findAll('.pi-discard')[0].trigger('click');
+    await wrapper.findAll('.pi-discard')[0].trigger('click');
+    await flushPromises();
+
+    expect(wrapper.find('.pending-error').text()).toBe('Could not discard this recording.');
+    expect(wrapper.findAll('.pending-item')).toHaveLength(2);
+    expect(wrapper.findAll('.pi-discard')[0].text()).toBe('Discard');
+  });
+
+  // Discarding a buffer mid-retry could pull it out from under the upload.
+  it('disables per-recording Discard while an upload is in flight', async () => {
+    list.mockResolvedValue(items);
+    combineAndUpload.mockReturnValue(new Promise(() => {}));
+    const wrapper = mount(PendingUploads);
+    await flushPromises();
+
+    await wrapper.find('.upload').trigger('click');
+    await flushPromises();
+
+    const buttons = wrapper.findAll('.pi-discard');
+    expect(buttons).toHaveLength(2);
+    for (const b of buttons) {
+      expect(b.attributes('disabled')).toBeDefined();
+    }
   });
 
   it('exposes refresh() to reload the list', async () => {

--- a/src/views/PendingUploads.vue
+++ b/src/views/PendingUploads.vue
@@ -11,7 +11,9 @@
           <span class="pi-title">{{ titleFor(it) }}</span>
           <span class="pi-dur">{{ durationFor(it) }}</span>
         </div>
-        <div class="pi-controls">
+        <!-- Leaving the row disarms this recording's discard confirmation, like
+             the "Discard all" row below. -->
+        <div class="pi-controls" @mouseleave="disarmItem(it)">
           <span class="pi-play">
             <RecordingAudioPlayer
               :load="() => loadAudio(it)"
@@ -25,16 +27,27 @@
           >
             Locate
           </button>
+          <!-- With one recording, "Discard all" already discards exactly it. -->
+          <button
+            v-if="items.length > 1"
+            class="pi-discard"
+            :class="{ armed: confirmingItem === it.createdAt }"
+            :disabled="actionsDisabled"
+            title="Delete this buffered recording without uploading it"
+            @click="onDiscardItem(it)"
+          >
+            {{ confirmingItem === it.createdAt ? 'Confirm' : 'Discard' }}
+          </button>
         </div>
       </div>
       <!-- Leaving the actions row cancels a pending discard confirmation so the
            destructive second click can't linger armed after the user moves away. -->
       <div class="pending-actions" @mouseleave="confirmingDiscard = false">
-        <button class="pending-btn upload" :disabled="busy" @click="onUpload">
+        <button class="pending-btn upload" :disabled="actionsDisabled" @click="onUpload">
           <span v-if="busy" class="spinner" />
           <span v-else>Upload ({{ items.length }})</span>
         </button>
-        <button class="pending-btn discard" :disabled="busy" @click="onDiscard">
+        <button class="pending-btn discard" :disabled="actionsDisabled" @click="onDiscard">
           {{ confirmingDiscard ? 'Confirm discard' : 'Discard all' }}
         </button>
       </div>
@@ -50,7 +63,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted } from 'vue';
+import { ref, computed, onMounted } from 'vue';
 import { auth, pending, type PendingUploadMeta } from '../tauri';
 import { combineAndUpload, discardAll, PartialUploadError } from '../composables/usePendingUploads';
 import { useMeetingProcessing } from '../composables/useMeetingProcessing';
@@ -64,6 +77,14 @@ const items = ref<PendingUploadMeta[]>([]);
 const busy = ref(false);
 const error = ref<string | null>(null);
 const confirmingDiscard = ref(false);
+// The `createdAt` of the one recording whose Discard is armed, if any.
+const confirmingItem = ref<string | null>(null);
+// A single-recording discard in flight. Kept apart from `busy` so it doesn't
+// put the upload spinner on the Upload button.
+const discardingItem = ref(false);
+// Any upload or discard in flight locks every action: discarding a buffer
+// mid-retry could pull it out from under the combine/upload.
+const actionsDisabled = computed(() => busy.value || discardingItem.value);
 // Rust resolves this ($HOME on macOS, %USERPROFILE% on Windows, ARISO_ROOT in
 // dev), so the recovery line names a folder the user can actually open. The
 // literal is only the pre-IPC placeholder and the fallback when the lookup
@@ -127,6 +148,7 @@ async function onUpload(): Promise<void> {
   busy.value = true;
   error.value = null;
   confirmingDiscard.value = false;
+  confirmingItem.value = null;
   try {
     if (!(await auth.checkSession())) {
       error.value = 'Upload failed — sign in to Ari again, then retry.';
@@ -154,7 +176,34 @@ async function onUpload(): Promise<void> {
   }
 }
 
+function disarmItem(it: PendingUploadMeta): void {
+  if (confirmingItem.value === it.createdAt) confirmingItem.value = null;
+}
+
+// Two clicks, like "Discard all": the first arms this recording (disarming any
+// other), the second deletes just its buffer.
+async function onDiscardItem(it: PendingUploadMeta): Promise<void> {
+  confirmingDiscard.value = false;
+  if (confirmingItem.value !== it.createdAt) {
+    confirmingItem.value = it.createdAt;
+    return;
+  }
+  confirmingItem.value = null;
+  discardingItem.value = true;
+  error.value = null;
+  try {
+    await pending.discardAudio(it.createdAt);
+    await refresh();
+  } catch (e) {
+    console.error('Discard pending upload failed', e);
+    error.value = 'Could not discard this recording.';
+  } finally {
+    discardingItem.value = false;
+  }
+}
+
 async function onDiscard(): Promise<void> {
+  confirmingItem.value = null;
   if (!confirmingDiscard.value) {
     confirmingDiscard.value = true;
     return;
@@ -300,6 +349,31 @@ onMounted(async () => {
   background: #f7f6f4;
   border-color: #bdbbb6;
 }
+/* Same shape as Locate but muted, like "Discard all"; red once armed so the
+   confirming second click reads as destructive. */
+.pi-discard {
+  flex-shrink: 0;
+  font-family: inherit;
+  font-size: 13px;
+  padding: 5px 10px;
+  border-radius: 6px;
+  border: 1px solid #d7d6d2;
+  background: #ffffff;
+  color: #6f6f6f;
+  cursor: pointer;
+  white-space: nowrap;
+}
+.pi-discard:not(:disabled):hover {
+  background: #f7f6f4;
+  border-color: #bdbbb6;
+  color: #1c1c1c;
+}
+.pi-discard.armed,
+.pi-discard.armed:not(:disabled):hover {
+  border-color: #e3b1ae;
+  color: #c2413b;
+}
+.pi-discard:disabled { opacity: 0.6; cursor: default; }
 .pending-error {
   margin: 0 10px;
   color: #c2413b;


### PR DESCRIPTION
## What does this PR do?

When several recordings are pending upload, the Library sidebar only offered **Discard all**. Each pending recording now has its own **Discard** button on the same line as Play and Locate.

- **Two-click confirm**, like "Discard all": the first click arms it (the button turns into a red **Confirm**), the second deletes only that recording's buffered `.mp3` + `.json`. Moving the pointer off the row, or arming another recording, disarms it.
- **Only shown with 2+ pending recordings.** With one, "Discard all" already does the same thing.
- **Uploads and discards lock each other out**, so a buffer can't be deleted while a retry is combining/uploading it. A single discard doesn't show the Upload button's spinner.
- **A failed discard** keeps the recording in the list and shows "Could not discard this recording."

Frontend only (`src/views/PendingUploads.vue`). It reuses the existing `discard_pending_audio` command, so nothing changes on the Rust side.

## Type of change

- [ ] `fix:` — bug fix
- [x] `feat:` — new feature
- [ ] `feat!:` / `BREAKING CHANGE:` — breaking change
- [ ] `docs:` / `chore:` / `refactor:` — no user-facing release

## How was this tested?

- `npm test`: 63 files / 1003 tests pass. 6 new tests in `PendingUploads.test.ts` cover: hidden with one recording, the confirm-then-discard flow deleting only that recording, arming one recording not letting another's click discard, pointer-leave disarm, the error when a discard fails, and the buttons being disabled during an upload.
- Manually on macOS (Apple Silicon), Local backend, with 3 fake pending recordings in `~/.ariso/pending-uploads`:
  - Play / Locate / Discard fit on one line in the sidebar with no overflow.
  - Arm → the files are untouched. Confirm → only that recording's files are deleted, the list and "Upload (N)" update.
  - With one recording left, the per-row Discard is hidden.

**Known tradeoff:** while a recording is playing, the native player shares the line with Locate and Discard, so it's about 89px wide (about 160px before). It keeps a working play/pause button but doesn't have room for the progress bar or time.

## Screenshots / recordings

Not attached. Layout per row: `[▶ Play] [Locate] [Discard]`. The armed state shows a red `Confirm`.

## Checklist

- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I ran `npm test` and the suite passes
- [x] I tested the change in the app (note which backend above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added per-recording discard controls for pending uploads.
  - Added two-step confirmation with hover-based cancellation.
  - Discarded recordings are hidden individually without affecting other uploads.
  - Upload and discard actions are disabled while an operation is in progress.
  - Upload retries reset pending discard confirmations.

- **Bug Fixes**
  - Improved handling of failed discard attempts and confirmation state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->