### PR TITLE
fix(recorder-pill): stop the macOS pill flapping on hover

### DIFF
--- a/docs/superpowers/specs/2026-09-11-native-recorder-pill-design.md
+++ b/docs/superpowers/specs/2026-09-11-native-recorder-pill-design.md
@@ -59,9 +59,9 @@ lives exactly as long as the `waveform` window. The visual design matches
 - **`src-tauri/recorder-pill/macos/`** — SwiftPM package `OatsRecorderPill`, a
   static library that `build.rs` compiles and links into the oats binary (plus
   search paths for the OS Swift runtime). An `NSPanel` (borderless,
-  non-activating, floating level, all Spaces + over fullscreen apps, native
-  shadow) hosts an `NSHostingView` of a SwiftUI view driven by an observable
-  model.
+  non-activating, floating level, all Spaces + over fullscreen apps, fixed
+  size) hosts an `NSHostingView` of a SwiftUI view driven by an observable
+  model; the capsule draws its own shadow.
 
 ## The C ABI (macOS)
 
@@ -97,6 +97,16 @@ The three new events carry no payload and are only acted on while
 
 - **Hover** expands the pill upward (bottom-anchored) to show the timer, Pause,
   and Stop; leaving collapses it. No expansion during uploading/success/failed.
+  The panel itself never resizes. Resizing a window makes AppKit re-derive its
+  tracking areas and report a resting pointer as exited, which made an
+  earlier build flap open and shut. The panel is instead sized for the tallest
+  capsule plus shadow room, and the capsule animates inside it. Hover comes
+  from the pointer's position against the capsule's current rect, not the
+  panel's rectangle; the expanded rect contains the collapsed one, so hover
+  can't oscillate. Clicks on the panel's fully transparent pixels go to
+  whatever is underneath (the window server routes by alpha).
+- **Dropped near an edge**, a dragged pill is pulled back so even the tallest
+  capsule fits on screen.
 - **Click without movement** on the pill body opens Meetings on the recording.
 - **Drag from anywhere** except a button: a press that moves more than 3pt
   hands off to the OS window drag (`NSWindow.performDrag`). This replaces the

--- a/src-tauri/recorder-pill/macos/Sources/OatsRecorderPill/PillController.swift
+++ b/src-tauri/recorder-pill/macos/Sources/OatsRecorderPill/PillController.swift
@@ -1,7 +1,7 @@
 import AppKit
 
-/// Owns the one pill panel: applies state from Rust, keeps the panel frame in
-/// step with the capsule's height, and turns clicks and drags into actions.
+/// Owns the one pill panel: applies state from Rust, places the panel, and
+/// turns pointer movement, clicks and drags into hover and actions.
 @MainActor
 final class PillController {
     static var shared: PillController?
@@ -11,8 +11,6 @@ final class PillController {
     private let hosting: PillHostingView
     private let sendAction: (PillAction) -> Void
     private var drag: ClickDragTracker?
-    /// The height the panel is at or animating toward.
-    private var targetHeight: CGFloat = 0
 
     init(send: @escaping (PillAction) -> Void) {
         sendAction = send
@@ -22,14 +20,16 @@ final class PillController {
             onBodyDrag: { [weak self] in self?.bodyDrag($0) },
             send: { [weak self] in self?.sendAction($0) }
         )
-        hosting.onHover = { [weak self] in self?.hover($0) }
+        hosting.onPointer = { [weak self] point in
+            guard let self else { return }
+            if let point { self.model.pointerMoved(to: point) } else { self.model.pointerExited() }
+        }
         panel.contentView = hosting
-        syncFrame(animated: false)
+        panel.setContentSize(PillGeometry.panelSize)
     }
 
     func update(phase: PillPhase, isPaused: Bool, durationSeconds: UInt32, bars: [Double]) {
         model.apply(phase: phase, isPaused: isPaused, durationSeconds: durationSeconds, bars: bars)
-        syncFrame(animated: false)
     }
 
     /// Showing always re-docks to the primary screen's right edge, like the
@@ -37,28 +37,20 @@ final class PillController {
     func setVisible(_ visible: Bool) {
         if visible {
             guard !panel.isVisible else { return }
-            let screen = NSScreen.screens.first ?? NSScreen.main
-            if let screen {
-                panel.setFrame(PillGeometry.dockFrame(in: screen.visibleFrame, height: model.height), display: false)
+            if let screen = NSScreen.screens.first ?? NSScreen.main {
+                panel.setFrameOrigin(PillGeometry.dockOrigin(in: screen.visibleFrame))
             }
             panel.orderFrontRegardless()
-            panel.invalidateShadow()
         } else {
             drag = nil
-            model.setHovering(false)
+            model.pointerExited()
             panel.orderOut(nil)
-            syncFrame(animated: false)
         }
     }
 
     func destroy() {
         panel.orderOut(nil)
         panel.close()
-    }
-
-    private func hover(_ hovering: Bool) {
-        model.setHovering(hovering)
-        syncFrame(animated: true)
     }
 
     private func bodyDrag(_ event: PillView.BodyDragEvent) {
@@ -75,31 +67,13 @@ final class PillController {
         case .ended:
             let wasClick = drag?.isClick ?? false
             drag = nil
-            if wasClick { sendAction(.openMeetings) }
-        }
-    }
-
-    /// The panel hugs the capsule, so transparent space never blocks clicks
-    /// meant for the app underneath. Compared against the last target rather
-    /// than the live frame: state updates arrive many times a second and must
-    /// not cut a running hover animation short.
-    private func syncFrame(animated: Bool) {
-        let height = model.height
-        guard height != targetHeight else { return }
-        targetHeight = height
-        let visible = (panel.screen ?? NSScreen.screens.first)?.visibleFrame ?? .infinite
-        let target = PillGeometry.resized(panel.frame, toHeight: height, within: visible)
-        guard animated, panel.isVisible else {
-            panel.setFrame(target, display: true)
-            panel.invalidateShadow()
-            return
-        }
-        NSAnimationContext.runAnimationGroup { context in
-            context.duration = PillGeometry.animation
-            context.timingFunction = CAMediaTimingFunction(name: .easeOut)
-            panel.animator().setFrame(target, display: true)
-        } completionHandler: { [weak self] in
-            MainActor.assumeIsolated { self?.panel.invalidateShadow() }
+            if wasClick {
+                sendAction(.openMeetings)
+            } else if let visible = (panel.screen ?? NSScreen.screens.first)?.visibleFrame {
+                // Keep room to expand: a pill parked under the menu bar would
+                // otherwise grow its controls off-screen.
+                panel.setFrameOrigin(PillGeometry.clampedOrigin(panel.frame.origin, within: visible))
+            }
         }
     }
 }

--- a/src-tauri/recorder-pill/macos/Sources/OatsRecorderPill/PillModel.swift
+++ b/src-tauri/recorder-pill/macos/Sources/OatsRecorderPill/PillModel.swift
@@ -57,14 +57,36 @@ final class PillModel: ObservableObject {
     func setHovering(_ hovering: Bool) {
         isHovering = hovering
     }
+
+    /// Hover is decided by the pointer's position (panel coordinates) against
+    /// the capsule as currently sized, not by the panel's rectangular tracking
+    /// area, so the transparent space above a collapsed pill doesn't expand it.
+    /// The expanded capsule contains the collapsed one, so this can't flap.
+    func pointerMoved(to point: NSPoint) {
+        let hovering = PillGeometry.capsuleRect(height: height).contains(point)
+        if hovering != isHovering { isHovering = hovering }
+    }
+
+    func pointerExited() {
+        if isHovering { isHovering = false }
+    }
 }
 
-/// Sizes and placement, shared by the SwiftUI layout and the panel frame so the
-/// window always hugs the capsule exactly.
+/// Sizes and placement, shared by the SwiftUI layout, hover hit-testing and
+/// the panel frame.
+///
+/// The panel never resizes: resizing a window makes AppKit re-derive its
+/// tracking areas and report the resting pointer as exited, which collapsed
+/// the pill mid-expansion and made it flap. Instead the panel is sized for the
+/// tallest capsule and the capsule grows inside it, bottom-anchored. The
+/// window server routes clicks on fully transparent pixels to the window
+/// underneath, so the empty space above a short capsule never blocks clicks.
 enum PillGeometry {
     static let width: CGFloat = 48
     static let cornerRadius: CGFloat = 24
     static let screenMargin: CGFloat = 16
+    /// Room around the capsule for its drop shadow.
+    static let shadowPad: CGFloat = 22
 
     static let padding: CGFloat = 7
     static let logo: CGFloat = 24
@@ -99,25 +121,35 @@ enum PillGeometry {
         }
     }
 
-    /// Right edge of `visibleFrame`, with the collapsed recording pill
-    /// vertically centered; a taller state extends upward from the same bottom.
-    static func dockFrame(in visibleFrame: NSRect, height: CGFloat) -> NSRect {
-        let collapsed = self.height(for: .recording, expanded: false)
-        return NSRect(
-            x: visibleFrame.maxX - screenMargin - width,
-            y: visibleFrame.midY - collapsed / 2,
-            width: width,
-            height: height
+    /// The fixed panel: the tallest capsule any phase needs, plus shadow room.
+    static var panelSize: NSSize {
+        let tallest = max(height(for: .recording, expanded: true), height(for: .failed, expanded: false))
+        return NSSize(width: width + 2 * shadowPad, height: tallest + 2 * shadowPad)
+    }
+
+    /// The capsule within the panel, in panel (bottom-left origin) coordinates.
+    static func capsuleRect(height: CGFloat) -> NSRect {
+        NSRect(x: shadowPad, y: shadowPad, width: width, height: height)
+    }
+
+    /// Panel origin that puts the capsule against the right edge of
+    /// `visibleFrame`, the collapsed recording pill vertically centered; taller
+    /// states extend upward from the same bottom edge.
+    static func dockOrigin(in visibleFrame: NSRect) -> NSPoint {
+        let collapsed = height(for: .recording, expanded: false)
+        return NSPoint(
+            x: visibleFrame.maxX - screenMargin - width - shadowPad,
+            y: visibleFrame.midY - collapsed / 2 - shadowPad
         )
     }
 
-    /// Cocoa frames grow from the bottom-left, so keeping `origin` is what
-    /// anchors the bottom edge and makes the pill grow upward — unless that
-    /// would push the top past `visibleFrame`, in which case it grows down.
-    static func resized(_ frame: NSRect, toHeight height: CGFloat, within visibleFrame: NSRect) -> NSRect {
-        var y = frame.minY
-        if y + height > visibleFrame.maxY { y = max(visibleFrame.minY, visibleFrame.maxY - height) }
-        return NSRect(x: frame.minX, y: y, width: frame.width, height: height)
+    /// Pulls a dragged panel back so even the tallest capsule stays inside
+    /// `visibleFrame` (only the shadow margin may hang off-screen).
+    static func clampedOrigin(_ origin: NSPoint, within visibleFrame: NSRect) -> NSPoint {
+        let capsule = NSSize(width: width, height: panelSize.height - 2 * shadowPad)
+        let x = min(max(origin.x, visibleFrame.minX - shadowPad), visibleFrame.maxX - capsule.width - shadowPad)
+        let y = min(max(origin.y, visibleFrame.minY - shadowPad), visibleFrame.maxY - capsule.height - shadowPad)
+        return NSPoint(x: x, y: y)
     }
 
     /// Mirrors `barHeightPercent` in src/views/waveformBars.ts: levels are

--- a/src-tauri/recorder-pill/macos/Sources/OatsRecorderPill/PillPanel.swift
+++ b/src-tauri/recorder-pill/macos/Sources/OatsRecorderPill/PillPanel.swift
@@ -17,8 +17,8 @@ final class PillPanel: NSPanel {
         collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .stationary, .ignoresCycle]
         isOpaque = false
         backgroundColor = .clear
-        // The shadow follows the capsule's alpha; re-derived after each resize.
-        hasShadow = true
+        // The capsule draws its own shadow, so it animates with the capsule.
+        hasShadow = false
         hidesOnDeactivate = false
         becomesKeyOnlyIfNeeded = true
         isReleasedWhenClosed = false
@@ -32,10 +32,13 @@ final class PillPanel: NSPanel {
 }
 
 /// Hosts the SwiftUI pill. Takes the first click (the panel is never key) and
-/// reports hover with an always-active tracking area, since oats is rarely
-/// the frontmost app while the pill is up.
+/// reports the pointer with an always-active tracking area, since oats is
+/// rarely the frontmost app while the pill is up. The area covers the whole
+/// (fixed-size) panel; the model decides whether the pointer is over the
+/// capsule itself.
 final class PillHostingView: NSHostingView<PillView> {
-    var onHover: ((Bool) -> Void)?
+    /// Pointer position in panel coordinates, or nil once it has left.
+    var onPointer: ((NSPoint?) -> Void)?
     private var hoverArea: NSTrackingArea?
 
     required init(rootView: PillView) {
@@ -56,7 +59,7 @@ final class PillHostingView: NSHostingView<PillView> {
         if let hoverArea { removeTrackingArea(hoverArea) }
         let area = NSTrackingArea(
             rect: .zero,
-            options: [.mouseEnteredAndExited, .activeAlways, .inVisibleRect],
+            options: [.mouseEnteredAndExited, .mouseMoved, .activeAlways, .inVisibleRect],
             owner: self,
             userInfo: nil
         )
@@ -66,11 +69,16 @@ final class PillHostingView: NSHostingView<PillView> {
 
     override func mouseEntered(with event: NSEvent) {
         super.mouseEntered(with: event)
-        if event.trackingArea === hoverArea { onHover?(true) }
+        if event.trackingArea === hoverArea { onPointer?(event.locationInWindow) }
+    }
+
+    override func mouseMoved(with event: NSEvent) {
+        super.mouseMoved(with: event)
+        onPointer?(event.locationInWindow)
     }
 
     override func mouseExited(with event: NSEvent) {
         super.mouseExited(with: event)
-        if event.trackingArea === hoverArea { onHover?(false) }
+        if event.trackingArea === hoverArea { onPointer?(nil) }
     }
 }

--- a/src-tauri/recorder-pill/macos/Sources/OatsRecorderPill/PillView.swift
+++ b/src-tauri/recorder-pill/macos/Sources/OatsRecorderPill/PillView.swift
@@ -21,9 +21,9 @@ private extension Color {
     static let retryIndigo = Color(hex: 0x818cf8)
 }
 
-/// The capsule. Its height always equals the panel's (see `PillController`),
-/// so the view fills the window and the flexible expanded area soaks up the
-/// difference while the window animates between collapsed and expanded.
+/// The capsule, bottom-anchored in the fixed-size panel (see `PillGeometry`).
+/// Its height animates between states; the flexible expanded area soaks up
+/// the difference so the controls are revealed as it grows.
 struct PillView: View {
     @ObservedObject var model: PillModel
     /// Moves the panel while the body is dragged; a press without movement
@@ -36,6 +36,20 @@ struct PillView: View {
     private typealias G = PillGeometry
 
     var body: some View {
+        // Clear space around the capsule is fully transparent, so the window
+        // server sends clicks there to whatever is underneath.
+        ZStack(alignment: .bottom) {
+            Color.clear
+            capsule
+                .frame(width: G.width, height: model.height)
+                .animation(.easeOut(duration: G.animation), value: model.height)
+                .shadow(color: .black.opacity(0.5), radius: 10, y: 6)
+                .padding(.bottom, G.shadowPad)
+        }
+        .frame(width: G.panelSize.width, height: G.panelSize.height)
+    }
+
+    private var capsule: some View {
         VStack(spacing: 0) {
             OatsLogo()
                 .fill(Color.white, style: FillStyle(eoFill: true))
@@ -61,6 +75,7 @@ struct PillView: View {
         }
         .frame(width: G.width)
         .frame(maxHeight: .infinity, alignment: .top)
+        .clipped()
         .background(Color.pillBackground)
         .clipShape(RoundedRectangle(cornerRadius: G.cornerRadius, style: .continuous))
         .contentShape(RoundedRectangle(cornerRadius: G.cornerRadius, style: .continuous))

--- a/src-tauri/recorder-pill/macos/Tests/OatsRecorderPillTests/PillModelTests.swift
+++ b/src-tauri/recorder-pill/macos/Tests/OatsRecorderPillTests/PillModelTests.swift
@@ -69,36 +69,81 @@ final class PillModelTests: XCTestCase {
         )
     }
 
-    func testDocksCollapsedPillToTheRightEdgeVerticallyCentered() {
+    func testPanelFitsTheTallestCapsulePlusShadowRoom() {
+        let tallest = max(
+            PillGeometry.height(for: .recording, expanded: true),
+            PillGeometry.height(for: .failed, expanded: false)
+        )
+        XCTAssertEqual(PillGeometry.panelSize.width, PillGeometry.width + 2 * PillGeometry.shadowPad)
+        XCTAssertEqual(PillGeometry.panelSize.height, tallest + 2 * PillGeometry.shadowPad)
+    }
+
+    func testCapsuleIsBottomAnchoredAndCenteredInThePanel() {
+        let rect = PillGeometry.capsuleRect(height: 90)
+        XCTAssertEqual(rect, NSRect(x: PillGeometry.shadowPad, y: PillGeometry.shadowPad, width: PillGeometry.width, height: 90))
+        // Growing keeps the bottom edge where it is.
+        XCTAssertEqual(PillGeometry.capsuleRect(height: 190).minY, rect.minY)
+    }
+
+    func testDocksCollapsedCapsuleToTheRightEdgeVerticallyCentered() {
         let visible = NSRect(x: 0, y: 40, width: 1440, height: 860)
-        let frame = PillGeometry.dockFrame(in: visible, height: 120)
-        XCTAssertEqual(frame.maxX, visible.maxX - PillGeometry.screenMargin)
-        XCTAssertEqual(frame.width, PillGeometry.width)
-        XCTAssertEqual(frame.height, 120)
-        let collapsed = PillGeometry.height(for: .recording, expanded: false)
-        // The collapsed pill is centered; taller states grow upward from it.
-        XCTAssertEqual(frame.minY, visible.midY - collapsed / 2)
+        let origin = PillGeometry.dockOrigin(in: visible)
+        let capsule = PillGeometry.capsuleRect(height: PillGeometry.height(for: .recording, expanded: false))
+            .offsetBy(dx: origin.x, dy: origin.y)
+        XCTAssertEqual(capsule.maxX, visible.maxX - PillGeometry.screenMargin)
+        XCTAssertEqual(capsule.midY, visible.midY)
     }
 
-    func testDockFrameRespectsAnOffsetScreen() {
+    func testDockOriginRespectsAnOffsetScreen() {
         let visible = NSRect(x: -1920, y: 0, width: 1920, height: 1080)
-        let frame = PillGeometry.dockFrame(in: visible, height: 90)
-        XCTAssertEqual(frame.maxX, -PillGeometry.screenMargin)
+        let origin = PillGeometry.dockOrigin(in: visible)
+        let capsule = PillGeometry.capsuleRect(height: 90).offsetBy(dx: origin.x, dy: origin.y)
+        XCTAssertEqual(capsule.maxX, -PillGeometry.screenMargin)
     }
 
-    func testResizeKeepsTheBottomEdgeFixed() {
-        let frame = NSRect(x: 100, y: 200, width: 48, height: 90)
-        let screen = NSRect(x: 0, y: 0, width: 1440, height: 900)
-        let grown = PillGeometry.resized(frame, toHeight: 190, within: screen)
-        XCTAssertEqual(grown, NSRect(x: 100, y: 200, width: 48, height: 190))
+    func testClampKeepsTheTallestCapsuleOnScreen() {
+        let visible = NSRect(x: 0, y: 0, width: 1440, height: 900)
+        let tallest = PillGeometry.panelSize.height - 2 * PillGeometry.shadowPad
+        func capsule(at origin: NSPoint) -> NSRect {
+            PillGeometry.capsuleRect(height: tallest).offsetBy(dx: origin.x, dy: origin.y)
+        }
+        // Dragged up under the menu bar: expanding must not go off the top.
+        XCTAssertEqual(capsule(at: PillGeometry.clampedOrigin(NSPoint(x: 600, y: 850), within: visible)).maxY, visible.maxY)
+        // Dragged below the bottom edge, and off either side.
+        XCTAssertEqual(capsule(at: PillGeometry.clampedOrigin(NSPoint(x: 600, y: -200), within: visible)).minY, visible.minY)
+        XCTAssertEqual(capsule(at: PillGeometry.clampedOrigin(NSPoint(x: -300, y: 300), within: visible)).minX, visible.minX)
+        XCTAssertEqual(capsule(at: PillGeometry.clampedOrigin(NSPoint(x: 1500, y: 300), within: visible)).maxX, visible.maxX)
+        // Anywhere inside is left alone.
+        XCTAssertEqual(PillGeometry.clampedOrigin(NSPoint(x: 600, y: 300), within: visible), NSPoint(x: 600, y: 300))
     }
 
-    func testResizeNearTheScreenTopGrowsDownInstead() {
-        // Dragged up against the menu bar: growing upward would go off-screen.
-        let screen = NSRect(x: 0, y: 0, width: 1440, height: 900)
-        let frame = NSRect(x: 100, y: 800, width: 48, height: 90)
-        let grown = PillGeometry.resized(frame, toHeight: 190, within: screen)
-        XCTAssertEqual(grown, NSRect(x: 100, y: 710, width: 48, height: 190))
+    func testHoverFollowsThePointerOverTheCapsuleOnly() {
+        let model = PillModel()
+        model.apply(phase: .recording, isPaused: false, durationSeconds: 1, bars: [])
+        let collapsed = PillGeometry.capsuleRect(height: model.height)
+        // Over the transparent space above the collapsed capsule: no hover.
+        model.pointerMoved(to: NSPoint(x: collapsed.midX, y: collapsed.maxY + 20))
+        XCTAssertFalse(model.isHovering)
+        // Onto the capsule: expands.
+        model.pointerMoved(to: NSPoint(x: collapsed.midX, y: collapsed.midY))
+        XCTAssertTrue(model.isExpanded)
+        // Up into the revealed controls: the expanded capsule contains it, so
+        // hover holds instead of collapsing under the pointer.
+        model.pointerMoved(to: NSPoint(x: collapsed.midX, y: collapsed.maxY + 20))
+        XCTAssertTrue(model.isExpanded)
+        // Into the shadow margin beside it: collapses.
+        model.pointerMoved(to: NSPoint(x: collapsed.minX - 4, y: collapsed.midY))
+        XCTAssertFalse(model.isHovering)
+    }
+
+    func testPointerLeavingThePanelEndsHover() {
+        let model = PillModel()
+        model.apply(phase: .recording, isPaused: false, durationSeconds: 1, bars: [])
+        let rect = PillGeometry.capsuleRect(height: model.height)
+        model.pointerMoved(to: NSPoint(x: rect.midX, y: rect.midY))
+        XCTAssertTrue(model.isHovering)
+        model.pointerExited()
+        XCTAssertFalse(model.isHovering)
     }
 
     func testBarHeightMatchesTheWebPillCurve() {


### PR DESCRIPTION
Follow-up to #392. This fix was committed on the stacked Windows branch (#393) after the macOS branch was frozen, so it never shipped with #392. Splitting it out keeps #393 Windows-only.

## Problem
Hovering the native macOS pill resized the panel, which made AppKit re-derive its tracking areas and report the resting pointer as exited mid-expansion. The pill collapsed, the next movement re-entered it, and it kept shaking open and shut.

## Fix
- The panel is now a fixed size (tallest capsule plus shadow room); the capsule animates its height inside it, bottom-anchored.
- Hover comes from the pointer's position against the capsule's current rect instead of the panel's tracking area. It can't oscillate because the expanded rect contains the collapsed one.
- Fully transparent pixels still pass clicks through to the app underneath.
- The capsule draws its own shadow so it animates with the capsule.
- A dragged pill is pulled back on screen so it always has room to expand.
- Spec updated to match.

## Testing
- `swift test --package-path src-tauri/recorder-pill/macos` — 18 tests pass (geometry/hover tests updated for the fixed panel).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved the macOS recorder pill’s appearance with a smoother in-panel capsule animation and custom shadow.
  * Hover interactions now respond specifically to the visible capsule, avoiding unintended activation in transparent areas.
  * Transparent areas around the pill allow clicks to pass through to underlying windows.
  * The recorder pill remains positioned within the visible screen area when docked or dragged.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->