### PR TITLE
chore(models): serve Windows model bundles from the shared R2 host

### DIFF
--- a/scripts/sync-windows-local-models.ps1
+++ b/scripts/sync-windows-local-models.ps1
@@ -266,7 +266,8 @@ if ($Upload) {
 
   $prefix = ([Uri]$Lock.cdnBase).AbsolutePath.Trim('/')
   foreach ($bundle in $bundles) {
-    $key = "$prefix/$($bundle.Path)"
+    # A bucket-root cdnBase has an empty prefix; don't emit a leading "/" key.
+    $key = (@($prefix, $bundle.Path) | Where-Object { $_ }) -join '/'
     $existing = & aws s3 ls "s3://$R2Bucket/$key/" --endpoint-url $R2Endpoint 2>$null
     if ($LASTEXITCODE -ne 0) {
       throw "Could not inspect s3://$R2Bucket/$key/."

--- a/src-tauri/ariso-stt/shared/windows-models.json
+++ b/src-tauri/ariso-stt/shared/windows-models.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "cdnBase": "https://pub-b22579d60a5b47d8835d2c4660e7bc16.r2.dev/models",
+  "cdnBase": "https://pub-dd2807d512d34e55b8a863f675ea8e6e.r2.dev",
   "speech": [
     {
       "id": "parakeet",

--- a/src-tauri/src/model_manager.rs
+++ b/src-tauri/src/model_manager.rs
@@ -1209,10 +1209,9 @@ mod tests {
     #[test]
     fn model_bundle_cdn_pins_are_well_formed() {
         assert!(MODELS_CDN_BASE.starts_with(r2_base!()));
-        assert_eq!(
-            WINDOWS_MODEL_LOCK.cdn_base,
-            "https://pub-b22579d60a5b47d8835d2c4660e7bc16.r2.dev/models"
-        );
+        // Windows bundles live at the bucket root (`windows/...`) of the same R2
+        // host as the macOS models and the updater.
+        assert_eq!(WINDOWS_MODEL_LOCK.cdn_base, r2_base!());
         let bundles = macos_stt_bundles()
             .into_iter()
             .chain(windows_stt_bundles())


### PR DESCRIPTION
## What does this PR do?

Moves the Windows local-model downloads (Parakeet STT, speaker diarization, Gemma notes LLM) off the separate `pub-b22579…r2.dev` bucket onto the R2 host that already serves the macOS models and the updater (`pub-dd2807…r2.dev`).

- **`windows-models.json`**: `cdnBase` now points at the root of the shared host. `folder`, `prefix` and every pinned `manifestSha256` are unchanged, so files resolve to `https://pub-dd2807…r2.dev/windows/<folder>/<prefix>/…`.
- **No re-download for existing Windows users.** The readiness identity is built from `folder@prefix`, which hasn't changed, so installs made by v0.23.0 stay ready after the update.
- **`model_manager.rs` test**: asserts the Windows `cdnBase` equals `r2_base!()` (the shared host) instead of a hard-coded URL.
- **`scripts/sync-windows-local-models.ps1`**: drops an empty key prefix. With a bucket-root `cdnBase`, `-Upload` now writes `windows/…` keys instead of `/windows/…`.

## Type of change

- [ ] `fix:` — bug fix
- [ ] `feat:` — new feature
- [ ] `feat!:` / `BREAKING CHANGE:` — breaking change
- [x] `docs:` / `chore:` / `refactor:` — no user-facing release

## How was this tested?

- **Bucket contents**: using the updated lock file, I followed the app's `download_model_bundles` steps against the new host. All 3 `SHA256SUMS` match their pinned `manifestSha256`, and all 7 model files match their manifest hashes.
- `cargo test model_manager -- --test-threads=1`: 20 passed, 3 ignored (network smoke tests).
- `npm test`: 64 files, 1024 tests passed.
- Not run: the PowerShell script (no `pwsh` on the Mac), and a local-model download on a real Windows machine.

## Checklist

- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I ran `npm test` and the suite passes
- [ ] I tested the change in the app (note which backend above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Windows model downloads when using a CDN hosted at the bucket root.
  - Updated the Windows model source to use the new CDN host and path.
  - Updated validation to reflect the revised Windows model hosting configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->