### PR TITLE
Feat: update logo and org name ariso backend

### DIFF
--- a/src-tauri/Info.plist
+++ b/src-tauri/Info.plist
@@ -8,5 +8,16 @@
 	<string>oats needs microphone access to record meeting audio for transcription.</string>
 	<key>NSAudioCaptureUsageDescription</key>
 	<string>oats needs system audio recording permission to capture audio from video calls.</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLName</key>
+			<string>ai.ariso.desktop</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>oats</string>
+			</array>
+		</dict>
+	</array>
 </dict>
 </plist>

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -624,6 +624,7 @@ async fn accept_loopback_callback(
     listener: &tokio::net::TcpListener,
     expected_nonce: &str,
     flow: BrowserFlow,
+    owner_label: &str,
 ) -> Result<LoopbackDelivery, String> {
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
@@ -655,6 +656,13 @@ async fn accept_loopback_callback(
             let matched = parse_loopback_callback(&request_line)
                 .filter(|(_, nonce)| nonce_matches(nonce, expected_nonce))
                 .map(|(delivery, _)| delivery);
+
+            // Remember the owning window before the browser can act on the
+            // success page's automatic `oats://return` navigation, so the
+            // deep-link handler always finds it.
+            if matched.is_some() {
+                crate::deep_link::remember_return_window(owner_label);
+            }
 
             let response = if matched.is_some() {
                 flow.callback_ok_response()
@@ -723,13 +731,9 @@ async fn run_browser_sign_in(
 ) {
     let delivery = tokio::time::timeout(
         SIGN_IN_TIMEOUT,
-        accept_loopback_callback(&listener, &nonce, BrowserFlow::SignIn),
+        accept_loopback_callback(&listener, &nonce, BrowserFlow::SignIn, window.label()),
     )
     .await;
-    // The browser now holds the page that hands back via `oats://`.
-    if matches!(delivery, Ok(Ok(_))) {
-        crate::deep_link::remember_return_window(window.label());
-    }
     let result = match delivery {
         Ok(Ok(LoopbackDelivery::Token(token))) => {
             exchange_token_for_session(window.app_handle(), &token).await
@@ -909,13 +913,14 @@ async fn run_calendar_connect(
 ) {
     let delivery = tokio::time::timeout(
         SIGN_IN_TIMEOUT,
-        accept_loopback_callback(&listener, &nonce, BrowserFlow::CalendarConnect),
+        accept_loopback_callback(
+            &listener,
+            &nonce,
+            BrowserFlow::CalendarConnect,
+            window.label(),
+        ),
     )
     .await;
-    // The browser now holds the page that hands back via `oats://`.
-    if matches!(delivery, Ok(Ok(_))) {
-        crate::deep_link::remember_return_window(window.label());
-    }
     let result = match delivery {
         Ok(Ok(LoopbackDelivery::Status(status))) => CalendarConnectResult {
             status: Some(status),
@@ -2938,7 +2943,7 @@ mod tests {
         let port = listener.local_addr().unwrap().port();
 
         let accept = tokio::spawn(async move {
-            accept_loopback_callback(&listener, "goodnonce", BrowserFlow::SignIn).await
+            accept_loopback_callback(&listener, "goodnonce", BrowserFlow::SignIn, "main").await
         });
 
         let send = |req: String| async move {
@@ -2975,7 +2980,8 @@ mod tests {
         let port = listener.local_addr().unwrap().port();
 
         let accept = tokio::spawn(async move {
-            accept_loopback_callback(&listener, "goodnonce", BrowserFlow::CalendarConnect).await
+            accept_loopback_callback(&listener, "goodnonce", BrowserFlow::CalendarConnect, "main")
+                .await
         });
 
         let mut conn = tokio::net::TcpStream::connect(("127.0.0.1", port)).await.unwrap();

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -560,6 +560,29 @@ fn parse_loopback_callback(request_line: &str) -> Option<(LoopbackDelivery, Stri
     Some((delivery, nonce?))
 }
 
+// On macOS the success page also hands the user back to the app: it redirects
+// to the `oats://` scheme (see `deep_link`), so the browser offers to open oats,
+// and keeps a link for a browser that blocks the automatic redirect. Nothing
+// about the flow rides in that URL. Other platforms register no scheme, so the
+// page there only says to close the tab.
+#[cfg(target_os = "macos")]
+macro_rules! callback_return_to_app {
+    () => {
+        concat!(
+            "<p><a href=\"oats://return\" style=\"display:inline-block;margin-top:8px;",
+            "padding:8px 16px;border-radius:10px;background:#1c1c1c;color:#fff;",
+            "text-decoration:none;font-weight:600\">Open oats</a></p>",
+            "<script>location.href=\"oats://return\";</script>"
+        )
+    };
+}
+#[cfg(not(target_os = "macos"))]
+macro_rules! callback_return_to_app {
+    () => {
+        ""
+    };
+}
+
 // Loopback responses. The success page must never echo the token, and its
 // wording must match the flow that opened the browser — see
 // `BrowserFlow::callback_ok_response`.
@@ -574,7 +597,9 @@ macro_rules! callback_ok_response {
             $heading,
             "</h2><p>",
             $body,
-            "</p></div></body></html>"
+            "</p>",
+            callback_return_to_app!(),
+            "</div></body></html>"
         )
     };
 }
@@ -696,12 +721,16 @@ async fn run_browser_sign_in(
     listener: tokio::net::TcpListener,
     nonce: String,
 ) {
-    let result = match tokio::time::timeout(
+    let delivery = tokio::time::timeout(
         SIGN_IN_TIMEOUT,
         accept_loopback_callback(&listener, &nonce, BrowserFlow::SignIn),
     )
-    .await
-    {
+    .await;
+    // The browser now holds the page that hands back via `oats://`.
+    if matches!(delivery, Ok(Ok(_))) {
+        crate::deep_link::remember_return_window(window.label());
+    }
+    let result = match delivery {
         Ok(Ok(LoopbackDelivery::Token(token))) => {
             exchange_token_for_session(window.app_handle(), &token).await
         }
@@ -878,12 +907,16 @@ async fn run_calendar_connect(
     listener: tokio::net::TcpListener,
     nonce: String,
 ) {
-    let result = match tokio::time::timeout(
+    let delivery = tokio::time::timeout(
         SIGN_IN_TIMEOUT,
         accept_loopback_callback(&listener, &nonce, BrowserFlow::CalendarConnect),
     )
-    .await
-    {
+    .await;
+    // The browser now holds the page that hands back via `oats://`.
+    if matches!(delivery, Ok(Ok(_))) {
+        crate::deep_link::remember_return_window(window.label());
+    }
+    let result = match delivery {
         Ok(Ok(LoopbackDelivery::Status(status))) => CalendarConnectResult {
             status: Some(status),
             error: None,
@@ -2963,6 +2996,20 @@ mod tests {
             accept.await.unwrap().unwrap(),
             LoopbackDelivery::Status("connected".into())
         );
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn callback_success_pages_hand_back_to_the_app_scheme() {
+        let return_url = format!("{}://return", crate::deep_link::APP_URL_SCHEME);
+        for flow in [BrowserFlow::SignIn, BrowserFlow::CalendarConnect] {
+            let page = flow.callback_ok_response();
+            // Redirects on load (the browser's "Open oats?" prompt)…
+            assert!(page.contains(&format!("location.href=\"{return_url}\"")), "{flow:?}");
+            // …with a link for a browser that blocks the automatic redirect.
+            assert!(page.contains(&format!("href=\"{return_url}\"")), "{flow:?}");
+        }
+        assert!(!CALLBACK_NOT_FOUND_RESPONSE.contains("oats://"));
     }
 
     #[test]

--- a/src-tauri/src/deep_link.rs
+++ b/src-tauri/src/deep_link.rs
@@ -1,0 +1,93 @@
+//! The `oats://` URL scheme, registered in `Info.plist` (macOS only).
+//!
+//! Its one job is handing control back from the browser: the loopback page that
+//! ends a sign-in (or Calendar connect) redirects to `oats://return`, so the
+//! browser offers to open oats and the window that started the flow comes
+//! forward. Any web page can open an `oats://` URL, so the handler treats the
+//! URL as untrusted: it never reads the host, path or query, and does nothing
+//! but surface a window.
+
+#![cfg_attr(not(target_os = "macos"), allow(dead_code))]
+
+use std::sync::Mutex;
+
+/// The scheme registered under `CFBundleURLSchemes` in `src-tauri/Info.plist`.
+pub(crate) const APP_URL_SCHEME: &str = "oats";
+
+/// Label of the webview that started the most recent browser flow whose
+/// callback arrived: the window to bring forward when the browser hands back.
+static RETURN_WINDOW: Mutex<Option<String>> = Mutex::new(None);
+
+/// Remember `label` as the window to surface on the next `oats://` open.
+pub(crate) fn remember_return_window(label: &str) {
+    *RETURN_WINDOW
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner()) = Some(label.to_string());
+}
+
+/// Take the remembered window: one hand-back per completed flow, so a later
+/// stray `oats://` open falls back to the Meetings window.
+fn take_return_window() -> Option<String> {
+    RETURN_WINDOW
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .take()
+}
+
+/// Whether `url` is one of ours. Only the scheme is inspected.
+pub(crate) fn is_app_url(url: &tauri::Url) -> bool {
+    url.scheme().eq_ignore_ascii_case(APP_URL_SCHEME)
+}
+
+/// Handle `RunEvent::Opened`: when any URL is an `oats://` one, bring the
+/// window that started the browser flow forward — or the Meetings window when
+/// that one is gone (or nothing is pending).
+#[cfg(target_os = "macos")]
+pub(crate) fn handle_opened_urls(app: &tauri::AppHandle, urls: &[tauri::Url]) {
+    use tauri::Manager;
+
+    if !urls.iter().any(is_app_url) {
+        return;
+    }
+    let target = take_return_window().and_then(|label| app.get_webview_window(&label));
+    let surfaced = match target {
+        Some(win) => {
+            let _ = win.unminimize();
+            win.show()
+                .and_then(|_| win.set_focus())
+                .map_err(|e| e.to_string())
+        }
+        None => crate::commands::open_library_window(app),
+    };
+    if let Err(e) = surfaced {
+        eprintln!("Failed to surface a window for an {APP_URL_SCHEME}:// open: {e}");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn url(s: &str) -> tauri::Url {
+        tauri::Url::parse(s).expect("test url parses")
+    }
+
+    #[test]
+    fn is_app_url_matches_only_the_oats_scheme() {
+        assert!(is_app_url(&url("oats://return")));
+        assert!(is_app_url(&url("OATS://return")));
+        assert!(is_app_url(&url("oats:anything?token=ignored")));
+        assert!(!is_app_url(&url("https://oats/return")));
+        assert!(!is_app_url(&url("oatsx://return")));
+        assert!(!is_app_url(&url("file:///tmp/oats")));
+    }
+
+    #[test]
+    fn return_window_is_handed_back_once() {
+        take_return_window();
+        remember_return_window("settings");
+        remember_return_window("onboarding");
+        assert_eq!(take_return_window().as_deref(), Some("onboarding"));
+        assert_eq!(take_return_window(), None);
+    }
+}

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -6,6 +6,7 @@ mod audio_util;
 mod audio_capture;
 mod mic_capture;
 mod commands;
+mod deep_link;
 mod meeting_notifications;
 mod mic_monitor;
 mod platform;
@@ -437,6 +438,8 @@ fn main() {
                         eprintln!("Failed to open meetings window on dock reopen: {e}");
                     }
                 }
+                // An `oats://` URL — the browser handing back after sign-in.
+                tauri::RunEvent::Opened { urls } => deep_link::handle_opened_urls(_app, urls),
                 // Keep the Dock / Stage Manager presence in sync with the
                 // visible windows: promote to Regular while a real window is up,
                 // demote to Accessory once they're all gone. Focused covers

--- a/src/composables/useOrganizationInfo.test.ts
+++ b/src/composables/useOrganizationInfo.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const apiRequest = vi.fn(
+  (_method: string, _path: string): Promise<{ status: number; data: unknown }> =>
+    Promise.resolve({ status: 200, data: {} })
+);
+
+vi.mock('../tauri', () => ({
+  api: {
+    request: (method: string, path: string) => apiRequest(method, path),
+  },
+}));
+
+import { useOrganizationInfo } from './useOrganizationInfo';
+
+const LOGO = 'data:image/png;base64,iVBORw0KGgo=';
+
+function respond(data: unknown, status = 200) {
+  apiRequest.mockResolvedValueOnce({ status, data });
+}
+
+beforeEach(() => {
+  apiRequest.mockReset();
+  apiRequest.mockResolvedValue({ status: 200, data: {} });
+});
+
+describe('useOrganizationInfo', () => {
+  it('fetches the org name and logo from /organizations/info', async () => {
+    respond({ organization: { id: 7, name: 'Acme', logo_data: LOGO } });
+    const org = useOrganizationInfo();
+    await org.refresh();
+    expect(apiRequest).toHaveBeenCalledWith('GET', '/organizations/info');
+    expect(org.name.value).toBe('Acme');
+    expect(org.logo.value).toBe(LOGO);
+  });
+
+  it('trims the name and treats a blank one as absent', async () => {
+    respond({ organization: { name: '   ', logo_data: null } });
+    const org = useOrganizationInfo();
+    await org.refresh();
+    expect(org.name.value).toBe('');
+    expect(org.logo.value).toBe('');
+  });
+
+  it('only accepts inline image data URLs as the logo', async () => {
+    respond({ organization: { name: 'Acme', logo_data: 'https://tracker.example/pixel.png' } });
+    const org = useOrganizationInfo();
+    await org.refresh();
+    expect(org.name.value).toBe('Acme');
+    expect(org.logo.value).toBe('');
+  });
+
+  it('clears the org on a non-200 response', async () => {
+    respond({ organization: { name: 'Acme', logo_data: LOGO } });
+    const org = useOrganizationInfo();
+    await org.refresh();
+    respond({ error: 'nope' }, 401);
+    await org.refresh();
+    expect(org.name.value).toBe('');
+    expect(org.logo.value).toBe('');
+  });
+
+  it('never throws when the request fails', async () => {
+    apiRequest.mockRejectedValueOnce(new Error('offline'));
+    const org = useOrganizationInfo();
+    await expect(org.refresh()).resolves.toBeUndefined();
+    expect(org.name.value).toBe('');
+  });
+
+  it('reset() clears the org and drops a response still in flight', async () => {
+    let resolve!: (v: { status: number; data: unknown }) => void;
+    apiRequest.mockReturnValueOnce(new Promise((r) => { resolve = r; }));
+    const org = useOrganizationInfo();
+    const pending = org.refresh();
+    org.reset();
+    resolve({ status: 200, data: { organization: { name: 'Stale', logo_data: LOGO } } });
+    await pending;
+    expect(org.name.value).toBe('');
+    expect(org.logo.value).toBe('');
+  });
+
+  it('lets the newest refresh win over a slower earlier one', async () => {
+    let resolveFirst!: (v: { status: number; data: unknown }) => void;
+    apiRequest.mockReturnValueOnce(new Promise((r) => { resolveFirst = r; }));
+    respond({ organization: { name: 'New Org', logo_data: null } });
+    const org = useOrganizationInfo();
+    const first = org.refresh();
+    await org.refresh();
+    resolveFirst({ status: 200, data: { organization: { name: 'Old Org', logo_data: null } } });
+    await first;
+    expect(org.name.value).toBe('New Org');
+  });
+});

--- a/src/composables/useOrganizationInfo.ts
+++ b/src/composables/useOrganizationInfo.ts
@@ -1,0 +1,60 @@
+import { ref } from 'vue';
+import { api } from '../tauri';
+
+interface RawOrganizationInfo {
+  organization?: { name?: unknown; logo_data?: unknown } | null;
+}
+
+// The API stores the logo inline as a base64 data URL (it validates that shape
+// on write). Anything else is dropped rather than bound to an <img>, so a
+// surprising value can never make the webview fetch a remote URL.
+const LOGO_DATA_URL = /^data:image\/(png|jpe?g|gif|webp);base64,/i;
+
+/**
+ * The signed-in user's Ariso organization — its name and logo — for branding
+ * the Library's Up Next greeting. Like `useAccountState`, callers decide when to
+ * refresh: Local mode must never call it, because it hits the network.
+ */
+export function useOrganizationInfo() {
+  const name = ref('');
+  // A `data:image/...` URL, or '' when the org has no (usable) logo.
+  const logo = ref('');
+
+  // Bumped by every refresh() and reset(), so a response that lands after a
+  // newer request (or after the account went away) is discarded.
+  let requestId = 0;
+
+  function apply(nextName: string, nextLogo: string) {
+    name.value = nextName;
+    logo.value = nextLogo;
+  }
+
+  /** Re-read the org. Never throws: a failure reads as "no org". */
+  async function refresh(): Promise<void> {
+    const mine = ++requestId;
+    let nextName = '';
+    let nextLogo = '';
+    try {
+      const res = await api.request('GET', '/organizations/info');
+      const org = res.status === 200 ? (res.data as RawOrganizationInfo | null)?.organization : null;
+      if (org) {
+        if (typeof org.name === 'string') nextName = org.name.trim();
+        if (typeof org.logo_data === 'string' && LOGO_DATA_URL.test(org.logo_data)) {
+          nextLogo = org.logo_data;
+        }
+      }
+    } catch (e) {
+      console.warn('Failed to load organization info', e);
+    }
+    if (mine !== requestId) return;
+    apply(nextName, nextLogo);
+  }
+
+  /** Forget the org without asking the backend, e.g. on sign-out or a switch to Local. */
+  function reset() {
+    requestId += 1;
+    apply('', '');
+  }
+
+  return { name, logo, refresh, reset };
+}

--- a/src/views/LibraryView.test.ts
+++ b/src/views/LibraryView.test.ts
@@ -2374,6 +2374,92 @@ describe('LibraryView Todo tab', () => {
   });
 });
 
+describe('LibraryView organization branding', () => {
+  const LOGO = 'data:image/png;base64,iVBORw0KGgo=';
+
+  function mockOrg() {
+    apiRequest.mockImplementation((_method: string, path: string) =>
+      Promise.resolve(
+        path === '/auth/me'
+          ? { status: 200, data: { full_name: 'Ada Lovelace', email: 'ada@example.com' } }
+          : path === '/organizations/info'
+            ? { status: 200, data: { organization: { id: 1, name: 'Acme', logo_data: LOGO } } }
+            : { status: 200, data: {} }
+      )
+    );
+  }
+
+  async function mountOn(backend: 'ariso' | 'local') {
+    backendId.mockReturnValue(backend);
+    listMeetings.mockResolvedValue([]);
+    const wrapper = mount(LibraryView);
+    await flushPromises();
+    return wrapper;
+  }
+
+  function orgRequests() {
+    return apiRequest.mock.calls.filter(([, path]) => path === '/organizations/info');
+  }
+
+  it('brands Up Next with the signed-in Ariso org', async () => {
+    checkSession.mockResolvedValue({ sessionToken: 't' });
+    mockOrg();
+    const wrapper = await mountOn('ariso');
+
+    expect(orgRequests()).toHaveLength(1);
+    const upNext = wrapper.findComponent(UpNextCard);
+    expect(upNext.props('orgName')).toBe('Acme');
+    expect(upNext.props('orgLogo')).toBe(LOGO);
+  });
+
+  it('asks for no org while signed out', async () => {
+    mockOrg();
+    const wrapper = await mountOn('ariso');
+
+    expect(orgRequests()).toHaveLength(0);
+    expect(wrapper.findComponent(UpNextCard).props('orgName')).toBe('');
+  });
+
+  it('never asks for the org on Local', async () => {
+    mockOrg();
+    const wrapper = await mountOn('local');
+
+    expect(orgRequests()).toHaveLength(0);
+    expect(wrapper.findComponent(UpNextCard).props('orgName')).toBe('');
+  });
+
+  it('drops the org on a switch to Local and refetches on the way back', async () => {
+    checkSession.mockResolvedValue({ sessionToken: 't' });
+    mockOrg();
+    const wrapper = await mountOn('ariso');
+    expect(wrapper.findComponent(UpNextCard).props('orgName')).toBe('Acme');
+
+    backendId.mockReturnValue('local');
+    emitEvent('backend://changed', null);
+    await flushPromises();
+    expect(wrapper.findComponent(UpNextCard).props('orgName')).toBe('');
+    expect(wrapper.findComponent(UpNextCard).props('orgLogo')).toBe('');
+
+    backendId.mockReturnValue('ariso');
+    emitEvent('backend://changed', null);
+    await flushPromises();
+    expect(orgRequests()).toHaveLength(2);
+    expect(wrapper.findComponent(UpNextCard).props('orgName')).toBe('Acme');
+  });
+
+  it('drops the org when the session ends elsewhere', async () => {
+    checkSession.mockResolvedValue({ sessionToken: 't' });
+    mockOrg();
+    const wrapper = await mountOn('ariso');
+    expect(wrapper.findComponent(UpNextCard).props('orgName')).toBe('Acme');
+
+    checkSession.mockResolvedValue(null);
+    emitEvent('auth://changed', null);
+    await flushPromises();
+    expect(wrapper.findComponent(UpNextCard).props('orgName')).toBe('');
+  });
+});
+
 describe('LibraryView backend indicator', () => {
   function mockProfile() {
     apiRequest.mockImplementation((_method: string, path: string) =>

--- a/src/views/LibraryView.test.ts
+++ b/src/views/LibraryView.test.ts
@@ -2458,6 +2458,18 @@ describe('LibraryView organization branding', () => {
     await flushPromises();
     expect(wrapper.findComponent(UpNextCard).props('orgName')).toBe('');
   });
+
+  it('keeps the org when an auth change leaves the same account signed in', async () => {
+    checkSession.mockResolvedValue({ sessionToken: 't' });
+    mockOrg();
+    const wrapper = await mountOn('ariso');
+    expect(wrapper.findComponent(UpNextCard).props('orgName')).toBe('Acme');
+
+    emitEvent('auth://changed', null);
+    await flushPromises();
+    expect(wrapper.findComponent(UpNextCard).props('orgName')).toBe('Acme');
+    expect(wrapper.findComponent(UpNextCard).props('orgLogo')).toBe(LOGO);
+  });
 });
 
 describe('LibraryView backend indicator', () => {

--- a/src/views/LibraryView.vue
+++ b/src/views/LibraryView.vue
@@ -1790,6 +1790,9 @@ onUnmounted(() => {
 }
 
 /* Sidebar */
+/* The top padding matches the detail pane's, so the search box lines up with
+   the detail card. The search box, meeting rows and nav pill all span the
+   sidebar's content width, 18px in from each side. */
 .sidebar {
   width: 300px;
   flex-shrink: 0;
@@ -2020,9 +2023,9 @@ onUnmounted(() => {
   display: flex;
   align-items: center;
   gap: 9px;
-  width: calc(100% - 12px);
+  width: 100%;
   min-height: 42px;
-  margin: 0 6px 10px;
+  margin: 0 0 10px;
   padding: 0 12px;
   border: 1px solid #d7d6d2;
   border-radius: 999px;
@@ -2065,7 +2068,8 @@ onUnmounted(() => {
   display: flex;
   flex-direction: column;
   gap: 6px;
-  padding: 6px;
+  /* No left padding: rows start flush with the search box and nav pill. */
+  padding: 6px 6px 6px 0;
   -webkit-mask-image: linear-gradient(to bottom, transparent 0, #000 24px, #000 calc(100% - 24px), transparent 100%);
   mask-image: linear-gradient(to bottom, transparent 0, #000 24px, #000 calc(100% - 24px), transparent 100%);
 }
@@ -2178,6 +2182,10 @@ onUnmounted(() => {
   gap: 8px;
   padding-top: 24px;
 }
+.nav-pill {
+  flex: 1;
+  min-width: 0;
+}
 .nav-pill,
 .nav-circle {
   display: flex;
@@ -2190,10 +2198,13 @@ onUnmounted(() => {
   padding: 5px;
 }
 .nav-tab {
+  /* Share the pill's width, so the tabs fill it edge to edge. */
+  flex: 1 1 auto;
+  justify-content: center;
   display: flex;
   align-items: center;
   gap: 6px;
-  padding: 6px 10px;
+  padding: 6px;
   border: none;
   border-radius: 999px;
   background: transparent;

--- a/src/views/LibraryView.vue
+++ b/src/views/LibraryView.vue
@@ -346,6 +346,8 @@
           v-else
           :meetings="displayMeetings"
           :now="now"
+          :org-name="orgName"
+          :org-logo="orgLogo"
           @select="(m) => selectMeeting(m, { userSelected: true })"
           @start="startRecordingFor"
           @record="startRecording"
@@ -423,6 +425,7 @@ import {
   recordingStartErrorMessage,
 } from '../composables/recordingStartError';
 import { useAccountState } from '../composables/useAccountState';
+import { useOrganizationInfo } from '../composables/useOrganizationInfo';
 import { AUTH_CHANGED_EVENT, local, setBackendSetting } from '../tauri';
 import { Cog6ToothIcon } from '@heroicons/vue/24/outline';
 import SignInButtons from './SignInButtons.vue';
@@ -824,6 +827,19 @@ watch(
       if (accountSigningInWith.value) void account.cancelSignIn();
       account.reset();
     }
+  }
+);
+
+// The signed-in user's Ariso org brands the Up Next greeting. Fetched only on
+// Ariso with a session — Local mode never asks — and refetched when the account
+// changes (the email tells one user from the next).
+const organization = useOrganizationInfo();
+const { name: orgName, logo: orgLogo } = organization;
+watch(
+  () => [activeBackend.value?.id, accountSignedIn.value, accountEmail.value] as const,
+  ([id, signedIn]) => {
+    if (id === 'ariso' && signedIn) void organization.refresh();
+    else organization.reset();
   }
 );
 

--- a/src/views/LibraryView.vue
+++ b/src/views/LibraryView.vue
@@ -838,8 +838,8 @@ const { name: orgName, logo: orgLogo } = organization;
 watch(
   () => [activeBackend.value?.id, accountSignedIn.value, accountEmail.value] as const,
   ([id, signedIn]) => {
+    organization.reset();
     if (id === 'ariso' && signedIn) void organization.refresh();
-    else organization.reset();
   }
 );
 
@@ -857,6 +857,7 @@ async function onBackendChanged(): Promise<void> {
 }
 
 function onAuthChanged(): void {
+  organization.reset();
   if (activeBackend.value?.id === 'ariso') void account.refresh(true);
 }
 

--- a/src/views/LibraryView.vue
+++ b/src/views/LibraryView.vue
@@ -856,8 +856,10 @@ async function onBackendChanged(): Promise<void> {
   await loadMeetings();
 }
 
+// The organization follows the account watcher above, which resets it on any
+// change of account. Resetting here too would blank it for good whenever the
+// session changes without the account changing.
 function onAuthChanged(): void {
-  organization.reset();
   if (activeBackend.value?.id === 'ariso') void account.refresh(true);
 }
 

--- a/src/views/UpNextCard.test.ts
+++ b/src/views/UpNextCard.test.ts
@@ -214,6 +214,50 @@ describe('UpNextCard', () => {
   });
 });
 
+describe('UpNextCard organization branding', () => {
+  const LOGO = 'data:image/png;base64,iVBORw0KGgo=';
+
+  function mountBranded(props: Record<string, unknown>) {
+    return mount(UpNextCard, { props: { meetings: [meeting({})], now: NOW, ...props } });
+  }
+
+  it('greets with the org name and moves the date/time to a smaller line', async () => {
+    const wrapper = mountBranded({ orgName: 'Acme' });
+    await flushPromises();
+    expect(wrapper.find('.greeting').text()).toBe("Acme's Notetaker");
+    const time = wrapper.find('.greeting-time');
+    expect(time.exists()).toBe(true);
+    expect(time.text()).toMatch(/\d{1,2}:\d{2}(AM|PM)/i);
+  });
+
+  it('shows the org logo above the heading and keeps the oats mark in the prompt', async () => {
+    const wrapper = mountBranded({ orgName: 'Acme', orgLogo: LOGO });
+    await flushPromises();
+    const logo = wrapper.find('.org-logo');
+    expect(logo.attributes('src')).toBe(LOGO);
+    expect(logo.attributes('alt')).toBe('Acme');
+    // The logo sits directly before the heading.
+    expect(logo.element.nextElementSibling).toBe(wrapper.find('.greeting').element);
+    expect(wrapper.find('.prompt-logo').attributes('alt')).toBe('oats');
+  });
+
+  it('omits the org logo when the org has none', async () => {
+    const wrapper = mountBranded({ orgName: 'Acme', orgLogo: '' });
+    await flushPromises();
+    expect(wrapper.find('.org-logo').exists()).toBe(false);
+    expect(wrapper.find('.prompt-logo').attributes('alt')).toBe('oats');
+  });
+
+  it('keeps the plain date/time greeting without an org', async () => {
+    const wrapper = mountBranded({});
+    await flushPromises();
+    expect(wrapper.find('.greeting').text()).toMatch(/\d{1,2}:\d{2}(AM|PM)/i);
+    expect(wrapper.find('.greeting-time').exists()).toBe(false);
+    expect(wrapper.find('.org-logo').exists()).toBe(false);
+    expect(wrapper.find('.prompt-logo').attributes('alt')).toBe('oats');
+  });
+});
+
 describe('UpNextCard Ari chip', () => {
   // In progress at NOW (12:00Z), so the "started but not ended" branch applies.
   const running = {

--- a/src/views/UpNextCard.vue
+++ b/src/views/UpNextCard.vue
@@ -1,13 +1,22 @@
 <template>
   <div class="up-next">
-    <!-- Big serif date/time heading for the empty home state. -->
-    <p class="greeting">{{ greeting }}</p>
+    <!-- Big serif heading for the empty home state: on Ariso, the org's logo
+         centered above "<org>'s Notetaker" with the date/time beneath it;
+         without an org, just the date/time. -->
+    <img
+      v-if="orgLogo"
+      class="org-logo"
+      :src="orgLogo"
+      :alt="orgName || 'Organization logo'"
+    />
+    <p class="greeting" :class="{ 'greeting--org': orgName, 'greeting--below-logo': orgLogo }">{{ orgName ? `${orgName}'s Notetaker` : dateTime }}</p>
+    <p v-if="orgName" class="greeting-time">{{ dateTime }}</p>
     <!-- Greeting prompt: oats mark + chat bubble, with the new-meeting CTA
          tucked under the bubble's bottom-right corner. -->
     <div class="prompt">
       <img class="prompt-logo" :src="oatsLogo" alt="oats" />
       <div class="prompt-body">
-        <p class="prompt-bubble">Ready for the next meet? Or do you want to spin up a new meeting?</p>
+        <p class="prompt-bubble">Ready for the next meet? Or a new one?</p>
         <button class="new-meeting-btn" type="button" title="Start a new recording" @click="$emit('record')">
           <span class="new-meeting-label">New Meeting</span>
           <span class="new-meeting-icon" aria-hidden="true">
@@ -164,6 +173,10 @@ import oatsLogo from '../assets/oats-light.svg';
 const props = defineProps<{
   meetings: MeetingListItem[];
   now: Date;
+  /** Ariso organization name; brands the heading. Empty/absent in Local mode. */
+  orgName?: string;
+  /** Ariso organization logo as a `data:image/...` URL; shown above the heading. */
+  orgLogo?: string;
 }>();
 
 defineEmits<{
@@ -188,7 +201,7 @@ function initials(name?: string): string {
 
 // "Tuesday June 9 1:42PM" — weekday, month, day, and the current clock with no
 // space before AM/PM, matching the Figma heading.
-const greeting = computed(() => {
+const dateTime = computed(() => {
   const d = props.now;
   const weekday = d.toLocaleDateString(undefined, { weekday: 'long' });
   const month = d.toLocaleDateString(undefined, { month: 'long' });
@@ -356,32 +369,66 @@ function rowSub(m: MeetingListItem): string {
   padding: 14px 16px 8px;
   flex-shrink: 0;
 }
+/* Org logo centered above the heading, in the heading's top spot. Logos come
+   in any aspect ratio; fit them inside the square. */
+.org-logo {
+  align-self: center;
+  width: 56px;
+  height: 56px;
+  margin-top: 14px;
+  object-fit: contain;
+  border-radius: 12px;
+  flex-shrink: 0;
+}
+.greeting--below-logo {
+  padding-top: 10px;
+}
+/* With an org, the date/time drops to its own smaller line underneath. */
+.greeting--org {
+  padding-bottom: 4px;
+  overflow-wrap: anywhere;
+}
+.greeting-time {
+  font-size: 15px;
+  line-height: 1.3;
+  color: #6f6f6f;
+  text-align: center;
+  padding: 0 16px 10px;
+  flex-shrink: 0;
+}
 
 /* Prompt sitting between the date heading and the Up Next card: oats mark on
    the left, a chat bubble, and the record CTA tucked under it. */
 .prompt {
   display: flex;
   align-items: flex-start;
-  gap: 14px;
   padding: 6px 2px 26px;
   flex-shrink: 0;
 }
+/* The oats mark overlaps the bubble: its center sits on the bubble's top-left
+   corner. The negative right margin and the body's top offset are both half the
+   mark's size (26px), and the body's offset is measured from the mark's top. */
 .prompt-logo {
+  position: relative;
+  z-index: 2;
   width: 52px;
   height: 52px;
   flex-shrink: 0;
-  margin-top: 2px;
+  margin-top: -10px;
+  margin-right: -26px;
 }
 .prompt-body {
   flex: 1;
   min-width: 0;
   display: flex;
   flex-direction: column;
+  margin-top: 16px; /* -10px (mark's top) + 26px (half the mark) */
 }
 .prompt-bubble {
   background: #ecebe8;
   border-radius: 8px 20px 20px 20px;
-  padding: 14px 20px;
+  /* Extra left padding so the text clears the mark's overlapping corner. */
+  padding: 14px 20px 14px 38px;
   font-size: 15px;
   line-height: 1.4;
   color: #1c1c1c;


### PR DESCRIPTION
<!--
Thanks for contributing to oats! A few quick things before you open this PR.
See CONTRIBUTING.md for the full guide.
-->

## What does this PR do?

When using ariso.ai backend, it will use the organization's logo and title on the greeting screen.

<!-- A short summary of the change and the problem it solves. Link any related issue, e.g. "Closes #123". -->

## Type of change

<!-- Releases are automated by release-please from your commit messages. -->
<!-- Make sure your PR title / commits follow Conventional Commits: -->
<!--   feat: ...        → minor bump        fix: ...   → patch bump -->
<!--   feat!: / BREAKING CHANGE: → major bump   chore/docs/refactor: → no release -->

- [ ] `fix:` — bug fix
- [x] `feat:` — new feature
- [ ] `feat!:` / `BREAKING CHANGE:` — breaking change
- [ ] `docs:` / `chore:` / `refactor:` — no user-facing release

## How was this tested?

<!-- Did you run the frontend tests (`npm test`)? Test manually with which backend (Ariso / Local)? On which OS/platform? -->

## Screenshots / recordings

<!-- For any UI change, drop a before/after screenshot or short clip here. -->

## Checklist

- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I ran `npm test` and the suite passes
- [x] I tested the change in the app (note which backend above)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - macOS sign-in and calendar connection flows now return to the app automatically through the `oats://` link, with a fallback “Open oats” option.
  - Library empty states can display your organization’s name and logo alongside the greeting.
  - Organization branding updates automatically when switching accounts or backends.

- **Improvements**
  - Organization logos are validated before display, with graceful fallback when unavailable.
  - Sidebar search, meeting rows, and navigation now use the available width more consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->